### PR TITLE
869373 - Reversed the order to account for the situation where, in the

### DIFF
--- a/pulp_rpm/src/pulp_rpm/extension/admin/status.py
+++ b/pulp_rpm/src/pulp_rpm/extension/admin/status.py
@@ -74,8 +74,8 @@ class RpmStatusRenderer(StatusRenderer):
             self.render_packages_step(progress_report)
             self.render_distributions_step(progress_report)
             self.render_generate_metadata_step(progress_report)
-            self.render_publish_http_step(progress_report)
             self.render_publish_https_step(progress_report)
+            self.render_publish_http_step(progress_report)
 
     def render_metadata_step(self, progress_report):
 


### PR DESCRIPTION
middle of the HTTPS publish, the HTTP publish both starts and completes.

https://bugzilla.redhat.com/show_bug.cgi?id=869373
