### PR TITLE
950690 - Removed copy commands that aren't supported in the plugin

### DIFF
--- a/pulp_rpm/extensions/admin/rpm_repo/pulp_cli.py
+++ b/pulp_rpm/extensions/admin/rpm_repo/pulp_cli.py
@@ -43,12 +43,15 @@ def initialize(context):
 
     copy_section = structure.repo_copy_section(context.cli)
     copy_section.add_command(copy_commands.RpmCopyCommand(context))
-    copy_section.add_command(copy_commands.SrpmCopyCommand(context))
-    copy_section.add_command(copy_commands.DrpmCopyCommand(context))
     copy_section.add_command(copy_commands.ErrataCopyCommand(context))
     copy_section.add_command(copy_commands.DistributionCopyCommand(context))
     copy_section.add_command(copy_commands.PackageGroupCopyCommand(context))
     copy_section.add_command(copy_commands.PackageCategoryCopyCommand(context))
+
+    # Disabled as per 950690. We'll likely be able to add these back once the new
+    # yum importer is finished and DRPMs are properly handled.
+    # copy_section.add_command(copy_commands.SrpmCopyCommand(context))
+    # copy_section.add_command(copy_commands.DrpmCopyCommand(context))
 
     remove_section = structure.repo_remove_section(context.cli)
     remove_section.add_command(remove.RpmRemoveCommand(context))


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=950690
