### PR TITLE
886240 - repo sync for a repo created with a feed of /var/lib/pulp of another repo results in less number of contents than the original repo

### DIFF
--- a/pulp_rpm/src/pulp_rpm/yum_plugin/metadata.py
+++ b/pulp_rpm/src/pulp_rpm/yum_plugin/metadata.py
@@ -588,6 +588,7 @@ xmlns:rpm="http://linux.duke.edu/metadata/rpm" packages="%s"> \n""" % self.unit_
                     _LOG.debug("No repodata found for the unit; continue")
                     continue
         finally:
+            self.unit_count += len(units)
             end = time.time()
         _LOG.info("per unit metadata merge completed in %s seconds" % (end - start))
 


### PR DESCRIPTION
Updated pagination logic for package metadata
