### PR TITLE
971167 - during repo sync, before each RPM's XML snippet from primary.xm...

### DIFF
--- a/plugins/pulp_rpm/plugins/importers/yum/repomd/primary.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/repomd/primary.py
@@ -160,8 +160,13 @@ def process_package_element(package_element):
     location_element = package_element.find(LOCATION_TAG)
     if location_element is not None:
         href = location_element.attrib['href']
+        filename = os.path.basename(href)
         package_info['relativepath'] = href
-        package_info['filename'] = os.path.basename(href)
+        package_info['filename'] = filename
+        # we don't make any attempt to preserve the original directory structure
+        # this element will end up being converted back to XML and stuffed into
+        # the DB on the unit object, so this  is our chance to modify it.
+        location_element.attrib['href'] = filename
 
     format_element = package_element.find(FORMAT_TAG)
     package_info.update(_process_format_element(format_element))


### PR DESCRIPTION
...l gets saved to the database, the <location/> tag is modified so that the href attribute contains only the file name, and no other leading path or URL elements. This matches the expectation that files are published at the root of the repository.

https://bugzilla.redhat.com/show_bug.cgi?id=971167
