### PR TITLE
971157 - the new yum importer can now at sync time skip the four types m...

### DIFF
--- a/plugins/pulp_rpm/plugins/importers/yum/listener.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/listener.py
@@ -18,7 +18,7 @@ from nectar.listener import DownloadEventListener, AggregatingEventListener
 from pulp.common.plugins import importer_constants
 from pulp.plugins.util import verification
 
-from pulp_rpm.common import constants
+from pulp_rpm.common import constants, models
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -84,7 +84,9 @@ class ContentListener(DownloadEventListener):
             # handling below doesn't run.
             return
 
-        self.metadata_files.add_repodata(model)
+        # these are the only types we store repo metadata snippets on in the DB
+        if isinstance(model, (models.RPM, models.SRPM)):
+            self.metadata_files.add_repodata(model)
         # init unit, which is idempotent
         unit = self.sync_conduit.init_unit(model.TYPE, model.unit_key, model.metadata, model.relative_path)
         # move to final location

--- a/plugins/pulp_rpm/plugins/importers/yum/sync.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/sync.py
@@ -20,7 +20,7 @@ from pulp.common.plugins import importer_constants
 from pulp.plugins.model import SyncReport
 from pulp.plugins.util import nectar_config as nectar_utils
 
-from pulp_rpm.common import constants
+from pulp_rpm.common import constants, models
 from pulp_rpm.plugins.importers.yum import existing, purge
 from pulp_rpm.plugins.importers.yum.repomd import metadata, primary, packages, updateinfo, presto, group
 from pulp_rpm.plugins.importers.yum.listener import ContentListener
@@ -118,16 +118,22 @@ class RepoSync(object):
                 self.content_report['state'] = constants.STATE_COMPLETE
             self.set_progress()
 
-            self.distribution_report['state'] = constants.STATE_RUNNING
-            self.set_progress()
-            treeinfo.sync(self.sync_conduit, self.sync_feed,
-                          self.tmp_dir, self.distribution_report, self.set_progress)
+            if models.Distribution.TYPE in self.call_config.get(constants.CONFIG_SKIP, []):
+                self.distribution_report['state'] = constants.STATE_SKIPPED
+            else:
+                self.distribution_report['state'] = constants.STATE_RUNNING
+                self.set_progress()
+                treeinfo.sync(self.sync_conduit, self.sync_feed,
+                              self.tmp_dir, self.distribution_report, self.set_progress)
             self.set_progress()
 
-            self.progress_status['errata']['state'] = constants.STATE_RUNNING
-            self.set_progress()
-            self.get_errata(metadata_files)
-            self.progress_status['errata']['state'] = constants.STATE_COMPLETE
+            if models.Errata.TYPE in self.call_config.get(constants.CONFIG_SKIP, []):
+                self.progress_status['errata']['state'] = constants.STATE_SKIPPED
+            else:
+                self.progress_status['errata']['state'] = constants.STATE_RUNNING
+                self.set_progress()
+                self.get_errata(metadata_files)
+                self.progress_status['errata']['state'] = constants.STATE_COMPLETE
             self.set_progress()
 
             self.progress_status['comps']['state'] = constants.STATE_RUNNING
@@ -230,6 +236,9 @@ class RepoSync(object):
         :return:    tuple of (set(RPM.NAMEDTUPLEs), number of RPMs, total size in bytes)
         :rtype:     tuple
         """
+        if models.RPM.TYPE in self.call_config.get(constants.CONFIG_SKIP, []):
+            _LOGGER.debug('skipping RPM sync')
+            return set(), 0, 0
         primary_file_handle = metadata_files.get_metadata_file_handle(primary.METADATA_FILE_NAME)
         try:
             # scan through all the metadata to decide which packages to download
@@ -257,6 +266,9 @@ class RepoSync(object):
         :return:    tuple of (set(DRPM.NAMEDTUPLEs), number of DRPMs, total size in bytes)
         :rtype:     tuple
         """
+        if models.DRPM.TYPE in self.call_config.get(constants.CONFIG_SKIP, []):
+            _LOGGER.debug('skipping DRPM sync')
+            return set(), 0, 0
         presto_file_handle = metadata_files.get_metadata_file_handle(presto.METADATA_FILE_NAME)
         if presto_file_handle:
             try:

--- a/pulp_rpm/src/pulp_rpm/common/constants.py
+++ b/pulp_rpm/src/pulp_rpm/common/constants.py
@@ -51,6 +51,10 @@ CONFIG_SERVE_HTTP          = 'serve_http'
 CONFIG_SERVE_HTTP_DEFAULT  = False
 CONFIG_SERVE_HTTPS         = 'serve_https'
 CONFIG_SERVE_HTTPS_DEFAULT = True
+
+# list of types to skip at sync time
+CONFIG_SKIP = 'type_skip_list'
+
 # This is the CA that we should verify client entitlement certificates with. If it is set, and protected repos
 # are enabled serverwide, we will protect the repo with this cert over SSL. If it is unset, no repo protection
 # will be configured. This option is currently only used by the ISO distributor.


### PR DESCRIPTION
...entioned in the --skip option of the pulp-admin rpm repo create command. Those types are rpm, drpm, erratum, and distribution.

https://bugzilla.redhat.com/show_bug.cgi?id=971157
