### PR TITLE
956372 - fix errata installs.

### DIFF
--- a/pulp_rpm/extensions/admin/rpm_admin_consumer/errata.py
+++ b/pulp_rpm/extensions/admin/rpm_admin_consumer/errata.py
@@ -90,7 +90,7 @@ class YumConsumerErrataInstallCommand(consumer_content.ConsumerContentInstallCom
 
         def _unit_dict(unit_id):
             return {'type_id': TYPE_ID_ERRATA,
-                    'unit_key': {'errata-id': unit_id}}
+                    'unit_key': {'id': unit_id}}
 
         units = map(_unit_dict, kwargs['errata-id'])
         return units

--- a/pulp_rpm/plugins/profilers/rpm_errata_profiler/profiler.py
+++ b/pulp_rpm/plugins/profilers/rpm_errata_profiler/profiler.py
@@ -206,10 +206,11 @@ class RPMErrataProfiler(Profiler):
 
         :rtype ([{'unit_key':{'name':name.arch}, 'type_id':'rpm'}], {'name arch':{'available':{}, 'installed':{}}   })
         """
-        errata = self.find_unit_associated_to_repos(TYPE_ID_ERRATA, unit, repo_ids, conduit)
+        unit_key = unit['unit_key']
+        errata = self.find_unit_associated_to_repos(TYPE_ID_ERRATA, unit_key, repo_ids, conduit)
         if not errata:
             error_msg = _("Unable to find errata with unit_key [%s] in bound repos [%s] to consumer [%s]") % \
-                    (unit, repo_ids, consumer.id)
+                    (unit_key, repo_ids, consumer.id)
             _LOG.info(error_msg)
             return None, None
         else:


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=956372

Two fixes here:
1. Extension passing 'errata-id' in the unit_key and should be 'id'.
2. In the errata profiler install flow, find_unit_associated_to_repos() being passed a unit but expecting a unit_key.
