### PR TITLE
970269 - making the 'id' attribute of errata references optional, since ...

### DIFF
--- a/plugins/pulp_rpm/plugins/importers/yum/repomd/updateinfo.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/repomd/updateinfo.py
@@ -57,7 +57,9 @@ def process_package_element(element):
 
 def _parse_reference(element):
     return {
-        'id': element.attrib['id'],
+        # evidence shows that the "id" attribute is sometimes missing, such as
+        # in a rhel6 repo.
+        'id': element.attrib.get('id'),
         'href': element.attrib['href'],
         'type': element.attrib['type'],
         'title': element.text,


### PR DESCRIPTION
...evidence suggests that they are not present in rhel6 repos.

https://bugzilla.redhat.com/show_bug.cgi?id=970269
