### PR TITLE
903387 - include /var/lib/pulp/published in pulp-rpm-plugins.

### DIFF
--- a/pulp-rpm.spec
+++ b/pulp-rpm.spec
@@ -66,7 +66,8 @@ mkdir -p %{buildroot}/%{_usr}/lib/pulp/plugins
 mkdir -p %{buildroot}/%{_usr}/lib/pulp/admin/extensions
 mkdir -p %{buildroot}/%{_usr}/lib/pulp/consumer/extensions
 mkdir -p %{buildroot}/%{_usr}/lib/pulp/agent/handlers
-mkdir -p %{buildroot}/%{_var}/lib/pulp/published
+mkdir -p %{buildroot}/%{_var}/lib/pulp/published/http
+mkdir -p %{buildroot}/%{_var}/lib/pulp/published/https
 mkdir -p %{buildroot}/%{_usr}/lib/yum-plugins/
 mkdir -p %{buildroot}/%{_var}/www
 
@@ -174,7 +175,7 @@ to provide RPM specific support.
 %{_usr}/lib/pulp/plugins/profilers/rpm_errata_profiler/
 %defattr(-,apache,apache,-)
 %{_var}/www/pub
-%dir %{_var}/lib/pulp/published
+%{_var}/lib/pulp/published/
 %{_sysconfdir}/pki/pulp/content/
 /srv/pulp/repo_auth.wsgi
 %doc


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=903387
