### PR TITLE
886240 - fixing distribution sync and publish

### DIFF
--- a/pulp_rpm/plugins/distributors/yum_distributor/distributor.py
+++ b/pulp_rpm/plugins/distributors/yum_distributor/distributor.py
@@ -671,6 +671,18 @@ class YumDistributor(Distributor):
             _LOG.debug("Found %s distribution files to symlink" % len(distro_files))
             distro_progress_status['items_total'] = len(distro_files)
             distro_progress_status['items_left'] = len(distro_files)
+            # Lookup treeinfo file in the source location
+            src_treeinfo_path = None
+            for treeinfo in constants.TREE_INFO_LIST:
+                src_treeinfo_path = os.path.join(source_path_dir, treeinfo)
+                if os.path.exists(src_treeinfo_path):
+                    # we found the treeinfo file
+                    break
+            if src_treeinfo_path is not None:
+                # create a symlink from content location to repo location.
+                symlink_treeinfo_path = os.path.join(symlink_dir, treeinfo)
+                _LOG.debug("creating treeinfo symlink from %s to %s" % (src_treeinfo_path, symlink_treeinfo_path))
+                util.create_symlink(src_treeinfo_path, symlink_treeinfo_path)
             published_distro_files = []
             for dfile in distro_files:
                 self.set_progress("distribution", distro_progress_status, progress_callback)

--- a/pulp_rpm/plugins/importers/yum_importer/importer_rpm.py
+++ b/pulp_rpm/plugins/importers/yum_importer/importer_rpm.py
@@ -21,6 +21,7 @@ from grinder.RepoFetch import YumRepoGrinder
 from pulp.server.db.model.criteria import UnitAssociationCriteria
 from pulp_rpm.yum_plugin import util, metadata
 from yum_importer import distribution, drpm
+import pulp_rpm.common.constants as constants
 
 _LOG = util.getLogger(__name__)
 
@@ -261,7 +262,7 @@ def get_yumRepoGrinder(repo_id, repo_working_dir, config):
         proxy_url=proxy_url, proxy_port=proxy_port, proxy_user=proxy_user,\
         proxy_pass=proxy_pass, sslverify=sslverify, packages_location="./",\
         remove_old=remove_old, numOldPackages=num_old_packages, skip=skip, max_speed=max_speed,\
-        purge_orphaned=purge_orphaned, distro_location=None, tmp_path=repo_working_dir)
+        purge_orphaned=purge_orphaned, distro_location=constants.DISTRIBUTION_STORAGE_PATH, tmp_path=repo_working_dir)
     return yumRepoGrinder
 
 def _search_for_error(rpm_dict):

--- a/pulp_rpm/src/pulp_rpm/common/constants.py
+++ b/pulp_rpm/src/pulp_rpm/common/constants.py
@@ -23,3 +23,12 @@ COMPLETE_STATES = (STATE_COMPLETE, STATE_FAILED, STATE_SKIPPED)
 REPO_NOTE_KEY = '_repo-type' # needs to be standard across extensions
 REPO_NOTE_RPM = 'rpm-repo'
 PUBLISHED_DISTRIBUTION_FILES_KEY = 'published_distributions'
+
+# There is no clean way to get the distribution storage location outside of the unit;
+# we need this path when initializing grinder so the treeinfo file gets compied and
+# symlinked to the right path. Once we have a nicer way of getting this path replace this
+DISTRIBUTION_STORAGE_PATH = '/var/lib/pulp/content/distribution/'
+
+# During publish we need to lookup and make sure the treeinfo exists; since the treeinfo
+# can be '.treeinfo' or 'treeinfo' (in cdn case) we need to check which one exists
+TREE_INFO_LIST = ['.treeinfo', 'treeinfo']


### PR DESCRIPTION
- set the distro location when grinder is invoked so treeinfo gets downloaded and symlinked to right location
- fix the publish to lookup treeinfo and symlink to publish location
