### PR TITLE
949008 - Use a value of 2 for pycurl's SSL_VERIFYHOST setting instead of...

### DIFF
--- a/pulp_rpm/src/pulp_rpm/plugins/importers/iso_importer/sync.py
+++ b/pulp_rpm/src/pulp_rpm/plugins/importers/iso_importer/sync.py
@@ -57,11 +57,13 @@ class ISOSyncRun(listener.DownloadEventListener):
         else:
             num_threads = constants.CONFIG_NUM_THREADS_DEFAULT
         downloader_config = {
-            'max_speed': max_speed, 'num_threads': num_threads,
+            'max_speed': max_speed,
+            'num_threads': num_threads,
             'ssl_client_cert': config.get(constants.CONFIG_SSL_CLIENT_CERT),
             'ssl_client_key': config.get(constants.CONFIG_SSL_CLIENT_KEY),
-            'ssl_ca_cert': config.get(constants.CONFIG_SSL_CA_CERT), 'ssl_verify_host': 1,
-            'ssl_verify_peer': 1, 'proxy_url': config.get(constants.CONFIG_PROXY_URL),
+            'ssl_ca_cert': config.get(constants.CONFIG_SSL_CA_CERT),
+            'ssl_verify_host': 2, 'ssl_verify_peer': 1,
+            'proxy_url': config.get(constants.CONFIG_PROXY_URL),
             'proxy_port': config.get(constants.CONFIG_PROXY_PORT),
             'proxy_user': config.get(constants.CONFIG_PROXY_USER),
             'proxy_password': config.get(constants.CONFIG_PROXY_PASSWORD)}

--- a/pulp_rpm/test/unit/server/test_iso_importer_sync.py
+++ b/pulp_rpm/test/unit/server/test_iso_importer_sync.py
@@ -88,7 +88,7 @@ class TestISOSyncRun(PulpRPMTests):
             'max_speed': 500.0, 'num_threads': 5,
             'ssl_client_cert': "Trust me, I'm who I say I am.",
             'ssl_client_key': 'Secret Key',
-            'ssl_ca_cert': "Uh, I guess that's the right server.", 'ssl_verify_host': 1,
+            'ssl_ca_cert': "Uh, I guess that's the right server.", 'ssl_verify_host': 2,
             'ssl_verify_peer': 1, 'proxy_url': 'http://proxy.com',
             'proxy_port': 1234,
             'proxy_user': 'the_dude',


### PR DESCRIPTION
... 1.

See
http://curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTSSLVERIFYHOST
for why this is important.

This is for https://bugzilla.redhat.com/show_bug.cgi?id=949008 and needs to be merged to 2.1 and to master.

I request a speedy review so that we can get this in for the 2.1.1 release.
