### PR TITLE
Unit tests for remove commands

### DIFF
--- a/pulp_rpm/src/pulp_rpm/extension/admin/remove.py
+++ b/pulp_rpm/src/pulp_rpm/extension/admin/remove.py
@@ -70,6 +70,7 @@ class PackageCategoryRemoveCommand(UnitRemoveCommand):
         super(PackageCategoryRemoveCommand, self).__init__(
                 context, name='category', description=DESC_CATEGORY, type_id=TYPE_ID_PKG_CATEGORY)
 
+
 class DistributionRemoveCommand(UnitRemoveCommand):
 
     def __init__(self, context):

--- a/pulp_rpm/test/unit/test_extensions_remove_units.py
+++ b/pulp_rpm/test/unit/test_extensions_remove_units.py
@@ -1,0 +1,106 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2013 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+import rpm_support_base
+
+from pulp.client.commands.unit import UnitRemoveCommand
+
+from pulp_rpm.common.ids import (TYPE_ID_RPM, TYPE_ID_SRPM, TYPE_ID_DRPM, TYPE_ID_ERRATA, TYPE_ID_DISTRO,
+                                 TYPE_ID_PKG_GROUP, TYPE_ID_PKG_CATEGORY)
+from pulp_rpm.extension.admin import remove as remove_commands
+
+class RemoveCommandsTests(rpm_support_base.PulpClientTests):
+    """
+    The command implementations are simply configuration to the base commands, so rather than
+    re-testing the functionality of the base commands, they simply assert that the configuration
+    is correct.
+    """
+
+    def test_rpm_remove_command(self):
+        # Test
+        command = remove_commands.RpmRemoveCommand(self.context)
+
+        # Verify
+        self.assertTrue(isinstance(command, UnitRemoveCommand))
+        self.assertEqual(command.name, 'rpm')
+        self.assertEqual(command.description, remove_commands.DESC_RPM)
+        self.assertEqual(command.type_id, TYPE_ID_RPM)
+
+    def test_srpm_remove_command(self):
+        # Test
+        command = remove_commands.SrpmRemoveCommand(self.context)
+
+        # Verify
+        self.assertTrue(isinstance(command, UnitRemoveCommand))
+        self.assertEqual(command.name, 'srpm')
+        self.assertEqual(command.description, remove_commands.DESC_SRPM)
+        self.assertEqual(command.type_id, TYPE_ID_SRPM)
+
+    def test_drpm_remove_command(self):
+        # Test
+        command = remove_commands.DrpmRemoveCommand(self.context)
+
+        # Verify
+        self.assertTrue(isinstance(command, UnitRemoveCommand))
+        self.assertEqual(command.name, 'drpm')
+        self.assertEqual(command.description, remove_commands.DESC_DRPM)
+        self.assertEqual(command.type_id, TYPE_ID_DRPM)
+
+    def test_srpm_remove_command(self):
+        # Test
+        command = remove_commands.SrpmRemoveCommand(self.context)
+
+        # Verify
+        self.assertTrue(isinstance(command, UnitRemoveCommand))
+        self.assertEqual(command.name, 'srpm')
+        self.assertEqual(command.description, remove_commands.DESC_SRPM)
+        self.assertEqual(command.type_id, TYPE_ID_SRPM)
+
+    def test_errata_remove_command(self):
+        # Test
+        command = remove_commands.ErrataRemoveCommand(self.context)
+
+        # Verify
+        self.assertTrue(isinstance(command, UnitRemoveCommand))
+        self.assertEqual(command.name, 'errata')
+        self.assertEqual(command.description, remove_commands.DESC_ERRATA)
+        self.assertEqual(command.type_id, TYPE_ID_ERRATA)
+
+    def test_group_remove_command(self):
+        # Test
+        command = remove_commands.PackageGroupRemoveCommand(self.context)
+
+        # Verify
+        self.assertTrue(isinstance(command, UnitRemoveCommand))
+        self.assertEqual(command.name, 'group')
+        self.assertEqual(command.description, remove_commands.DESC_GROUP)
+        self.assertEqual(command.type_id, TYPE_ID_PKG_GROUP)
+
+    def test_package_category_remove_command(self):
+        # Test
+        command = remove_commands.PackageCategoryRemoveCommand(self.context)
+
+        # Verify
+        self.assertTrue(isinstance(command, UnitRemoveCommand))
+        self.assertEqual(command.name, 'category')
+        self.assertEqual(command.description, remove_commands.DESC_CATEGORY)
+        self.assertEqual(command.type_id, TYPE_ID_PKG_CATEGORY)
+
+    def test_distribution_remove_command(self):
+        # Test
+        command = remove_commands.DistributionRemoveCommand(self.context)
+
+        # Verify
+        self.assertTrue(isinstance(command, UnitRemoveCommand))
+        self.assertEqual(command.name, 'distribution')
+        self.assertEqual(command.description, remove_commands.DESC_DISTRIBUTION)
+        self.assertEqual(command.type_id, TYPE_ID_DISTRO)


### PR DESCRIPTION
Corresponds to the changes in https://github.com/pulp/pulp/pull/407

The APIs didn't actually change, but there were no unit tests so this PR is largely just to add those.
