### PR TITLE
rpm repos now clean up their relative urls when updated and republished

### DIFF
--- a/pulp_rpm/plugins/distributors/yum_distributor/distributor.py
+++ b/pulp_rpm/plugins/distributors/yum_distributor/distributor.py
@@ -490,8 +490,8 @@ class YumDistributor(Distributor):
         if OLD_REL_PATH_KEYWORD in scratchpad:
             old_https_publish_dir = os.path.join(https_publish_dir, scratchpad[OLD_REL_PATH_KEYWORD])
             old_http_publish_dir = os.path.join(http_publish_dir, scratchpad[OLD_REL_PATH_KEYWORD])
-            util.remove_symlink(https_publish_dir, old_https_publish_dir)
-            util.remove_symlink(http_publish_dir, old_http_publish_dir)
+            util.remove_publish_dir(https_publish_dir, old_https_publish_dir)
+            util.remove_publish_dir(http_publish_dir, old_http_publish_dir)
 
         # Now write the current publish relative path to the scratch pad. This way, if the relative path
         # changes before the next publish, we can clean up the old path.
@@ -513,7 +513,7 @@ class YumDistributor(Distributor):
             self.set_progress("publish_https", {"state" : "SKIPPED"}, progress_callback)
             if os.path.lexists(https_repo_publish_dir):
                 _LOG.debug("Removing link for %s since https is not set" % https_repo_publish_dir)
-                util.remove_symlink(https_publish_dir, https_repo_publish_dir)
+                util.remove_publish_dir(https_publish_dir, https_repo_publish_dir)
 
         # Handle publish link for HTTP
         if config.get("http"):
@@ -530,7 +530,7 @@ class YumDistributor(Distributor):
             self.set_progress("publish_http", {"state" : "SKIPPED"}, progress_callback)
             if os.path.lexists(http_repo_publish_dir):
                 _LOG.debug("Removing link for %s since http is not set" % http_repo_publish_dir)
-                util.remove_symlink(http_publish_dir, http_repo_publish_dir)
+                util.remove_publish_dir(http_publish_dir, http_repo_publish_dir)
 
         summary["num_package_units_attempted"] = len(pkg_units)
         summary["num_package_units_published"] = len(pkg_units) - len(pkg_errors)
@@ -754,7 +754,7 @@ class YumDistributor(Distributor):
                 for orphaned_path in published_distro_units[distroid]:
                     if os.path.islink(orphaned_path):
                         _LOG.debug("cleaning up orphaned distribution path %s" % orphaned_path)
-                        util.remove_symlink(repo_working_dir, orphaned_path)
+                        util.remove_publish_dir(repo_working_dir, orphaned_path)
                     # remove the cleaned up distroid from scratchpad
                 del scratchpad[constants.PUBLISHED_DISTRIBUTION_FILES_KEY][distroid]
         return scratchpad

--- a/pulp_rpm/test/unit/server/test_distributor.py
+++ b/pulp_rpm/test/unit/server/test_distributor.py
@@ -235,8 +235,8 @@ class TestDistributor(rpm_support_base.PulpRPMTests):
         a = os.readlink(symlink_path)
         self.assertEqual(a, source_path)
 
-    @mock.patch('pulp_rpm.yum_plugin.util.remove_symlink', autospec=True)
-    def test_remove_publish_symlinks(self, mock_remove_symlink):
+    @mock.patch('pulp_rpm.yum_plugin.util.remove_publish_dir', autospec=True)
+    def test_remove_publish_symlinks(self, mock_remove_publish_dir):
         # Setup
         repo = mock.Mock(spec=Repository)
         repo.working_dir = self.repo_working_dir
@@ -254,15 +254,15 @@ class TestDistributor(rpm_support_base.PulpRPMTests):
         # Test
         report = distributor.publish_repo(repo, publish_conduit, config)
         self.assertTrue(report.success_flag)
-        self.assertEqual(2, mock_remove_symlink.call_count)
-        # Confirm the first call to remove_symlink used the correct arguments (https)
-        self.assertEqual(self.https_publish_dir, mock_remove_symlink.call_args_list[0][0][0])
+        self.assertEqual(2, mock_remove_publish_dir.call_count)
+        # Confirm the first call to remove_publish_dir used the correct arguments (https)
+        self.assertEqual(self.https_publish_dir, mock_remove_publish_dir.call_args_list[0][0][0])
         self.assertEqual(os.path.join(self.https_publish_dir, 'relative/url'),
-                         mock_remove_symlink.call_args_list[0][0][1])
+                         mock_remove_publish_dir.call_args_list[0][0][1])
         # Confirm the second call also used the correct arguments (http)
-        self.assertEqual(self.http_publish_dir, mock_remove_symlink.call_args_list[1][0][0])
+        self.assertEqual(self.http_publish_dir, mock_remove_publish_dir.call_args_list[1][0][0])
         self.assertEqual(os.path.join(self.http_publish_dir, 'relative/url'),
-                         mock_remove_symlink.call_args_list[1][0][1])
+                         mock_remove_publish_dir.call_args_list[1][0][1])
 
 
     def test_create_dirs(self):
@@ -647,7 +647,7 @@ class TestDistributor(rpm_support_base.PulpRPMTests):
         os.symlink(self.https_publish_dir, link_path)
         self.assertTrue(os.path.exists(link_path))
 
-        util.remove_symlink(pub_dir, link_path)
+        util.remove_publish_dir(pub_dir, link_path)
         self.assertFalse(os.path.exists(link_path))
         self.assertEqual(len(os.listdir(pub_dir)), 0)
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=915880
