### PR TITLE
947927 - When looking for nested elements in a copy, only check the sour...

### DIFF
--- a/pulp_rpm/plugins/importers/yum_importer/importer.py
+++ b/pulp_rpm/plugins/importers/yum_importer/importer.py
@@ -407,8 +407,8 @@ class YumImporter(Importer):
 
         pkg_group_unit_ids = pkg_category_unit.metadata['packagegroupids']
         for pgid in pkg_group_unit_ids:
-            criteria = Criteria(filters={'id' : pgid})
-            found_pkggrp = import_conduit.search_all_units(type_id=TYPE_ID_PKG_GROUP, criteria=criteria)
+            criteria = UnitAssociationCriteria(type_ids=[TYPE_ID_PKG_GROUP], unit_filters={'id' : pgid})
+            found_pkggrp = import_conduit.get_source_units(criteria=criteria)
             if not len(found_pkggrp):
                 # couldnt find the pkggrp, continue to the next one
                 continue
@@ -444,8 +444,8 @@ class YumImporter(Importer):
         conditional_pkg_names = [cond_pkg[0] for cond_pkg in pkg_group_unit.metadata["conditional_package_names"]]
         default_pkg_names = pkg_group_unit.metadata['default_package_names'] or []
         for pname in mandatory_pkg_names + optional_pkg_names + conditional_pkg_names + default_pkg_names:
-            criteria = Criteria(filters={'name' : pname})
-            found_pkgs = import_conduit.search_all_units(type_id=TYPE_ID_RPM, criteria=criteria)
+            criteria = UnitAssociationCriteria(type_ids=[TYPE_ID_RPM], unit_filters={'name' : pname})
+            found_pkgs = import_conduit.get_source_units(criteria=criteria)
             if not len(found_pkgs):
                 continue
             newest = self._find_newest_pkg(found_pkgs)

--- a/pulp_rpm/test/unit/server/test_import_units.py
+++ b/pulp_rpm/test/unit/server/test_import_units.py
@@ -409,7 +409,7 @@ class TestImportUnits(PulpRPMTests):
                                                           "package_group")
         # Now make a config mock, an import_conduit mock, and an importer
         config = importer_mocks.get_basic_config()
-        import_conduit = importer_mocks.get_import_conduit(
+        import_conduit = importer_mocks.get_import_conduit(source_units=[],
             existing_units=[pkg_group_unit])
         importer = YumImporter()
 


### PR DESCRIPTION
...ce repository, not all of Pulp. By nested elements I mean RPMs in a package group or groups in a package category.

Fix for: https://bugzilla.redhat.com/show_bug.cgi?id=947927
