### PR TITLE
887959 - Removing NameVirtualHost entries from plugin httpd conf files a...

### DIFF
--- a/pulp_rpm/etc/httpd/conf.d/pulp_rpm.conf
+++ b/pulp_rpm/etc/httpd/conf.d/pulp_rpm.conf
@@ -34,7 +34,6 @@ Alias /pulp/repos /var/www/pub/https/repos
 </Directory>
 
 # -- HTTP Repositories ---------
-NameVirtualHost *:80
 <VirtualHost *:80>
     Alias /pulp/repos /var/www/pub/http/repos
     Alias /pulp/isos /var/www/pub/http/isos


### PR DESCRIPTION
...nd adding it only at one place in main pulp.conf

https://bugzilla.redhat.com/show_bug.cgi?id=887959

Please review pull requests for same bugzilla in pulp and pulp_puppet as well. 
