### PR TITLE
971953 - Work around to limit RAM usage during RPM removal

### DIFF
--- a/pulp_rpm/src/pulp_rpm/extension/admin/remove.py
+++ b/pulp_rpm/src/pulp_rpm/extension/admin/remove.py
@@ -17,6 +17,7 @@ from pulp_rpm.common.constants import DISPLAY_UNITS_THRESHOLD
 from pulp_rpm.common.ids import (TYPE_ID_RPM, TYPE_ID_SRPM, TYPE_ID_DRPM,
                                  TYPE_ID_ERRATA, TYPE_ID_PKG_GROUP,
                                  TYPE_ID_PKG_CATEGORY, TYPE_ID_DISTRO)
+from pulp_rpm.common.models import RPM
 from pulp_rpm.extension import criteria_utils
 from pulp_rpm.extension.admin import units_display
 
@@ -54,6 +55,13 @@ class PackageRemoveCommand(BaseRemoveCommand):
     @classmethod
     def _parse_sort(cls, sort_args):
         return criteria_utils.parse_sort(BaseRemoveCommand, sort_args)
+
+    def modify_user_input(self, user_input):
+        super(PackageRemoveCommand, self).modify_user_input(user_input)
+
+        # Work around to scope the fields loaded by the platform to limit the amount of
+        # RAM used. This addition will find its way to the criteria parsing in the bindings.
+        user_input['fields'] = RPM.UNIT_KEY_NAMES
 
 
 class RpmRemoveCommand(PackageRemoveCommand):

--- a/pulp_rpm/test/unit/test_extensions_remove_units.py
+++ b/pulp_rpm/test/unit/test_extensions_remove_units.py
@@ -15,8 +15,9 @@ import mock
 
 from pulp.client.commands.unit import UnitRemoveCommand
 
-from pulp_rpm.common.ids import (TYPE_ID_RPM, TYPE_ID_SRPM, TYPE_ID_DRPM, TYPE_ID_ERRATA, TYPE_ID_DISTRO,
-                                 TYPE_ID_PKG_GROUP, TYPE_ID_PKG_CATEGORY)
+from pulp_rpm.common.ids import (TYPE_ID_RPM, TYPE_ID_SRPM, TYPE_ID_DRPM, TYPE_ID_ERRATA,
+                                 TYPE_ID_DISTRO, TYPE_ID_PKG_GROUP, TYPE_ID_PKG_CATEGORY)
+from pulp_rpm.common.models import RPM
 from pulp_rpm.extension.admin import remove as remove_commands
 from pulp_rpm.extension.admin.remove import BaseRemoveCommand, PackageRemoveCommand
 import rpm_support_base
@@ -63,6 +64,18 @@ class PackageRemoveCommandTests(rpm_support_base.PulpClientTests):
         command = remove_commands.PackageRemoveCommand(self.context, 'copy', '', '')
         command._parse_sort('foo')
         mock_parse.assert_called_once_with(remove_commands.BaseRemoveCommand, 'foo')
+
+    @mock.patch('pulp.client.commands.unit.UnitRemoveCommand.modify_user_input')
+    def test_modify_user_input(self, mock_super):
+        command = remove_commands.PackageRemoveCommand(self.context, 'remove', '', '')
+        user_input = {'a' : 'a'}
+        command.modify_user_input(user_input)
+
+        # The super call is required.
+        self.assertEqual(1, mock_super.call_count)
+
+        # The user_input variable itself should be modified.
+        self.assertEqual(user_input, {'a' : 'a', 'fields' : RPM.UNIT_KEY_NAMES})
 
 
 class RemoveCommandsTests(rpm_support_base.PulpClientTests):


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=971953
