### PR TITLE
949004 - Append trailing slashes to ISO feed URLs when they lack them.

### DIFF
--- a/pulp_rpm/src/pulp_rpm/plugins/importers/iso_importer/sync.py
+++ b/pulp_rpm/src/pulp_rpm/plugins/importers/iso_importer/sync.py
@@ -43,9 +43,13 @@ class ISOSyncRun(listener.DownloadEventListener):
         self.sync_conduit = sync_conduit
         self._remove_missing_units = config.get(constants.CONFIG_REMOVE_MISSING_UNITS,
                                                 default=constants.CONFIG_REMOVE_MISSING_UNITS_DEFAULT)
-        self._repo_url = encode_unicode(config.get(constants.CONFIG_FEED_URL))
         self._validate_downloads = config.get(constants.CONFIG_VALIDATE_DOWNLOADS,
                                               default=constants.CONFIG_VALIDATE_DOWNLOADS_DEFAULT)
+        self._repo_url = encode_unicode(config.get(constants.CONFIG_FEED_URL))
+        # The _repo_url must end in a trailing slash, because we will use urljoin to determine the path to
+        # PULP_MANIFEST later
+        if self._repo_url[-1] != '/':
+            self._repo_url = self._repo_url + '/'
 
         # Cast our config parameters to the correct types and use them to build a Downloader
         max_speed = config.get(constants.CONFIG_MAX_SPEED)

--- a/pulp_rpm/test/unit/server/test_iso_importer_sync.py
+++ b/pulp_rpm/test/unit/server/test_iso_importer_sync.py
@@ -97,6 +97,20 @@ class TestISOSyncRun(PulpRPMTests):
             self.assertEquals(getattr(downloader.config, key), value)
         self.assertEquals(type(iso_sync_run.progress_report), SyncProgressReport)
 
+    def test__init___with_feed_lacking_trailing_slash(self):
+        """
+        In bug https://bugzilla.redhat.com/show_bug.cgi?id=949004 we had a problem where feed URLs that didn't
+        have trailing slashes would get their last URL component clobbered when we used urljoin to determine
+        the path to PULP_MANIFEST. The solution is to have __init__() automatically append a trailing slash to
+        URLs that lack it so that urljoin will determine the correct path to PULP_MANIFEST.
+        """
+        config = importer_mocks.get_basic_config(feed_url='http://fake.com/no_trailing_slash')
+
+        iso_sync_run = ISOSyncRun(self.sync_conduit, config)
+
+        # Humorously enough, the _repo_url attribute named no_trailing_slash should now have a trailing slash
+        self.assertEqual(iso_sync_run._repo_url, 'http://fake.com/no_trailing_slash/')
+
     def test_cancel_sync(self):
         """
         Test what happens if cancel_sync is called when there is no Bumper.


### PR DESCRIPTION
Simple fix to a simple, but sad, bug.

https://bugzilla.redhat.com/show_bug.cgi?id=949004
