### PR TITLE
1091078 - rhui cataloger requires nectar >= 1.2.0.

### DIFF
--- a/pulp-rpm.spec
+++ b/pulp-rpm.spec
@@ -155,7 +155,7 @@ Requires: pulp-server = %{pulp_version}
 Requires: createrepo >= 0.9.9-21
 Requires: python-rhsm >= 1.8.0
 Requires: pyliblzma
-Requires: python-nectar >= 1.1.0
+Requires: python-nectar >= 1.2.1
 %description plugins
 Provides a collection of platform plugins that extend the Pulp platform
 to provide RPM specific support.


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1091078

Needed for custom header support.  Requiring 1.2.1 since it's the latest anyway.
