### PR TITLE
Jconnor yum distributor migration

### DIFF
--- a/pulp_rpm/src/pulp_rpm/migrations/0015_new_yum_distributor.py
+++ b/pulp_rpm/src/pulp_rpm/migrations/0015_new_yum_distributor.py
@@ -67,6 +67,8 @@ def migrate(*args, **kwargs):
         _clear_old_publish_dirs(repo, config)
         _re_publish_repository(repo, d)
 
+    _remove_legacy_publish_dirs()
+
 
 def _clear_working_dir(repo, working_dir=None):
     """
@@ -146,7 +148,12 @@ def _clear_orphaned_publish_dirs(root_dir, publish_dir):
             try: os.unlink(listing_path)
             except: pass
 
-        os.rmdir(publish_dir)
+        if os.path.islink(publish_dir):
+            try: os.unlink(publish_dir)
+            except: pass
+
+        else:
+            os.rmdir(publish_dir)
 
     _clear_orphaned_publish_dirs(root_dir, os.path.dirname(publish_dir))
 
@@ -166,3 +173,8 @@ def _re_publish_repository(repo, distributor):
     publisher = Publisher(repo, conduit, config)
     publisher.publish()
 
+
+def _remove_legacy_publish_dirs():
+
+    _clear_orphaned_publish_dirs(OLD_ROOT_PUBLISH_DIR, OLD_HTTP_PUBLISH_DIR)
+    _clear_orphaned_publish_dirs(OLD_ROOT_PUBLISH_DIR, OLD_HTTPS_PUBLISH_DIR)

--- a/pulp_rpm/test/unit/server/test_0015_new_yum_distrubutor.py
+++ b/pulp_rpm/test/unit/server/test_0015_new_yum_distrubutor.py
@@ -196,9 +196,11 @@ class MigrationTests(BaseMigrationTests):
         self.orig_clear_working_dir = self.migration_module._clear_working_dir
         self.orig_clear_old_publish_dirs = self.migration_module._clear_old_publish_dirs
         self.orig_re_publish_repository = self.migration_module._re_publish_repository
+        self.orig_remove_legacy_publish_dirs = self.migration_module._remove_legacy_publish_dirs
 
         self.migration_module._clear_working_dir = mock.MagicMock()
         self.migration_module._clear_old_publish_dirs = mock.MagicMock()
+        self.migration_module._remove_legacy_publish_dirs = mock.MagicMock()
         self.migration_module._re_publish_repository = mock.MagicMock()
 
     def tearDown(self):
@@ -207,6 +209,7 @@ class MigrationTests(BaseMigrationTests):
         self.migration_module._clear_working_dir = self.orig_clear_working_dir
         self.migration_module._clear_old_publish_dirs = self.orig_clear_old_publish_dirs
         self.migration_module._re_publish_repository = self.orig_re_publish_repository
+        self.migration_module._remove_legacy_publish_dirs = self.orig_remove_legacy_publish_dirs
 
 
     def test_migrate(self):
@@ -222,4 +225,5 @@ class MigrationTests(BaseMigrationTests):
         self.migration_module._clear_working_dir.assert_called_once()
         self.migration_module._clear_old_publish_dirs.assert_called_once()
         self.migration_module._re_publish_repository.assert_called_once()
+        self.migration_module._remove_legacy_publish_dirs.assert_called_once()
 


### PR DESCRIPTION
Migration script that clears out the old distributor's working directory and http/https publish directories and republishes the repositories.
