### PR TITLE
987663 - syncing of a distribution now uses a nectar factory to get the ...

### DIFF
--- a/plugins/pulp_rpm/plugins/importers/yum/parse/treeinfo.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/parse/treeinfo.py
@@ -17,13 +17,12 @@ import os
 import shutil
 import tempfile
 
-from nectar.config import DownloaderConfig
-from nectar.downloaders.curl import HTTPCurlDownloader
 from nectar.listener import AggregatingEventListener
 from nectar.request import DownloadRequest
 
 from pulp_rpm.common import constants, ids, models
 from pulp_rpm.plugins.importers.yum.listener import DistroFileListener
+from pulp_rpm.plugins.importers.yum.repomd import nectar_factory
 
 SECTION_GENERAL = 'general'
 SECTION_STAGE2 = 'stage2'
@@ -32,7 +31,7 @@ SECTION_CHECKSUMS = 'checksums'
 _LOGGER = logging.getLogger(__name__)
 
 
-def sync(sync_conduit, feed, working_dir, report, progress_callback):
+def sync(sync_conduit, feed, working_dir, nectar_config, report, progress_callback):
     """
     Look for a distribution in the target repo and sync it if found
 
@@ -43,6 +42,8 @@ def sync(sync_conduit, feed, working_dir, report, progress_callback):
     :param working_dir:         full path to the directory to which files
                                 should be downloaded
     :type  working_dir:         basestring
+    :param nectar_config:       download config to be used by nectar
+    :type  nectar_config:       nectar.config.DownloaderConfig
     :param report:              progress report object
     :type  report:              pulp_rpm.plugins.importers.yum.report.DistributionReport
     :param progress_callback:   function that takes no arguments but induces
@@ -53,7 +54,7 @@ def sync(sync_conduit, feed, working_dir, report, progress_callback):
     # complete cleanup
     tmp_dir = tempfile.mkdtemp(dir=working_dir)
     try:
-        treefile_path = get_treefile(feed, tmp_dir)
+        treefile_path = get_treefile(feed, tmp_dir, nectar_config)
         if not treefile_path:
             _LOGGER.debug('no treefile found')
             report['state'] = constants.STATE_COMPLETE
@@ -67,9 +68,8 @@ def sync(sync_conduit, feed, working_dir, report, progress_callback):
             return
 
         report.set_initial_values(len(files))
-        config = DownloaderConfig()
         listener = DistroFileListener(report, progress_callback)
-        downloader = HTTPCurlDownloader(config, listener)
+        downloader = nectar_factory.create_downloader(feed, nectar_config, listener)
         _LOGGER.debug('downloading distribution files')
         downloader.download(file_to_download_request(f, feed, tmp_dir) for f in files)
         if len(listener.failed_reports) == 0:
@@ -120,14 +120,17 @@ def file_to_download_request(file_dict, feed, storage_path):
     )
 
 
-def get_treefile(feed, tmp_dir):
+def get_treefile(feed, tmp_dir, nectar_config):
     """
     Download the treefile and return its full path on disk, or None if not found
 
-    :param feed:    URL to the repository
-    :type  feed:    str
-    :param tmp_dir: full path to the temporary directory being used
-    :type  tmp_dir: str
+    :param feed:            URL to the repository
+    :type  feed:            str
+    :param tmp_dir:         full path to the temporary directory being used
+    :type  tmp_dir:         str
+    :param nectar_config:   download config to be used by nectar
+    :type  nectar_config:   nectar.config.DownloaderConfig
+
     :return:        full path to treefile on disk, or None if not found
     :rtype:         str or NoneType
     """
@@ -135,10 +138,8 @@ def get_treefile(feed, tmp_dir):
         path = os.path.join(tmp_dir, filename)
         url = os.path.join(feed, filename)
         request = DownloadRequest(url, path)
-        # TODO: use the config settings available from the sync workflow.
-        config = DownloaderConfig()
         listener = AggregatingEventListener()
-        downloader = HTTPCurlDownloader(config, listener)
+        downloader = nectar_factory.create_downloader(feed, nectar_config, listener)
         downloader.download([request])
         if len(listener.succeeded_reports) == 1:
             return path

--- a/plugins/pulp_rpm/plugins/importers/yum/repomd/nectar_factory.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/repomd/nectar_factory.py
@@ -35,10 +35,15 @@ def create_downloader(repo_url, nectar_config, event_listener):
     Note: In the future we may want to enhance this by passing in some sort of
     configuration that will let this method apply more than just protocol checking.
 
-    :param repo_url: where the repository will be syncced from
-    :type  repo_url: str
+    :param repo_url:        where the repository will be syncced from
+    :type  repo_url:        str
+    :param nectar_config:   download config to be used by nectar
+    :type  nectar_config:   nectar.config.DownloaderConfig
+    :param event_listener:  listener that will receive reports of download completion
+    :type  event_listener:  nectar.listener.DownloadEventListener
 
-    :rtype: nectar.downloaders.base.Downloader
+    :return:    a new nectar downloader instance
+    :rtype:     nectar.downloaders.base.Downloader
     """
     parsed = urlparse.urlparse(repo_url)
 

--- a/plugins/pulp_rpm/plugins/importers/yum/sync.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/sync.py
@@ -123,8 +123,8 @@ class RepoSync(object):
             else:
                 self.distribution_report['state'] = constants.STATE_RUNNING
                 self.set_progress()
-                treeinfo.sync(self.sync_conduit, self.sync_feed,
-                              self.tmp_dir, self.distribution_report, self.set_progress)
+                treeinfo.sync(self.sync_conduit, self.sync_feed, self.tmp_dir,
+                              self.nectar_config, self.distribution_report, self.set_progress)
             self.set_progress()
 
             if models.Errata.TYPE in self.call_config.get(constants.CONFIG_SKIP, []):


### PR DESCRIPTION
...most appropriate downloader type for a given URL, defaulting to the requests library for HTTP. It also now uses the nectar config options that are specified in the importer config instead of always using a default config.

https://bugzilla.redhat.com/show_bug.cgi?id=987663

Unit tests are forthcoming in another large PR. I don't want to hold up progress on this bug waiting for that whole PR to be done.
