### PR TITLE
1029057 - Override sha to sha1 for modifyrepo command support

### DIFF
--- a/pulp_rpm/src/pulp_rpm/yum_plugin/metadata.py
+++ b/pulp_rpm/src/pulp_rpm/yum_plugin/metadata.py
@@ -128,6 +128,9 @@ def get_repo_checksum_type(publish_conduit, config):
       Lookup checksum type on the repo to use for metadata generation;
       importer sets this value if available on the repo scratchpad.
 
+      This method overrides the 'sha' encoding with 'sha1' in order to support
+      the modifyrepo command line that is used for merging metadata into the repomd.xml file
+
       @param config: plugin configuration
       @type  config: L{pulp.server.content.plugins.config.PluginCallConfiguration}
 


### PR DESCRIPTION
The yum modifyrepo command does not support sha encoding.  Modify here to use sha1 instead.  

Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1029057
