### PR TITLE
1081865 - updating location element in the repomd file to include href a...

### DIFF
--- a/plugins/pulp_rpm/plugins/distributors/yum/metadata/repomd.py
+++ b/plugins/pulp_rpm/plugins/distributors/yum/metadata/repomd.py
@@ -81,8 +81,8 @@ class RepomdXMLFileContext(MetadataFileContext):
         data_attributes = {'type': data_type}
         data_element = ElementTree.Element('data', data_attributes)
 
-        location_element = ElementTree.SubElement(data_element, 'location')
-        location_element.text = os.path.join(REPO_DATA_DIR_NAME, file_name)
+        location_attributes = {'href': os.path.join(REPO_DATA_DIR_NAME, file_name)}
+        ElementTree.SubElement(data_element, 'location', location_attributes)
 
         timestamp_element = ElementTree.SubElement(data_element, 'timestamp')
         timestamp_element.text = str(os.path.getmtime(file_path))

--- a/plugins/test/unit/test_yum_distributor_metadata.py
+++ b/plugins/test/unit/test_yum_distributor_metadata.py
@@ -710,7 +710,8 @@ class YumDistributorMetadataTests(unittest.TestCase):
             content = repomd_handle.read()
 
             self.assertEqual(content.count('<data type="metadata"'), 1)
-            self.assertEqual(content.count('<location>%s/%s</location>' % (REPO_DATA_DIR_NAME, test_metadata_file_name)), 1)
+            self.assertEqual(content.count('<location href="%s/%s"' %
+                                           (REPO_DATA_DIR_NAME, test_metadata_file_name)), 1)
             self.assertEqual(content.count('<timestamp>'), 1)
             self.assertEqual(content.count('<size>'), 1)
             self.assertEqual(content.count('<checksum type="sha256">'), 1)


### PR DESCRIPTION
...ttribute

https://bugzilla.redhat.com/show_bug.cgi?id=1081865

It seems that the location element in repomd.xml which is supposed to contain href attribute with location as the value was not done correctly in the new distributor -  
eg. expected value is 
<location href="repodata/filelists.xml.gz"/>
as opposed to 
<location>repodata/filelists.xml.gz</location>
