### PR TITLE
979589 - fixing consumer update for all packages failing with  KeyError:...

### DIFF
--- a/pulp_rpm/extensions/admin/rpm_admin_consumer/package.py
+++ b/pulp_rpm/extensions/admin/rpm_admin_consumer/package.py
@@ -209,10 +209,13 @@ class YumConsumerPackageUpdateCommand(consumer_content.ConsumerContentUpdateComm
         commit = not kwargs[FLAG_NO_COMMIT.keyword]
         reboot = kwargs[FLAG_REBOOT.keyword]
         import_keys = kwargs[FLAG_IMPORT_KEYS.keyword]
+        options = {'apply': commit,
+                   'reboot': reboot,
+                   'importkeys': import_keys}
 
-        return {'apply': commit,
-                'reboot': reboot,
-                'importkeys': import_keys}
+        if kwargs['name'] is None:
+            options['all'] = True
+        return options
 
     def get_content_units(self, kwargs):
         def _unit_dict(unit_name):


### PR DESCRIPTION
... 'resolved'

https://bugzilla.redhat.com/show_bug.cgi?id=979589

After looking through and debugging the server code, it ended up being an issue of the client not passing correct "all" flag through options.
