### PR TITLE
970267 - removing the use of a parameter that didn't exist in python 2.6...

### DIFF
--- a/plugins/pulp_rpm/plugins/importers/yum/repomd/packages.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/repomd/packages.py
@@ -105,7 +105,7 @@ def element_to_raw_xml(element):
     strip_ns(element)
     tree = ElementTree(element)
     io = StringIO()
-    tree.write(io, xml_declaration=False)
+    tree.write(io)
     return io.getvalue()
 
 


### PR DESCRIPTION
.... Thankfully I was passing the default value anyway, so the 2.6 behavior is what I want even without the parameter.

https://bugzilla.redhat.com/show_bug.cgi?id=970267
