### PR TITLE
pulp_rpm requires: python-nectar 1.0.0

### DIFF
--- a/pulp-rpm.spec
+++ b/pulp-rpm.spec
@@ -166,7 +166,7 @@ Requires: createrepo >= 0.9.9-21
 Requires: python-rhsm >= 1.8.0
 Requires: grinder >= 0.1.16
 Requires: pyliblzma
-Requires: python-nectar >= 0.99
+Requires: python-nectar >= 1.0.0
 %description plugins
 Provides a collection of platform plugins that extend the Pulp platform
 to provide RPM specific support.


### PR DESCRIPTION
bump pulp_rpm requirement on nectar to 1.0.0.
