### PR TITLE
Added sort index calculation to sync and upload units

### DIFF
--- a/pulp_rpm/plugins/importers/yum_importer/importer.py
+++ b/pulp_rpm/plugins/importers/yum_importer/importer.py
@@ -28,7 +28,7 @@ from pulp.plugins.importer import Importer
 from pulp.plugins.model import Unit, SyncReport
 from pulp_rpm.common.ids import TYPE_ID_IMPORTER_YUM, TYPE_ID_PKG_GROUP, TYPE_ID_PKG_CATEGORY, TYPE_ID_DISTRO,\
         TYPE_ID_DRPM, TYPE_ID_ERRATA, TYPE_ID_RPM, TYPE_ID_SRPM
-from pulp_rpm.common import constants
+from pulp_rpm.common import constants, version_utils
 from pulp_rpm.yum_plugin import util, depsolver, metadata
 from pulp_rpm.yum_plugin.metadata import get_package_xml
 
@@ -595,7 +595,13 @@ class YumImporter(Importer):
             details['errors'].append(msg)
             return False, summary, details
         relative_path = "%s/%s/%s/%s/%s/%s" % (unit_key['name'], unit_key['version'],
-                                                        unit_key['release'], unit_key['arch'], unit_key['checksum'], metadata['filename'])
+                                               unit_key['release'], unit_key['arch'], unit_key['checksum'],
+                                               metadata['filename'])
+
+        # Calculate the sort indexes
+        metadata['version_sort_index'] = version_utils.encode(unit_key['version'])
+        metadata['release_sort_index'] = version_utils.encode(unit_key['release'])
+
         u = conduit.init_unit(TYPE_ID_RPM, unit_key, metadata, relative_path)
         new_path = u.storage_path
         try:

--- a/pulp_rpm/plugins/importers/yum_importer/importer_rpm.py
+++ b/pulp_rpm/plugins/importers/yum_importer/importer_rpm.py
@@ -24,6 +24,7 @@ from pulp.server.db.model.criteria import UnitAssociationCriteria
 from pulp_rpm.yum_plugin import util, metadata
 from yum_importer import distribution, drpm
 import pulp_rpm.common.constants as constants
+from pulp_rpm.common import version_utils
 from pulp_rpm.common.ids import TYPE_ID_DRPM, TYPE_ID_DISTRO
 
 _LOG = util.getLogger(__name__)
@@ -152,6 +153,10 @@ def form_rpm_metadata(rpm):
     metadata = {}
     for key in ("filename", "relativepath"):
         metadata[key] = rpm[key]
+
+    metadata['version_sort_index'] = version_utils.encode(rpm['version'])
+    metadata['release_sort_index'] = version_utils.encode(rpm['release'])
+
     return metadata
 
 def form_lookup_key(rpm):


### PR DESCRIPTION
There is a glaring lack of unit tests in this. I can't find one that actually verifies the structure of an RPM being added to the database. In theory, this code won't see a release anyway if the new importer gets included in 2.2 (just these hooks, the rest of the work in this area will stick), so I'm not interested in taking the time to add that test.
