### PR TITLE
1034366 - Failure to export RPM repositories to ISO where the repository...

### DIFF
--- a/pulp_rpm/src/pulp_rpm/yum_plugin/metadata.py
+++ b/pulp_rpm/src/pulp_rpm/yum_plugin/metadata.py
@@ -31,7 +31,8 @@ from pulp.common.util import encode_unicode, decode_unicode
 from pulp.plugins.conduits.mixins import MultipleRepoUnitsMixin, SingleRepoUnitsMixin
 from pulp.server.db.model.criteria import UnitAssociationCriteria
 from pulp.server.managers import factory
-from pulp_rpm.common.ids import TYPE_ID_RPM, TYPE_ID_SRPM, TYPE_ID_YUM_REPO_METADATA_FILE
+from pulp_rpm.common.ids import TYPE_ID_RPM, TYPE_ID_SRPM, TYPE_ID_YUM_REPO_METADATA_FILE, \
+    YUM_DISTRIBUTOR_ID
 from pulp_rpm.common.constants import SCRATCHPAD_DEFAULT_METADATA_CHECKSUM
 from pulp_rpm.yum_plugin import util
 
@@ -132,8 +133,9 @@ def get_repo_checksum_type(publish_conduit, config):
     This method overrides the 'sha' encoding with 'sha1' in order to support
     the modifyrepo command line that is used for merging metadata into the repomd.xml file
 
-    WARNING: This method has a side effect of saving the checksum type on the distributor
-     config if a checksum has not already been set on the distributor config.
+    WARNING: If this method is called on yum_distributor it has the side effect of
+     saving the checksum type on the distributor config if a checksum has not already
+     been set on the distributor config.
 
     :param config: publish conduit
     :type  config: pulp.plugins.conduits.repo_publish.RepoPublishConduit
@@ -156,7 +158,8 @@ def get_repo_checksum_type(publish_conduit, config):
         # Save the checksum back on the distributor config if it isn't there already
         # This is so that it can be synchronized to nodes and used for uploaded RPMS
         distributor_config = config.repo_plugin_config
-        if 'checksum_type' not in distributor_config:
+        if 'checksum_type' not in distributor_config and \
+                publish_conduit.distributor_id is YUM_DISTRIBUTOR_ID:
             distributor_manager = factory.repo_distributor_manager()
             distributor_manager.update_distributor_config(publish_conduit.repo_id,
                                                           publish_conduit.distributor_id,

--- a/pulp_rpm/test/unit/server/test_distributor.py
+++ b/pulp_rpm/test/unit/server/test_distributor.py
@@ -427,7 +427,7 @@ class TestDistributor(rpm_support_base.PulpRPMTests):
         existing_units = self.get_units(count=num_units)
         publish_conduit = distributor_mocks.get_publish_conduit(type_id="rpm", existing_units=existing_units, pkg_dir=self.pkg_dir)
         publish_conduit.repo_id = 'foo'
-        publish_conduit.distributor_id = 'bar'
+        publish_conduit.distributor_id = TYPE_ID_DISTRIBUTOR_YUM
         config = distributor_mocks.get_basic_config(https_publish_dir=self.https_publish_dir, relative_url=relative_url,
                 http=False, https=True)
         distributor = YumDistributor()
@@ -445,6 +445,34 @@ class TestDistributor(rpm_support_base.PulpRPMTests):
             assert_called_with(ANY, ANY, {'checksum_type': 'sha1'})
 
 
+    @patch('pulp.server.managers.factory.repo_distributor_manager')
+    @patch('pulp_rpm.yum_plugin.metadata.YumMetadataGenerator')
+    def test_yum_plugin_generate_yum_metadata_checksum_from_conduit_sha1_conversion_non_yum_distributor(self,
+                                                                    mock_YumMetadataGenerator,
+                                                                    mock_distributor_manager):
+        repo = mock.Mock(spec=Repository)
+        repo.working_dir = self.repo_working_dir
+        repo.id = "test_publish"
+        num_units = 10
+        relative_url = "rel_a/rel_b/rel_c/"
+        existing_units = self.get_units(count=num_units)
+        publish_conduit = distributor_mocks.get_publish_conduit(type_id="rpm", existing_units=existing_units, pkg_dir=self.pkg_dir)
+        publish_conduit.repo_id = 'foo'
+        publish_conduit.distributor_id = 'foo'
+        config = distributor_mocks.get_basic_config(https_publish_dir=self.https_publish_dir, relative_url=relative_url,
+                http=False, https=True)
+        distributor = YumDistributor()
+        distributor.process_repo_auth_certificate_bundle = mock.Mock()
+        config_conduit = mock.Mock(spec=RepoConfigConduit)
+        config_conduit.get_repo_distributors_by_relative_url.return_value = MockCursor([])
+        metadata.generate_yum_metadata(repo.id, repo.working_dir, publish_conduit, config,
+                                        repo_scratchpad={'checksum_type': 'sha'})
+        mock_YumMetadataGenerator.assert_called_with(ANY, checksum_type='sha1',
+                                                     skip_metadata_types=ANY, is_cancelled=ANY,
+                                                     group_xml_path=ANY,
+                                                     updateinfo_xml_path=ANY,
+                                                     custom_metadata_dict=ANY)
+        self.assertFalse(mock_distributor_manager.return_value.update_distributor_config.called)
 
     @patch('pulp.server.managers.factory.repo_distributor_manager')
     @patch('pulp_rpm.yum_plugin.metadata.YumMetadataGenerator')


### PR DESCRIPTION
... does not have a checksum manually set.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1034366
