### PR TITLE
923792 - Errata queries during sync don't properly limit returned data

### DIFF
--- a/pulp_rpm/plugins/importers/yum_importer/errata.py
+++ b/pulp_rpm/plugins/importers/yum_importer/errata.py
@@ -17,7 +17,7 @@ Errata Support for Yum Importer
 import os
 import time
 import yum
-from pulp_rpm.common.ids import TYPE_ID_ERRATA, UNIT_KEY_ERRATA, METADATA_ERRATA
+from pulp_rpm.common.ids import TYPE_ID_ERRATA, UNIT_KEY_ERRATA, METADATA_ERRATA, UNIT_KEY_RPM
 from pulp_rpm.yum_plugin import util, updateinfo
 from pulp.server.db.model.criteria import UnitAssociationCriteria, Criteria
 from yum_importer import importer_rpm
@@ -187,10 +187,18 @@ def link_errata_rpm_units(sync_conduit, new_errata_units):
     @return a link_report dictionry.
     @rtype {}
     """
+    valid_fields = []
+    valid_fields.extend(UNIT_KEY_RPM)
+    valid_fields.append("_storage_path")
     link_report = {}
+    existing_rpms = {}
     # link errata and rpm units
-    criteria = UnitAssociationCriteria(type_ids=[importer_rpm.RPM_TYPE_ID, importer_rpm.SRPM_TYPE_ID])
-    existing_rpms = importer_rpm.get_existing_units(sync_conduit, criteria=criteria)
+    criteria = UnitAssociationCriteria(type_ids=[importer_rpm.RPM_TYPE_ID], unit_fields=valid_fields)
+    partial_rpms = importer_rpm.get_existing_units(sync_conduit, criteria=criteria)
+    existing_rpms.update(partial_rpms)
+    criteria = UnitAssociationCriteria(type_ids=[importer_rpm.SRPM_TYPE_ID], unit_fields=valid_fields)
+    partial_rpms = importer_rpm.get_existing_units(sync_conduit, criteria=criteria)
+    existing_rpms.update(partial_rpms)
     link_report['linked_units'] = []
     link_report['missing_rpms'] = []
     for u in new_errata_units.values():


### PR DESCRIPTION
This patch uses the criteria to restrict package metadata snippets from being included with mongo queries.

Sync of RHEL 6.2 to CDN with 4 threads took 70 minutes
and ended up ~1.1GB of memory usage.

apache   14571 75.2 14.6 2504504 1121640 ?     Sl   10:06  55:17  _ (wsgi:pulp)

Previously we were seeing usage of ~3.5GB
