### PR TITLE
Removing a non-deterministic unit test. We have a Rally task to reimplim...

### DIFF
--- a/pulp_rpm/test/unit/server/test_distributor.py
+++ b/pulp_rpm/test/unit/server/test_distributor.py
@@ -639,78 +639,7 @@ class TestDistributor(rpm_support_base.PulpRPMTests):
         repo.display_name = 'Nice Repo'
         payload = distributor.create_consumer_payload(repo, config, None)
         for field in PAYLOAD_FIELDS:
-            print field
             self.assertTrue(field in payload)
 
         self.assertTrue('http' in payload['protocols'])
         self.assertTrue('https' in payload['protocols'])
-        print payload
-
-
-    def test_cancel_publish(self):
-        global updated_progress
-        updated_progress = None
-
-        def set_progress(progress):
-            global updated_progress
-            updated_progress = progress
-
-        class TestPublishThread(threading.Thread):
-            def __init__(self, working_dir, pkg_dir, config):
-                threading.Thread.__init__(self)
-                self.repo = mock.Mock(spec=Repository)
-                self.repo.working_dir = working_dir
-                self.repo.id = "test_cancel_publish"
-                self.publish_conduit = distributor_mocks.get_publish_conduit(pkg_dir=pkg_dir)
-                self.publish_conduit.set_progress = mock.Mock()
-                self.publish_conduit.set_progress.side_effect = set_progress
-                self.config = config
-                self.distributor = YumDistributor()
-
-            def run(self):
-                self.distributor.publish_repo(self.repo, self.publish_conduit, self.config)
-
-            def cancel(self):
-                return self.distributor.cancel_publish_repo(None, None)
-
-        working_dir = os.path.join(self.temp_dir, "test_cancel_publish")
-
-        try:
-            ####
-            # Prepare a directory with test data so that createrepo will run for a minute or more
-            # this allows us time to interrupt it and test that cancel is working
-            ####
-            num_links = 1500
-            source_rpm = os.path.join(self.data_dir, "createrepo_test", "pulp-large_1mb_test-packageA-0.1.1-1.fc14.noarch.rpm")
-            self.assertTrue(os.path.exists(source_rpm))
-            os.makedirs(working_dir)
-            for index in range(num_links):
-                temp_name = "temp_link-%s.rpm" % (index)
-                temp_name = os.path.join(working_dir, temp_name)
-                if not os.path.exists(temp_name):
-                    os.symlink(source_rpm, temp_name)
-
-            config = distributor_mocks.get_basic_config(https_publish_dir=self.https_publish_dir,
-                http_publish_dir=self.http_publish_dir, relative_url="rel_temp/",
-                generate_metadata=True, http=True, https=False, use_createrepo=True)
-            test_thread = TestPublishThread(working_dir, self.pkg_dir, config)
-            test_thread.start()
-            running = False
-            for index in range(15):
-                if updated_progress and updated_progress.has_key("metadata") and updated_progress["metadata"].has_key("state"):
-                    if updated_progress["metadata"]["state"] in ["IN_PROGRESS", "FAILED", "FINISHED", "CANCELED"]:
-                        running = True
-                        break
-                time.sleep(1)
-            self.assertTrue(running)
-            self.assertEquals(updated_progress["metadata"]["state"], "IN_PROGRESS")
-            self.assertTrue(test_thread.cancel())
-            for index in range(15):
-                if updated_progress and updated_progress.has_key("metadata") and updated_progress["metadata"].has_key("state"):
-                    if updated_progress["metadata"]["state"] in ["FAILED", "FINISHED", "CANCELED"]:
-                        break
-                time.sleep(1)
-            self.assertEquals(updated_progress["metadata"]["state"], "CANCELED")
-        finally:
-            if os.path.exists(working_dir):
-                shutil.rmtree(working_dir)


### PR DESCRIPTION
Removing a non-deterministic unit test. We have a Rally task to reimpliment it more suitably when we rewrite the distributor.

This test is difficult to follow, and I believe more complicated than necessary. I think it would be better to assert cancellation behaviors by asserting appropriate calls are made by using Mock to wrap objects. Due to this test using threads of its own to test cancellation, it is not deterministic likely due to race conditions, and does occasionally fail. We will write a better test to ensure cancellation works when we rewrite the distributor.

We also benefit because this test was slow (there is a loop with a sleep(1) in it).

I also removed some stray print statements.
