### PR TITLE
973387 - fix fsize attribute error on unit install progress reporting.

### DIFF
--- a/pulp_rpm/src/pulp_rpm/handler/rpmtools.py
+++ b/pulp_rpm/src/pulp_rpm/handler/rpmtools.py
@@ -462,8 +462,9 @@ class DownloadCallback(DownloadBaseCallback):
         @param now: timestamp.
         @type now: float
         """
+        DownloadBaseCallback._do_start(self, now)
         action = 'Downloading'
-        package = ' | '.join((self._getName(), self.fsize))
+        package = ' | '.join((self._getName(), self.totSize))
         self.report.set_action(action, package)
 
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=973387

Cannot use super(self.**class**, self) because _DownloadBaseCallback_ is not a subclass of _object_.

Apparently, the _fsize_ attribute conditionally exists in urlgrabber.progress.BaseMeter (which sucks).  The DownloadBaseCallback.totsize attribute is safer to use but requires _do_start() to be updated.  The superclass method should be called in most cases anyway.
