### PR TITLE
It turns out that the repo group distributor accepts the same arguments.

### DIFF
--- a/docs/tech-reference/export-distributor.rst
+++ b/docs/tech-reference/export-distributor.rst
@@ -1,14 +1,15 @@
-==================
-Export Distributor
-==================
+===================
+Export Distributors
+===================
 
-The Export Distributor can be used to build an ISO image out of the content available in RPM repositories.
-The Export Distributor ID is ``export_distributor``.
+There are two export distributors, one that allows exporting a single repository, and another that allows you to
+export a repository group. The export distributors build ISO images out of the content available in RPM
+repositories. Both distributors use the same ID, ``export_distributor``.
 
 Configuration Parameters
 ========================
 
-The following options are available when configuring the Export Distributor.
+The following options are available when configuring the export distributors.
 
 Required Configuration Parameters
 ---------------------------------


### PR DESCRIPTION
I poked around in the code, and it does appear that the group distributor and the repo distributor take the same arguments in the same way, so I've just modified the docs slightly to reflect that.
