### PR TITLE
916336 - Change the default num_threads to 4.

### DIFF
--- a/pulp_rpm/plugins/importers/yum_importer/importer_rpm.py
+++ b/pulp_rpm/plugins/importers/yum_importer/importer_rpm.py
@@ -215,6 +215,7 @@ def force_ascii(value):
         retval = value.encode('ascii', 'ignore')
     return retval
 
+
 def get_yumRepoGrinder(repo_id, repo_working_dir, config):
     """
     @param repo_id repo id
@@ -231,7 +232,7 @@ def get_yumRepoGrinder(repo_id, repo_working_dir, config):
     """
     repo_label = repo_id
     repo_url = config.get("feed_url")
-    num_threads = config.get("num_threads") or 1
+    num_threads = config.get("num_threads") or 4
     proxy_url = force_ascii(config.get("proxy_url"))
     proxy_port = force_ascii(config.get("proxy_port"))
     proxy_user = force_ascii(config.get("proxy_user"))
@@ -264,6 +265,7 @@ def get_yumRepoGrinder(repo_id, repo_working_dir, config):
         remove_old=remove_old, numOldPackages=num_old_packages, skip=skip, max_speed=max_speed,\
         purge_orphaned=purge_orphaned, distro_location=constants.DISTRIBUTION_STORAGE_PATH, tmp_path=repo_working_dir)
     return yumRepoGrinder
+
 
 def _search_for_error(rpm_dict):
     errors = {}


### PR DESCRIPTION
I was unable to verify that this change actually causes Grinder to use 4 threads by default, due to https://bugzilla.redhat.com/show_bug.cgi?id=916345. I humbly request that the reviewer of this PR would check the grinder log to ensure that it is using 4 threads with this change (and that someone who doesn't develop on F18 review this).
