### PR TITLE
881932 - updated bind/unbind output.

### DIFF
--- a/pulp_rpm/extensions/admin/rpm_admin_consumer/bind.py
+++ b/pulp_rpm/extensions/admin/rpm_admin_consumer/bind.py
@@ -30,9 +30,11 @@ class BindCommand(PulpCliCommand):
         repo_id = kwargs['repo-id']
 
         try:
-            self.context.server.bind.bind(id, repo_id, YUM_DISTRIBUTOR_ID)
-            m = _('Consumer [%(c)s] successfully bound to repository [%(r)s]')
-            self.context.prompt.render_success_message(m % {'c' : id, 'r' : repo_id})
+            response = self.context.server.bind.bind(id, repo_id, YUM_DISTRIBUTOR_ID)
+            msg = _('Bind tasks successfully created:')
+            self.context.prompt.render_success_message(msg)
+            tasks = [dict(task_id=str(t.task_id)) for t in response.response_body]
+            self.context.prompt.render_document_list(tasks)
         except NotFoundException, e:
             resources = e.extra_data['resources']
             if 'consumer' in resources:
@@ -57,9 +59,11 @@ class UnbindCommand(PulpCliCommand):
         repo_id = kwargs['repo-id']
         force = kwargs['force']
         try:
-            self.context.server.bind.unbind(id, repo_id, YUM_DISTRIBUTOR_ID, force)
-            m = _('Consumer [%(c)s] successfully unbound from repository [%(r)s]')
-            self.context.prompt.render_success_message(m % {'c' : id, 'r' : repo_id})
+            response = self.context.server.bind.unbind(id, repo_id, YUM_DISTRIBUTOR_ID, force)
+            msg = _('Unbind tasks successfully created:')
+            self.context.prompt.render_success_message(msg)
+            tasks = [dict(task_id=str(t.task_id)) for t in response.response_body]
+            self.context.prompt.render_document_list(tasks)
         except NotFoundException, e:
             bind_id = e.extra_data['resources']['bind_id']
             m = _('Binding [consumer: %(c)s, repository: %(r)s] does not exist on the server')

--- a/pulp_rpm/extensions/consumer/rpm_consumer/pulp_cli.py
+++ b/pulp_rpm/extensions/consumer/rpm_consumer/pulp_cli.py
@@ -54,9 +54,11 @@ class BindCommand(PulpCliCommand):
         repo_id = kwargs['repo-id']
 
         try:
-            self.context.server.bind.bind(consumer_id, repo_id, YUM_DISTRIBUTOR_TYPE_ID)
-            m = _('Consumer [%(c)s] successfully bound to repository [%(r)s]')
-            self.prompt.render_success_message(m % {'c' : consumer_id, 'r' : repo_id})
+            response = self.context.server.bind.bind(consumer_id, repo_id, YUM_DISTRIBUTOR_TYPE_ID)
+            msg = _('Bind tasks successfully created:')
+            self.context.prompt.render_success_message(msg)
+            tasks = [dict(task_id=str(t.task_id)) for t in response.response_body]
+            self.context.prompt.render_document_list(tasks)
         except NotFoundException, e:
             resources = e.extra_data['resources']
             if 'consumer' in resources:
@@ -88,9 +90,11 @@ class UnbindCommand(PulpCliCommand):
         force = kwargs['force']
 
         try:
-            self.context.server.bind.unbind(consumer_id, repo_id, YUM_DISTRIBUTOR_TYPE_ID, force)
-            m = _('Consumer [%(c)s] successfully unbound from repository [%(r)s]')
-            self.prompt.render_success_message(m % {'c' : consumer_id, 'r' : repo_id})
+            response = self.context.server.bind.unbind(consumer_id, repo_id, YUM_DISTRIBUTOR_TYPE_ID, force)
+            msg = _('Unbind tasks successfully created:')
+            self.context.prompt.render_success_message(msg)
+            tasks = [dict(task_id=str(t.task_id)) for t in response.response_body]
+            self.context.prompt.render_document_list(tasks)
         except NotFoundException, e:
             bind_id = e.extra_data['resources']['bind_id']
             m = _('Binding [consumer: %(c)s, repository: %(r)s] does not exist on the server')


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=881932

sample output:

[jortel@localhost pulp_rpm]$ pulp-admin rpm consumer unbind --consumer-id=jortel --repo-id=jeff
Unbind tasks successfully created:

Task Id: 99d0f41d-eb53-4454-a2f2-b21bef1c269d

Task Id: a5443c5b-ddd7-4255-8fb4-ce742e91d299

Task Id: c1e3a66c-3bbb-4bfe-ad7a-2a138839966b

[jortel@localhost pulp_rpm]$ pulp-admin rpm consumer bind --consumer-id=jortel --repo-id=jeff
Bind tasks successfully created:

Task Id: 7f0fa3d6-83f4-4177-88ba-12e86d76ae9c

Task Id: e8feb7f0-cde5-4ab8-9a90-d6e85e0b1d42
