### PR TITLE
Enable srpm copy command in pulp 2.3

### DIFF
--- a/pulp_rpm/extensions/admin/rpm_repo/pulp_cli.py
+++ b/pulp_rpm/extensions/admin/rpm_repo/pulp_cli.py
@@ -49,10 +49,10 @@ def initialize(context):
     copy_section.add_command(copy_commands.PackageGroupCopyCommand(context))
     copy_section.add_command(copy_commands.PackageCategoryCopyCommand(context))
     copy_section.add_command(copy_commands.AllCopyCommand(context))
+    copy_section.add_command(copy_commands.SrpmCopyCommand(context))
 
     # Disabled as per 950690. We'll likely be able to add these back once the new
     # yum importer is finished and DRPMs are properly handled.
-    # copy_section.add_command(copy_commands.SrpmCopyCommand(context))
     # copy_section.add_command(copy_commands.DrpmCopyCommand(context))
 
     remove_section = structure.repo_remove_section(context.cli)


### PR DESCRIPTION
Repo's can sync srpm units already and the infrastructure is in place to copy them.  Re-enable this functionality so command line users can copy SRPMs that are pulled in via a sync
