### PR TITLE
check if a feed url is set to the importer config before performing repo...

### DIFF
--- a/pulp_rpm/plugins/importers/yum_importer/importer.py
+++ b/pulp_rpm/plugins/importers/yum_importer/importer.py
@@ -497,6 +497,14 @@ class YumImporter(Importer):
         return report
 
     def _sync_repo(self, repo, sync_conduit, config):
+        summary = {}
+        details = {}
+        if not config.get("feed_url", None):
+            # No feed url found, return a sync failure
+            msg = _("Cannot perform repository sync on a repository with no feed")
+            _LOG.error(msg)
+            summary['error'] = msg
+            return False, summary, details
         progress_status = {
                 "metadata": {"state": "NOT_STARTED"},
                 "content": {"state": "NOT_STARTED"},
@@ -510,8 +518,6 @@ class YumImporter(Importer):
             sync_conduit.set_progress(progress_status)
 
         sync_conduit.set_progress(progress_status)
-        summary = {}
-        details = {}
         # sync rpms
         rpm_status, summary["packages"], details["packages"] = self.importer_rpm.sync(repo, sync_conduit, config, progress_callback)
 

--- a/pulp_rpm/test/unit/server/test_rpms.py
+++ b/pulp_rpm/test/unit/server/test_rpms.py
@@ -973,3 +973,15 @@ class TestRPMs(rpm_support_base.PulpRPMTests):
         self.assertEquals(summary["num_synced_new_rpms"], 12)
         pkgs = self.get_files_in_dir("*.rpm", self.pkg_dir)
         self.assertEquals(len(pkgs), 12)
+
+    def test_feedless_repo_sync(self):
+        repo = mock.Mock(spec=Repository)
+        repo.working_dir = self.working_dir
+        repo.id = "test_feedless_repo_sync"
+        sync_conduit = importer_mocks.get_sync_conduit(type_id=TYPE_ID_RPM, pkg_dir=self.pkg_dir)
+        sync_conduit.set_progress = mock.Mock()
+        config = importer_mocks.get_basic_config()
+        importer = YumImporter()
+        status, summary, details = importer._sync_repo(repo, sync_conduit, config)
+        self.assertFalse(status)
+        self.assertEquals(summary['error'], "Cannot perform repository sync on a repository with no feed")


### PR DESCRIPTION
... sync. If no feed is present return a failure
