### PR TITLE
1020460 - Fixed removing skip list from an existing repository

### DIFF
--- a/pulp_rpm/src/pulp_rpm/extension/admin/repo_create_update.py
+++ b/pulp_rpm/src/pulp_rpm/extension/admin/repo_create_update.py
@@ -366,9 +366,7 @@ def _prep_config(kwargs, plugin_config_keys):
 
     # Simple name translations
     for plugin_key, cli_key in plugin_config_keys:
-        plugin_config[plugin_key] = plugin_config.pop(cli_key, None)
-
-    # Apply option removal conventions
-    arg_utils.convert_removed_options(plugin_config)
+        if cli_key in plugin_config:
+            plugin_config[plugin_key] = plugin_config.pop(cli_key, None)
 
     return plugin_config

--- a/pulp_rpm/src/pulp_rpm/extension/admin/repo_options.py
+++ b/pulp_rpm/src/pulp_rpm/extension/admin/repo_options.py
@@ -36,8 +36,11 @@ def parse_skip_types(t):
 
     :param t: user entered value or None
     """
-    if t is None:
-        return
+    if t in (None, ''):
+        # Returning t itself is important. If it's None, it's an unspecified parameter
+        # and should be ignored. If it's an empty string, it's the unset convention,
+        # which is translated into a removal later in the parsing.
+        return t
 
     parsed = t.split(',')
     parsed = [p.strip() for p in parsed]


### PR DESCRIPTION
There are a few things going on in here:

= repo_create_update =
The convert_removed_options call was removed from _pre_config. This is called earlier in the flow. This was actually really bad; I'm surprised we didn't see more bugs about it.

= repo_options =
The parsing logic for the skip list correctly handles an empty string, which is the convention for removing a configuration value.

= test_extensions_repo_create_update =
The bulk of this was swapping two tests. There was a create test in the update suite and vice-versa. Github is trying to compare them as a diff so it's hard to tell that's what happened.

A new test was added for verifying `--skip ""` is correctly translated in the submitted configuration.
