### PR TITLE
875163 - use group as the xml filename when generating comps so modifyre...

### DIFF
--- a/pulp_rpm/src/pulp_rpm/yum_plugin/comps_util.py
+++ b/pulp_rpm/src/pulp_rpm/yum_plugin/comps_util.py
@@ -399,7 +399,7 @@ def write_comps_xml(repo_working_dir, existing_groups, existing_cats):
     comps_xml = form_comps_xml_from_units(existing_groups, existing_cats)
     if not comps_xml:
         return None
-    out_path = os.path.join(repo_working_dir, "comps.xml")
+    out_path = os.path.join(repo_working_dir, "group.xml")
     f = open(out_path, "w")
     try:
         try:

--- a/pulp_rpm/test/unit/test_comps.py
+++ b/pulp_rpm/test/unit/test_comps.py
@@ -397,7 +397,7 @@ class TestComps(rpm_support_base.PulpRPMTests):
         self.assertTrue(report.success_flag)
         self.assertEqual(report.summary["num_package_groups_published"], 2)
         self.assertEqual(report.summary["num_package_categories_published"], 2)
-        expected_comps_xml = os.path.join(repo.working_dir, "comps.xml")
+        expected_comps_xml = os.path.join(repo.working_dir, "group.xml")
         self.assertTrue(os.path.exists(expected_comps_xml))
         #
         # Find the path that createrepo added the comps.xml as
@@ -509,7 +509,7 @@ class TestComps(rpm_support_base.PulpRPMTests):
             cats, cat_units = comps.get_new_category_units(avail_cats, {}, sync_conduit, repo)
             yum_distributor = YumDistributor()
             comps_xml_out_path = comps_util.write_comps_xml(repo.working_dir, group_units.values(), cat_units.values())
-            self.assertEqual(comps_xml_out_path, os.path.join(repo.working_dir, "comps.xml"))
+            self.assertEqual(comps_xml_out_path, os.path.join(repo.working_dir, "group.xml"))
             yc = yum.comps.Comps()
             yc.add(comps_xml_out_path)
             self.assertTrue(len(group_units), len(yc.groups))


### PR DESCRIPTION
...po uses that as type id which yum expects
