### PR TITLE
880441 - Ported over group commands from builtins

### DIFF
--- a/pulp_rpm/extensions/admin/rpm_admin_consumer/consumer_group_cudl.py
+++ b/pulp_rpm/extensions/admin/rpm_admin_consumer/consumer_group_cudl.py
@@ -1,0 +1,185 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © 2012 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+"""
+Post 2.0, commands in this module will be refactored to remove any reference to
+RPM consumers and moved into the pulp.client.commands package in the platform
+project. They will be needed there for when we start to handle puppet master
+consumers. For now, this is the easiest approach to get this functionality
+back into 2.0.
+jdob, Nov 28, 2012
+"""
+
+from gettext import gettext as _
+
+from pulp.bindings.exceptions import NotFoundException
+from pulp.client import arg_utils
+from pulp.client.commands.criteria import CriteriaCommand
+from pulp.client.commands.options import  (OPTION_DESCRIPTION, OPTION_GROUP_ID,
+                                           OPTION_NAME, OPTION_NOTES)
+from pulp.client.extensions.extensions import (PulpCliCommand, PulpCliOption)
+
+
+DESC_CREATE = _('creates a new consumer group')
+DESC_DELETE = _('deletes a consumer group')
+DESC_UPDATE = _('updates the metadata about the group itself (not its members)')
+DESC_LIST   = _('lists consumer groups on the Pulp server')
+DESC_SEARCH = _('searches for consumer groups on the Pulp server')
+
+# Defaults to pass to render_document_list when displaying groups
+DEFAULT_FILTERS = ['id', 'display_name', 'description', 'consumer_ids', 'notes']
+DEFAULT_ORDER = DEFAULT_FILTERS
+
+
+class CreateConsumerGroupCommand(PulpCliCommand):
+
+    def __init__(self, context, name='create', description=DESC_CREATE, method=None):
+        self.context = context
+        self.prompt = context.prompt
+
+        if method is None:
+            method = self.run
+
+        super(CreateConsumerGroupCommand, self).__init__(name, description, method)
+
+        self.add_option(OPTION_GROUP_ID)
+        self.add_option(OPTION_NAME)
+        self.add_option(OPTION_DESCRIPTION)
+        self.add_option(OPTION_NOTES)
+
+    def run(self, **kwargs):
+        # Collect input
+        consumer_group_id = kwargs[OPTION_GROUP_ID.keyword]
+        name = consumer_group_id
+        if OPTION_NAME.keyword in kwargs:
+            name = kwargs[OPTION_NAME.keyword]
+        description = kwargs[OPTION_DESCRIPTION.keyword]
+        notes = kwargs[OPTION_NOTES.keyword]
+
+        # Call the server
+        self.context.server.consumer_group.create(consumer_group_id, name, description, notes)
+
+        msg = _('Consumer Group [%(group)s] successfully created')
+        self.prompt.render_success_message(msg % {'group' : consumer_group_id})
+
+
+class UpdateConsumerGroupCommand(PulpCliCommand):
+
+    def __init__(self, context, name='update', description=DESC_UPDATE, method=None):
+        self.context = context
+        self.prompt = context.prompt
+
+        if method is None:
+            method = self.run
+
+        super(UpdateConsumerGroupCommand, self).__init__(name, description, method)
+
+        self.add_option(OPTION_GROUP_ID)
+        self.add_option(OPTION_NAME)
+        self.add_option(OPTION_DESCRIPTION)
+        self.add_option(OPTION_NOTES)
+
+    def run(self, **kwargs):
+        # Assemble the delta for all options that were passed in
+        delta = dict([(k, v) for k, v in kwargs.items() if v is not None])
+        delta.pop(OPTION_GROUP_ID.keyword) # not needed in the delta
+
+        if delta.pop(OPTION_NAME.keyword, None) is not None:
+            delta['display_name'] = kwargs[OPTION_NAME.keyword]
+
+        if delta.pop(OPTION_NOTES.keyword, None) is not None:
+            delta['notes'] = kwargs[OPTION_NOTES.keyword]
+
+        try:
+            self.context.server.consumer_group.update(kwargs[OPTION_GROUP_ID.keyword], delta)
+            msg = _('Consumer Group [%(group)s] successfully updated')
+            self.prompt.render_success_message(msg % {'group' : kwargs[OPTION_GROUP_ID.keyword]})
+        except NotFoundException:
+            msg = _('Consumer Group [%(group)s] does not exist on the server')
+            self.prompt.write(msg % {'group' : kwargs[OPTION_GROUP_ID.keyword]}, tag='not-found')
+
+
+class DeleteConsumerGroupCommand(PulpCliCommand):
+
+    def __init__(self, context, name='delete', description=DESC_DELETE, method=None):
+        self.context = context
+        self.prompt = context.prompt
+
+        if method is None:
+            method = self.run
+
+        super(DeleteConsumerGroupCommand, self).__init__(name, description, method)
+
+        self.add_option(OPTION_GROUP_ID)
+
+    def run(self, **kwargs):
+        id = kwargs[OPTION_GROUP_ID.keyword]
+
+        try:
+            self.context.server.consumer_group.delete(id)
+            msg = _('Consumer Group [%(group)s] successfully deleted')
+            self.prompt.render_success_message(msg % {'group' : id})
+        except NotFoundException:
+            msg = _('Consumer Group [%(group)s] does not exist on the server')
+            self.prompt.write(msg % {'group' : id}, tag='not-found')
+
+
+class ListConsumerGroupsCommand(PulpCliCommand):
+
+    def __init__(self, context, name='list', description=DESC_LIST, method=None):
+        self.context = context
+        self.prompt = context.prompt
+
+        if method is None:
+            method = self.run
+
+        super(ListConsumerGroupsCommand, self).__init__(name, description, method)
+
+        self.add_option(PulpCliOption('--fields', _('comma-separated list of repo group fields; if specified, only the given fields will displayed'), required=False))
+
+    def run(self, **kwargs):
+        self.prompt.render_title(_('Consumer Groups'))
+
+        consumer_group_list = self.context.server.consumer_group.consumer_groups().response_body
+
+        # Default flags to render_document_list
+        filters = DEFAULT_FILTERS
+        order = DEFAULT_ORDER
+
+        if kwargs['fields'] is not None:
+            filters = kwargs['fields'].split(',')
+            if 'id' not in filters:
+                filters.append('id')
+            order = ['id']
+
+        self.prompt.render_document_list(consumer_group_list, filters=filters, order=order)
+
+
+class SearchConsumerGroupsCommand(CriteriaCommand):
+
+    def __init__(self, context, name='search', description=DESC_SEARCH, method=None):
+        self.context = context
+        self.prompt = context.prompt
+
+        if method is None:
+            method = self.run
+
+        super(SearchConsumerGroupsCommand, self).__init__(method, name=name,
+                                                          description=description,
+                                                          include_search=True)
+
+    def run(self, **kwargs):
+        self.prompt.render_title(_('Consumer Groups'))
+
+        consumer_group_list = self.context.server.consumer_group_search.search(**kwargs)
+        self.prompt.render_document_list(consumer_group_list, order=DEFAULT_ORDER)

--- a/pulp_rpm/extensions/admin/rpm_admin_consumer/consumer_group_members.py
+++ b/pulp_rpm/extensions/admin/rpm_admin_consumer/consumer_group_members.py
@@ -1,0 +1,159 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2012 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+"""
+Post 2.0, commands in this module will be refactored to remove any reference to
+RPM consumers and moved into the pulp.client.commands package in the platform
+project. They will be needed there for when we start to handle puppet master
+consumers. For now, this is the easiest approach to get this functionality
+back into 2.0.
+
+In fact, I suspect a lot of this code will be refactored into a generic "group
+membership" series of commands. Again, with 2.0 so close, I'd rather not bite
+off the risk of refactoring the repo group membership commands, so there
+are concepts duplicated here.
+
+jdob, Nov 28, 2012
+"""
+
+import copy
+from gettext import gettext as _
+
+from pulp.client.commands.criteria import CriteriaCommand
+from pulp.client.commands.options import  (OPTION_GROUP_ID, FLAG_ALL, OPTION_CONSUMER_ID)
+from pulp.client.extensions.extensions import PulpCliCommand
+from pulp.common import compat
+
+
+DESC_LIST = _('list the consumers in a particular group')
+DESC_ADD = _('add consumers to an existing group')
+DESC_REMOVE = _('remove consumers from a group')
+
+
+class ListConsumerGroupMembersCommand(PulpCliCommand):
+
+    def __init__(self, context, name='list', description=DESC_LIST, method=None):
+        self.context = context
+        self.prompt = context.prompt
+
+        if method is None:
+            method = self.run
+
+        super(ListConsumerGroupMembersCommand, self).__init__(name, description,
+                                                              method)
+
+        self.add_option(OPTION_GROUP_ID)
+
+    def run(self, **kwargs):
+        self.prompt.render_title(_('Consumer Group Members'))
+
+        consumer_group_id = kwargs[OPTION_GROUP_ID.keyword]
+        criteria = {'fields':('consumer_ids',),
+                    'filters':{'id':consumer_group_id}}
+
+        consumer_group_list = self.context.server.consumer_group_search.search(**criteria)
+
+        if len(consumer_group_list) != 1:
+            msg = _('Consumer group [%(g)s] does not exist on the server')
+            self.prompt.render_failure_message(msg % {'g' : consumer_group_id}, tag='not-found')
+        else:
+            consumer_ids = consumer_group_list[0].get('consumer_ids')
+            if consumer_ids:
+                criteria = {'filters':{'id':{'$in':consumer_ids}}}
+                consumer_list = self.context.server.consumer_search.search(**criteria)
+
+                filters = ['id', 'display_name', 'description', 'notes']
+                order = filters
+
+                self.prompt.render_document_list(consumer_list, filters=filters, order=order)
+
+
+class ConsumerGroupMembersCommand(CriteriaCommand):
+    """
+    This class is very similar to pulp.client.commands.repo.group.RepositoryGroupMembersCommand.
+    Post 2.0 that class should be refactored to be a base for all group membership
+    commands, but I'm not willing to take on the risk or time investment right
+    now.
+    jdob, Dec 4, 2012
+    """
+
+    def __init__(self, context, name, description, method=None):
+        self.context = context
+        self.prompt = context.prompt
+
+        if method is None:
+            method = self.run
+
+        super(ConsumerGroupMembersCommand, self).__init__(
+            method, name, description, include_search=False
+        )
+
+        self.add_option(OPTION_GROUP_ID)
+        self.add_flag(FLAG_ALL)
+
+        # Copy the consumer ID option so we can dork with it
+        consumer_id_option = copy.copy(OPTION_CONSUMER_ID)
+        consumer_id_option.required = False
+        consumer_id_option.allow_multiple = True
+        self.add_option(consumer_id_option)
+
+    def run(self, **kwargs):
+        group_id = kwargs.pop(OPTION_GROUP_ID.keyword)
+        if not compat.any(kwargs.values()):
+            self.prompt.render_failure_message(
+                _('At least one matching option must be provided.'))
+            return
+        kwargs.pop(FLAG_ALL.keyword, None)
+
+        consumer_ids = kwargs.pop(OPTION_CONSUMER_ID.keyword)
+        if consumer_ids:
+            in_arg = kwargs.get('in') or []
+            in_arg.append(('id', ','.join(consumer_ids)))
+            kwargs['in'] = in_arg
+
+        self._action(group_id, **kwargs)
+
+    def _action(self, group_id, **kwargs):
+        """
+        Override this in base classes. It should call an appropriate remote
+        method to execute an action.
+
+        :param group_id:    primary key for a repo group
+        :type  group_id:    str
+        """
+        raise NotImplementedError
+
+
+class AddConsumerGroupMembersCommand(ConsumerGroupMembersCommand):
+
+    def __init__(self, context, name='add', description=DESC_ADD, method=None):
+        super(AddConsumerGroupMembersCommand, self).__init__(
+            context, name, description, method
+        )
+
+    def _action(self, group_id, **kwargs):
+        self.context.server.consumer_group_actions.associate(group_id, **kwargs)
+        msg = _('Consumer Group [%(c)s] membership updated')
+        self.context.prompt.render_success_message(msg % {'c' : group_id})
+
+
+class RemoveConsumerGroupMembersCommand(ConsumerGroupMembersCommand):
+
+    def __init__(self, context, name='remove', description=DESC_REMOVE, method=None):
+        super(RemoveConsumerGroupMembersCommand, self).__init__(
+            context, name, description, method
+        )
+
+    def _action(self, group_id, **kwargs):
+        self.context.server.consumer_group_actions.unassociate(group_id, **kwargs)
+        msg = _('Consumer Group [%(c)s] membership updated')
+        self.context.prompt.render_success_message(msg % {'c' : group_id})

--- a/pulp_rpm/extensions/admin/rpm_admin_consumer/package_group.py
+++ b/pulp_rpm/extensions/admin/rpm_admin_consumer/package_group.py
@@ -25,36 +25,36 @@ from pulp_rpm.extension.admin.content_schedules import (
 from pulp_rpm.common.ids import TYPE_ID_PKG_GROUP
 
 
-class GroupSection(PulpCliSection):
+class PackageGroupSection(PulpCliSection):
 
     def __init__(self, context):
         super(self.__class__, self).__init__(
             'package-group',
             _('package-group installation management'))
-        for Section in (InstallSection, UninstallSection):
+        for Section in (PackageGroupInstallSection, PackageGroupUninstallSection):
             self.add_subsection(Section(context))
 
-class InstallSection(PulpCliSection):
+class PackageGroupInstallSection(PulpCliSection):
 
     def __init__(self, context):
         super(self.__class__, self).__init__(
             'install',
             _('run or schedule a package-group installation task'))
 
-        self.add_subsection(SchedulesSection(context, 'install'))
-        self.add_command(Install(context))
+        self.add_subsection(PackageGroupSchedulesSection(context, 'install'))
+        self.add_command(PackageGroupInstallCommand(context))
 
-class UninstallSection(PulpCliSection):
+class PackageGroupUninstallSection(PulpCliSection):
 
     def __init__(self, context):
         super(self.__class__, self).__init__(
             'uninstall',
             _('run or schedule a package-group removal task'))
 
-        self.add_subsection(SchedulesSection(context, 'uninstall'))
-        self.add_command(Uninstall(context))
+        self.add_subsection(PackageGroupSchedulesSection(context, 'uninstall'))
+        self.add_command(PackageGroupUninstallCommand(context))
 
-class SchedulesSection(PulpCliSection):
+class PackageGroupSchedulesSection(PulpCliSection):
     def __init__(self, context, action):
         super(self.__class__, self).__init__(
             'schedules',
@@ -65,7 +65,7 @@ class SchedulesSection(PulpCliSection):
         self.add_command(ContentUpdateScheduleCommand(context, action))
         self.add_command(ContentNextRunCommand(context, action))
 
-class Install(PollingCommand):
+class PackageGroupInstallCommand(PollingCommand):
 
     def __init__(self, context):
         super(self.__class__, self).__init__(
@@ -161,7 +161,7 @@ class Install(PollingCommand):
                 filters=filter)
 
 
-class Uninstall(PollingCommand):
+class PackageGroupUninstallCommand(PollingCommand):
 
     def __init__(self, context):
         super(self.__class__, self).__init__(

--- a/pulp_rpm/extensions/admin/rpm_admin_consumer/pulp_cli.py
+++ b/pulp_rpm/extensions/admin/rpm_admin_consumer/pulp_cli.py
@@ -19,9 +19,11 @@ import basics
 from consumer_group_bind import (ConsumerGroupBindCommand,
                                  ConsumerGroupUnbindCommand)
 from consumer_group_package import ConsumerGroupPackageSection
+import consumer_group_cudl
+import consumer_group_members
 from bind import BindCommand, UnbindCommand
 from errata import ErrataSection
-from group import GroupSection
+from package_group import PackageGroupSection
 from package import PackageSection
 
 # -- framework hook -----------------------------------------------------------
@@ -46,12 +48,18 @@ def initialize(context):
 
     # New subsections
     consumer_section.add_subsection(PackageSection(context))
-    consumer_section.add_subsection(GroupSection(context))
+    consumer_section.add_subsection(PackageGroupSection(context))
     consumer_section.add_subsection(ErrataSection(context))
 
-    # consumer groups
-    consumer_group_description = _('rpm consumer group commands')
+    # Consumer groups
+    consumer_group_description = _('consumer group commands')
     consumer_group_section = consumer_section.create_subsection('group', consumer_group_description)
+
+    consumer_group_section.add_command(consumer_group_cudl.CreateConsumerGroupCommand(context))
+    consumer_group_section.add_command(consumer_group_cudl.UpdateConsumerGroupCommand(context))
+    consumer_group_section.add_command(consumer_group_cudl.DeleteConsumerGroupCommand(context))
+    consumer_group_section.add_command(consumer_group_cudl.ListConsumerGroupsCommand(context))
+    consumer_group_section.add_command(consumer_group_cudl.SearchConsumerGroupsCommand(context))
 
     m = _('binds each consumer in a consumer group to a repository')
     consumer_group_section.add_command(
@@ -60,6 +68,14 @@ def initialize(context):
     m = _('unbinds each consumer in a consumer group from a repository')
     consumer_group_section.add_command(
         ConsumerGroupUnbindCommand(context, 'unbind', m))
+
+    # Consumer group membership
+    members_description = _('manage members of repository groups')
+    members_section = consumer_group_section.create_subsection('members', members_description)
+
+    members_section.add_command(consumer_group_members.ListConsumerGroupMembersCommand(context))
+    members_section.add_command(consumer_group_members.AddConsumerGroupMembersCommand(context))
+    members_section.add_command(consumer_group_members.RemoveConsumerGroupMembersCommand(context))
 
     # New subsections for group subsection
     consumer_group_section.add_subsection(ConsumerGroupPackageSection(context))

--- a/pulp_rpm/test/unit/test_rpm_admin_consumer_extension.py
+++ b/pulp_rpm/test/unit/test_rpm_admin_consumer_extension.py
@@ -24,7 +24,7 @@ sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)) + '/../../extensio
 
 import rpm_support_base
 
-from rpm_admin_consumer import package, group
+from rpm_admin_consumer import package, package_group
 from pulp.client.extensions.core import TAG_SUCCESS
 from pulp_rpm.common.ids import TYPE_ID_RPM, TYPE_ID_PKG_GROUP
 
@@ -164,7 +164,7 @@ class TestGroups(rpm_support_base.PulpClientTests):
 
     def test_install(self):
         # Setup
-        command = group.Install(self.context)
+        command = package_group.PackageGroupInstallCommand(self.context)
         self.server_mock.request = Mock(side_effect=Request('install'))
         # Test
         args = {
@@ -186,7 +186,7 @@ class TestGroups(rpm_support_base.PulpClientTests):
 
     def test_uninstall(self):
         # Setup
-        command = group.Uninstall(self.context)
+        command = package_group.PackageGroupUninstallCommand(self.context)
         self.server_mock.request = Mock(side_effect=Request('uninstall'))
         # Test
         args = {


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=880441

Here's what happened. The consumer stuff used the old model of adding into the standard consumer section with RPM-specific stuff. We've moved away from that in favor of the root-level branching by support bundle so that we can fit Puppet stuff in.

As part of the root-level branching support, the repo commands were extracted out to pulp.client with the intention that the bundle extensions would leverage them and simply add in the specifics they need. All was right with the world.

We ran out of time to do the same for consumers. However, for 2.0 we need to at least have the consumer commands/sections under the rpm section so that they don't move post-2.0. A few weeks ago, a quick version of this was done by copying the commands out of the builtins and stuffing them directly into the RPM extensions. The builtins extension for this functionality was simply disabled (it's a no-op in it's init method).

In disabling that extension, however, we lost the group manipulation stuff. So for this fix, I basically copied with some structural changes these consumer group commands into the RPM extension. I left the originals and their unit tests alone and didn't carry over the unit tests since in January these will be refactored again to move into pulp.client (which I didn't have time to do cleanly with proper test coverage and docstrings now).

Where I'm going with all this is don't be surprised to find a lack of unit tests in this pull request. It's a 2.0 dirtiness and I feel dirty for it, but given the explanation above realize this isn't a few hundred lines of brand new untested code.
