### PR TITLE
896027 - pulp-rpm-common owns site-packages/pulp_rpm directory only.

### DIFF
--- a/pulp-rpm.spec
+++ b/pulp-rpm.spec
@@ -123,7 +123,7 @@ A collection of modules shared among all RPM components.
 
 %files -n python-pulp-rpm-common
 %defattr(-,root,root,-)
-%{python_sitelib}/pulp_rpm
+%dir %{python_sitelib}/pulp_rpm
 %{python_sitelib}/pulp_rpm/__init__.py*
 %{python_sitelib}/pulp_rpm/common/
 %doc
@@ -162,6 +162,7 @@ to provide RPM specific support.
 
 %files plugins
 %defattr(-,root,root,-)
+%{python_sitelib}/pulp_rpm/migrations/
 %{python_sitelib}/pulp_rpm/repo_auth/
 %{python_sitelib}/pulp_rpm/yum_plugin/
 %config(noreplace) %{_sysconfdir}/pulp/repo_auth.conf


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=896027

When narrowing down the scope of pulp-rpm-common, the migration strips were not accounted for.  Seemed they should be owned by the plugins.
