### PR TITLE
975543 - Change the ISO "content" command name to "isos".

### DIFF
--- a/pulp_rpm/src/pulp_rpm/extension/admin/iso/structure.py
+++ b/pulp_rpm/src/pulp_rpm/extension/admin/iso/structure.py
@@ -94,7 +94,7 @@ def add_repo_section(context, parent_section):
     repo_section.add_command(repo_list.ISORepoListCommand(context))
     repo_section.add_command(unit.UnitCopyCommand(context, type_id=ids.TYPE_ID_ISO))
     repo_section.add_command(unit.UnitRemoveCommand(context, type_id=ids.TYPE_ID_ISO))
-    repo_section.add_command(contents.ISOSearchCommand(context, name='content'))
+    repo_section.add_command(contents.ISOSearchCommand(context, name='isos'))
 
 
 def add_schedules_section(context, parent_section):

--- a/pulp_rpm/test/unit/test_extension_admin_iso_structure.py
+++ b/pulp_rpm/test/unit/test_extension_admin_iso_structure.py
@@ -125,10 +125,10 @@ class TestAddRepoSection(rpm_support_base.PulpClientTests):
         self.assertEqual(remove_command.context, self.context)
         self.assertEqual(remove_command.type_id, ids.TYPE_ID_ISO)
 
-        # Content command
-        content_command = repo_section.commands['content']
-        self.assertTrue(isinstance(content_command, contents.ISOSearchCommand))
-        self.assertEqual(content_command.context, self.context)
+        # isos command
+        isos_command = repo_section.commands['isos']
+        self.assertTrue(isinstance(isos_command, contents.ISOSearchCommand))
+        self.assertEqual(isos_command.context, self.context)
 
 
 class TestAddSchedulesSection(rpm_support_base.PulpClientTests):


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=975543
