### PR TITLE
adding a requirement for createrepo. This was previously on pulp-server,...

### DIFF
--- a/pulp-rpm.spec
+++ b/pulp-rpm.spec
@@ -145,6 +145,7 @@ Summary: Pulp RPM plugins
 Group: Development/Languages
 Requires: python-pulp-rpm-common = %{pulp_version}
 Requires: pulp-server = %{pulp_version}
+Requires: createrepo >= 0.9.8-3
 
 %description plugins
 Provides a collection of platform plugins that extend the Pulp platform


### PR DESCRIPTION
... which is not the correct place. It was also previously only for RHEL5 and required an exact version, instead of allowing >= a version. It is now for all distros and requires a >= version.
