### PR TITLE
889565 - Corrected configuration options from being flags to options

### DIFF
--- a/pulp_rpm/src/pulp_rpm/extension/admin/upload/group.py
+++ b/pulp_rpm/src/pulp_rpm/extension/admin/upload/group.py
@@ -11,6 +11,7 @@
 
 from gettext import gettext as _
 
+from pulp.client import parsers
 from pulp.client.commands.options import OPTION_REPO_ID
 from pulp.client.commands.repo.upload import UploadCommand
 from pulp.client.extensions.extensions import PulpCliFlag, PulpCliOption
@@ -54,10 +55,10 @@ d = _('sets the "langonly" attribute for the package group')
 OPT_LANGONLY = PulpCliOption('--langonly', d, allow_multiple=False, required=False)
 
 d = _('set "default" flag on package group to True')
-OPT_DEFAULT = PulpCliFlag('--default', d)
+OPT_DEFAULT = PulpCliOption('--default', d, allow_multiple=False, required=False, parse_func=parsers.parse_boolean)
 
 d = _('set "user_visible" flag on package group to True')
-OPT_USER_VISIBLE = PulpCliFlag('--user-visible', d)
+OPT_USER_VISIBLE = PulpCliOption('--user-visible', d, allow_multiple=False, required=False, parse_func=parsers.parse_boolean)
 
 
 class CreatePackageGroupCommand(UploadCommand) :

--- a/pulp_rpm/test/unit/test_extensions_upload_group.py
+++ b/pulp_rpm/test/unit/test_extensions_upload_group.py
@@ -81,3 +81,70 @@ class CreatePackageGroupCommand(rpm_support_base.PulpClientTests):
         self.assertEqual(metadata['display_order'], 'test-order')
         self.assertEqual(metadata['translated_description'], {})
         self.assertEqual(metadata['translated_name'], '')
+
+    def test_user_visible_option(self):
+        # Setup
+        self.cli.add_command(self.command)
+        mock_generate = mock.MagicMock()
+        self.command.generate_metadata = mock_generate
+
+        # Test
+        cmd = 'group --repo-id repo-a --group-id group-a --name name-a ' \
+              '--description desc-a --user-visible true'
+        exit_code = self.cli.run(cmd.split())
+
+        # Verify
+        self.assertEqual(exit_code, 0)
+
+        kwargs = mock_generate.call_args[1]
+        self.assertTrue('user-visible' in kwargs)
+        self.assertEqual(kwargs['user-visible'], True)  # ensure correct parsing to boolean
+
+    def test_user_visible_unparsable(self):
+        # Setup
+        self.cli.add_command(self.command)
+        mock_generate = mock.MagicMock()
+        self.command.generate_metadata = mock_generate
+
+        # Test
+        cmd = 'group --repo-id repo-a --group-id group-a --name name-a ' \
+              '--description desc-a --user-visible foo'
+        exit_code = self.cli.run(cmd.split())
+
+        # Verify
+        self.assertTrue(exit_code != 0)
+        self.assertEqual(mock_generate.call_count, 0)  # command shouldn't even get this far
+
+    def test_default_option(self):
+        # Setup
+        self.cli.add_command(self.command)
+        mock_generate = mock.MagicMock()
+        self.command.generate_metadata = mock_generate
+
+        # Test
+        cmd = 'group --repo-id repo-a --group-id group-a --name name-a ' \
+              '--description desc-a --default false'
+        exit_code = self.cli.run(cmd.split())
+
+        # Verify
+        self.assertEqual(exit_code, 0)
+
+        kwargs = mock_generate.call_args[1]
+        self.assertTrue('default' in kwargs)
+        self.assertEqual(kwargs['default'], False)  # ensure correct parsing to boolean
+
+    def test_default_option(self):
+        # Setup
+        self.cli.add_command(self.command)
+        mock_generate = mock.MagicMock()
+        self.command.generate_metadata = mock_generate
+
+        # Test
+        cmd = 'group --repo-id repo-a --group-id group-a --name name-a ' \
+              '--description desc-a --default foo'
+        exit_code = self.cli.run(cmd.split())
+
+        # Verify
+        self.assertTrue(exit_code != 0)
+        self.assertEqual(mock_generate.call_count, 0)  # command shouldn't even get this far
+


### PR DESCRIPTION
Configuration options should always be expressed as key=value, even for booleans. This translates to using PulpCliOption instead of PulpCliFlag. This fix makes that change and uses the boolean parser to ensure the parsing of those boolean values is correct.
