### PR TITLE
928084 - The ISOImporter now handles malformed PULP_MANIFEST files.

### DIFF
--- a/pulp_rpm/src/pulp_rpm/common/progress.py
+++ b/pulp_rpm/src/pulp_rpm/common/progress.py
@@ -61,7 +61,6 @@ class ISOProgressReport(object):
         :return: description of the current state of the sync
         :rtype:  dict
         """
-
         report = {
             'manifest': self._generate_manifest_section(),
             'isos': self._generate_isos_section(),


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=928084
