### PR TITLE
Added display of removed units, refactoring copy units a bit in the

### DIFF
--- a/pulp_rpm/src/pulp_rpm/common/constants.py
+++ b/pulp_rpm/src/pulp_rpm/common/constants.py
@@ -62,3 +62,9 @@ DISTRIBUTION_STORAGE_PATH = '/var/lib/pulp/content/distribution/'
 # During publish we need to lookup and make sure the treeinfo exists; since the treeinfo
 # can be '.treeinfo' or 'treeinfo' (in cdn case) we need to check which one exists
 TREE_INFO_LIST = ['.treeinfo', 'treeinfo']
+
+# -- extensions ---------------------------------------------------------------
+
+# Number of units to display by name for operations that return a list of
+# modules that were acted on, such as copy and remove
+DISPLAY_UNITS_THRESHOLD = 100

--- a/pulp_rpm/src/pulp_rpm/extension/admin/copy_commands.py
+++ b/pulp_rpm/src/pulp_rpm/extension/admin/copy_commands.py
@@ -13,6 +13,8 @@ from gettext import gettext as _
 
 from pulp.client.commands.unit import UnitCopyCommand
 from pulp.client.extensions.extensions import PulpCliFlag
+
+from pulp_rpm.common.constants import DISPLAY_UNITS_THRESHOLD
 from pulp_rpm.common.ids import (TYPE_ID_RPM, TYPE_ID_SRPM, TYPE_ID_DRPM, TYPE_ID_ERRATA, TYPE_ID_DISTRO,
                                  TYPE_ID_PKG_GROUP, TYPE_ID_PKG_CATEGORY)
 from pulp_rpm.extension.admin import units_display
@@ -31,9 +33,6 @@ DESC_RECURSIVE = _('if specified, any dependencies of units being copied that ar
                    'will be copied as well')
 FLAG_RECURSIVE = PulpCliFlag('--recursive', DESC_RECURSIVE)
 
-# Number of modules after which this command won't bother printing them all to the screen
-DEFAULT_UNIT_THRESHOLD = 100
-
 # -- commands -----------------------------------------------------------------
 
 class RecursiveCopyCommand(UnitCopyCommand):
@@ -46,7 +45,7 @@ class RecursiveCopyCommand(UnitCopyCommand):
     stick with the approach that it's supported for all of them.
     """
 
-    def __init__(self, context, name, description, type_id, unit_threshold=DEFAULT_UNIT_THRESHOLD):
+    def __init__(self, context, name, description, type_id, unit_threshold=DISPLAY_UNITS_THRESHOLD):
         UnitCopyCommand.__init__(self, context, name=name, description=description, type_id=type_id)
 
         self.add_flag(FLAG_RECURSIVE)

--- a/pulp_rpm/src/pulp_rpm/extension/admin/remove.py
+++ b/pulp_rpm/src/pulp_rpm/extension/admin/remove.py
@@ -13,9 +13,11 @@ from gettext import gettext as _
 
 from pulp.client.commands.unit import UnitRemoveCommand
 
+from pulp_rpm.common.constants import DISPLAY_UNITS_THRESHOLD
 from pulp_rpm.common.ids import (TYPE_ID_RPM, TYPE_ID_SRPM, TYPE_ID_DRPM,
                                  TYPE_ID_ERRATA, TYPE_ID_PKG_GROUP,
                                  TYPE_ID_PKG_CATEGORY, TYPE_ID_DISTRO)
+from pulp_rpm.extension.admin import units_display
 
 # -- constants ----------------------------------------------------------------
 
@@ -29,50 +31,55 @@ DESC_DISTRIBUTION = _('remove distributions from a repository')
 
 # -- commands -----------------------------------------------------------------
 
-class RpmRemoveCommand(UnitRemoveCommand):
+class BaseRemoveCommand(UnitRemoveCommand):
+
+    def __init__(self, context, name, description, type_id, unit_threshold=DISPLAY_UNITS_THRESHOLD):
+        UnitRemoveCommand.__init__(self, context, name=name, description=description, type_id=type_id)
+        self.unit_threshold = unit_threshold
+
+    def succeeded(self, task):
+        removed_units = task.result  # entries are a dict containing unit_key and type_id
+        units_display.display_units(self.prompt, removed_units, self.unit_threshold)
+
+class RpmRemoveCommand(BaseRemoveCommand):
 
     def __init__(self, context):
-        super(RpmRemoveCommand, self).__init__(
-                context, name='rpm', description=DESC_RPM, type_id=TYPE_ID_RPM)
+        super(RpmRemoveCommand, self).__init__(context, 'rpm', DESC_RPM, TYPE_ID_RPM)
 
 
-class SrpmRemoveCommand(UnitRemoveCommand):
-
-    def __init__(self, context):
-        super(SrpmRemoveCommand, self).__init__(
-                context, name='srpm', description=DESC_SRPM, type_id=TYPE_ID_SRPM)
-
-
-class DrpmRemoveCommand(UnitRemoveCommand):
+class SrpmRemoveCommand(BaseRemoveCommand):
 
     def __init__(self, context):
-        super(DrpmRemoveCommand, self).__init__(
-                context, name='drpm', description=DESC_DRPM, type_id=TYPE_ID_DRPM)
+        super(SrpmRemoveCommand, self).__init__(context, 'srpm', DESC_SRPM, TYPE_ID_SRPM)
 
 
-class ErrataRemoveCommand(UnitRemoveCommand):
-
-    def __init__(self, context):
-        super(ErrataRemoveCommand, self).__init__(
-                context, name='errata', description=DESC_ERRATA, type_id=TYPE_ID_ERRATA)
-
-
-class PackageGroupRemoveCommand(UnitRemoveCommand):
+class DrpmRemoveCommand(BaseRemoveCommand):
 
     def __init__(self, context):
-        super(PackageGroupRemoveCommand, self).__init__(
-                context, name='group', description=DESC_GROUP, type_id=TYPE_ID_PKG_GROUP)
+        super(DrpmRemoveCommand, self).__init__(context, 'drpm', DESC_DRPM, TYPE_ID_DRPM)
 
 
-class PackageCategoryRemoveCommand(UnitRemoveCommand):
-
-    def __init__(self, context):
-        super(PackageCategoryRemoveCommand, self).__init__(
-                context, name='category', description=DESC_CATEGORY, type_id=TYPE_ID_PKG_CATEGORY)
-
-
-class DistributionRemoveCommand(UnitRemoveCommand):
+class ErrataRemoveCommand(BaseRemoveCommand):
 
     def __init__(self, context):
-        super(DistributionRemoveCommand, self).__init__(
-                context, name='distribution', description=DESC_DISTRIBUTION, type_id=TYPE_ID_DISTRO)
+        super(ErrataRemoveCommand, self).__init__(context, 'errata', DESC_ERRATA, TYPE_ID_ERRATA)
+
+
+class PackageGroupRemoveCommand(BaseRemoveCommand):
+
+    def __init__(self, context):
+        super(PackageGroupRemoveCommand, self).__init__(context, 'group', DESC_GROUP, TYPE_ID_PKG_GROUP)
+
+
+class PackageCategoryRemoveCommand(BaseRemoveCommand):
+
+    def __init__(self, context):
+        super(PackageCategoryRemoveCommand, self).__init__(context, 'category', DESC_CATEGORY,
+                                                           TYPE_ID_PKG_CATEGORY)
+
+
+class DistributionRemoveCommand(BaseRemoveCommand):
+
+    def __init__(self, context):
+        super(DistributionRemoveCommand, self).__init__(context, 'distribution', DESC_DISTRIBUTION,
+                                                        TYPE_ID_DISTRO)

--- a/pulp_rpm/src/pulp_rpm/extension/admin/units_display.py
+++ b/pulp_rpm/src/pulp_rpm/extension/admin/units_display.py
@@ -41,27 +41,26 @@ def display_units(prompt, units, unit_threshold):
     else:
         _details(prompt, units)
 
-def _summary(prompt, copied_units):
+def _summary(prompt, units):
     """
-    Displays a shortened view of the copied units. This implementation will display a count of
-    units copied by type.
+    Displays a shortened view of the units. This implementation will display a count of units by type.
     """
 
     # Create count by each by type
     unit_count_by_type = {}
-    for u in copied_units:
+    for u in units:
         count = unit_count_by_type.setdefault(u['type_id'], 0)
         unit_count_by_type[u['type_id']] = count + 1
 
-    msg = _('Copy Summary:')
+    msg = _('Summary:')
     prompt.write(msg, tag='summary')
     for type_id, count in unit_count_by_type.items():
         entry = '  %s: %s' % (type_id, count)
         prompt.write(entry, tag='count-entry')
 
-def _details(prompt, copied_units):
+def _details(prompt, units):
     """
-    Displays information about each unit that was copied. If multiple types are present, the
+    Displays information about each unit. If multiple types are present, the
     list will be broken down by type. As each unit is rendered, care should be taken to not call
     this with a large amount of units as it will flood the user's terminal.
     """
@@ -80,10 +79,10 @@ def _details(prompt, copied_units):
 
     # Restructure into a list of unit keys by type
     units_by_type = {}
-    map(lambda u : units_by_type.setdefault(u['type_id'], []).append(u['unit_key']), copied_units)
+    map(lambda u : units_by_type.setdefault(u['type_id'], []).append(u['unit_key']), units)
 
     # Each unit is formatted to accomodate its unit key and displayed
-    prompt.write(_('Copied Units:'), tag='header')
+    prompt.write(_('Units:'), tag='header')
 
     sorted_type_ids = sorted(units_by_type.keys())
     for type_id in sorted_type_ids:

--- a/pulp_rpm/test/unit/test_extensions_remove_units.py
+++ b/pulp_rpm/test/unit/test_extensions_remove_units.py
@@ -10,13 +10,42 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
-import rpm_support_base
+import mock
+
 
 from pulp.client.commands.unit import UnitRemoveCommand
 
 from pulp_rpm.common.ids import (TYPE_ID_RPM, TYPE_ID_SRPM, TYPE_ID_DRPM, TYPE_ID_ERRATA, TYPE_ID_DISTRO,
                                  TYPE_ID_PKG_GROUP, TYPE_ID_PKG_CATEGORY)
 from pulp_rpm.extension.admin import remove as remove_commands
+from pulp_rpm.extension.admin.remove import BaseRemoveCommand
+import rpm_support_base
+
+
+class BaseRemoveCommandTests(rpm_support_base.PulpClientTests):
+
+    def setUp(self):
+        super(BaseRemoveCommandTests, self).setUp()
+
+        self.command = BaseRemoveCommand(self.context, 'remove', 'base-remove', 'base-type')
+
+    def test_structure(self):
+        self.assertTrue(isinstance(self.command, UnitRemoveCommand))
+
+
+    @mock.patch('pulp_rpm.extension.admin.units_display.display_units')
+    def test_succeeded(self, mock_display):
+        # Setup
+        fake_units = 'u'
+        fake_task = mock.MagicMock()
+        fake_task.result = fake_units
+
+        # Test
+        self.command.succeeded(fake_task)
+
+        # Verify
+        mock_display.assert_called_once_with(self.prompt, fake_units, self.command.unit_threshold)
+
 
 class RemoveCommandsTests(rpm_support_base.PulpClientTests):
     """
@@ -30,7 +59,7 @@ class RemoveCommandsTests(rpm_support_base.PulpClientTests):
         command = remove_commands.RpmRemoveCommand(self.context)
 
         # Verify
-        self.assertTrue(isinstance(command, UnitRemoveCommand))
+        self.assertTrue(isinstance(command, BaseRemoveCommand))
         self.assertEqual(command.name, 'rpm')
         self.assertEqual(command.description, remove_commands.DESC_RPM)
         self.assertEqual(command.type_id, TYPE_ID_RPM)
@@ -40,7 +69,7 @@ class RemoveCommandsTests(rpm_support_base.PulpClientTests):
         command = remove_commands.SrpmRemoveCommand(self.context)
 
         # Verify
-        self.assertTrue(isinstance(command, UnitRemoveCommand))
+        self.assertTrue(isinstance(command, BaseRemoveCommand))
         self.assertEqual(command.name, 'srpm')
         self.assertEqual(command.description, remove_commands.DESC_SRPM)
         self.assertEqual(command.type_id, TYPE_ID_SRPM)
@@ -50,7 +79,7 @@ class RemoveCommandsTests(rpm_support_base.PulpClientTests):
         command = remove_commands.DrpmRemoveCommand(self.context)
 
         # Verify
-        self.assertTrue(isinstance(command, UnitRemoveCommand))
+        self.assertTrue(isinstance(command, BaseRemoveCommand))
         self.assertEqual(command.name, 'drpm')
         self.assertEqual(command.description, remove_commands.DESC_DRPM)
         self.assertEqual(command.type_id, TYPE_ID_DRPM)
@@ -60,7 +89,7 @@ class RemoveCommandsTests(rpm_support_base.PulpClientTests):
         command = remove_commands.SrpmRemoveCommand(self.context)
 
         # Verify
-        self.assertTrue(isinstance(command, UnitRemoveCommand))
+        self.assertTrue(isinstance(command, BaseRemoveCommand))
         self.assertEqual(command.name, 'srpm')
         self.assertEqual(command.description, remove_commands.DESC_SRPM)
         self.assertEqual(command.type_id, TYPE_ID_SRPM)
@@ -70,7 +99,7 @@ class RemoveCommandsTests(rpm_support_base.PulpClientTests):
         command = remove_commands.ErrataRemoveCommand(self.context)
 
         # Verify
-        self.assertTrue(isinstance(command, UnitRemoveCommand))
+        self.assertTrue(isinstance(command, BaseRemoveCommand))
         self.assertEqual(command.name, 'errata')
         self.assertEqual(command.description, remove_commands.DESC_ERRATA)
         self.assertEqual(command.type_id, TYPE_ID_ERRATA)
@@ -80,7 +109,7 @@ class RemoveCommandsTests(rpm_support_base.PulpClientTests):
         command = remove_commands.PackageGroupRemoveCommand(self.context)
 
         # Verify
-        self.assertTrue(isinstance(command, UnitRemoveCommand))
+        self.assertTrue(isinstance(command, BaseRemoveCommand))
         self.assertEqual(command.name, 'group')
         self.assertEqual(command.description, remove_commands.DESC_GROUP)
         self.assertEqual(command.type_id, TYPE_ID_PKG_GROUP)
@@ -90,7 +119,7 @@ class RemoveCommandsTests(rpm_support_base.PulpClientTests):
         command = remove_commands.PackageCategoryRemoveCommand(self.context)
 
         # Verify
-        self.assertTrue(isinstance(command, UnitRemoveCommand))
+        self.assertTrue(isinstance(command, BaseRemoveCommand))
         self.assertEqual(command.name, 'category')
         self.assertEqual(command.description, remove_commands.DESC_CATEGORY)
         self.assertEqual(command.type_id, TYPE_ID_PKG_CATEGORY)
@@ -100,7 +129,7 @@ class RemoveCommandsTests(rpm_support_base.PulpClientTests):
         command = remove_commands.DistributionRemoveCommand(self.context)
 
         # Verify
-        self.assertTrue(isinstance(command, UnitRemoveCommand))
+        self.assertTrue(isinstance(command, BaseRemoveCommand))
         self.assertEqual(command.name, 'distribution')
         self.assertEqual(command.description, remove_commands.DESC_DISTRIBUTION)
         self.assertEqual(command.type_id, TYPE_ID_DISTRO)


### PR DESCRIPTION
process

The actual change is two lines, simply the implementation of the succeeded hook and pass it to the existing display_units call. I pulled out a base class for the remove commands to define that and tweaked the tests accordingly. There were a few tweaks to the unit display method itself because as forward thinking as I thought I was being when I wrote it for copy, I still had some copy-specific verbiage in there.

Corresponds to: https://github.com/pulp/pulp/pull/416
