### PR TITLE
1026907 - Fix dep equality comparison when a release is omitted.

### DIFF
--- a/plugins/pulp_rpm/plugins/importers/yum/depsolve.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/depsolve.py
@@ -116,8 +116,13 @@ class Requirement(object):
             return False
 
         # Attempt to compare the version information
-        mine = [self.epoch, self.version, self.release]
-        theirs = [other.epoch, other.version, other.release]
+        mine_version = version_utils.encode(self.version)
+        mine_release = version_utils.encode(self.release) if self.release else None
+        mine = [self.epoch, mine_version, mine_release]
+
+        theirs_version = version_utils.encode(other.version)
+        theirs_release = version_utils.encode(other.release) if other.release else None
+        theirs = [other.epoch, theirs_version, theirs_release]
 
         # Release is optional, so if it's omitted in either case, remove it entirely
         # from the check.

--- a/plugins/test/unit/test_importers_yum_depsolve.py
+++ b/plugins/test/unit/test_importers_yum_depsolve.py
@@ -323,12 +323,24 @@ class TestRequirement(unittest.TestCase):
 
         self.assertTrue(r_1 == r_2)
 
+    def test__eq__leading_version_zeroes(self):
+        r_1 = depsolve.Requirement('test', epoch='0', version='1', release='0')
+        r_2 = depsolve.Requirement('test', epoch='0', version='01', release='0')
+
+        self.assertTrue(r_1 == r_2)
+
+    def test__eq__leading_release_zeroes(self):
+        r_1 = depsolve.Requirement('test', epoch='0', version='0', release='1')
+        r_2 = depsolve.Requirement('test', epoch='0', version='0', release='01')
+
+        self.assertTrue(r_1 == r_2)
+
     def test__eq__no_release(self):
         """
         Test the __eq__ method with one object missing a release.
         """
-        r_1 = depsolve.Requirement('test', epoch=1, version=1, release=1)
-        r_2 = depsolve.Requirement('test', epoch=1, version=1)
+        r_1 = depsolve.Requirement('test', epoch='1', version='1', release='1')
+        r_2 = depsolve.Requirement('test', epoch='1', version='1')
 
         self.assertTrue(r_1 == r_2)
         self.assertTrue(r_2 == r_1)


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1026907
