### PR TITLE
1093429 - Changing parameter name for repo create due to API change

### DIFF
--- a/extensions_admin/pulp_rpm/extensions/admin/iso/create_update.py
+++ b/extensions_admin/pulp_rpm/extensions/admin/iso/create_update.py
@@ -96,7 +96,7 @@ class ISORepoCreateUpdateMixin(ImporterConfigMixin, ISODistributorConfigMixin):
             return os.EX_DATAERR
 
         distributors = [
-            {'distributor_type': ids.TYPE_ID_DISTRIBUTOR_ISO, 'distributor_config': distributor_config,
+            {'distributor_type_id': ids.TYPE_ID_DISTRIBUTOR_ISO, 'distributor_config': distributor_config,
              'auto_publish': True, 'distributor_id': ids.TYPE_ID_DISTRIBUTOR_ISO}]
         self._perform_command(repo_id, display_name, description, notes, importer_config, distributors)
 

--- a/extensions_admin/pulp_rpm/extensions/admin/repo_create_update.py
+++ b/extensions_admin/pulp_rpm/extensions/admin/repo_create_update.py
@@ -132,10 +132,10 @@ class RpmRepoCreateCommand(CreateRepositoryCommand, ImporterConfigMixin):
         :rtype:  tuple
         """
         distributors = [
-            dict(distributor_type=ids.TYPE_ID_DISTRIBUTOR_YUM,
+            dict(distributor_type_id=ids.TYPE_ID_DISTRIBUTOR_YUM,
                  distributor_config=yum_distributor_config,
                  auto_publish=True, distributor_id=ids.YUM_DISTRIBUTOR_ID),
-            dict(distributor_type=ids.TYPE_ID_DISTRIBUTOR_EXPORT,
+            dict(distributor_type_id=ids.TYPE_ID_DISTRIBUTOR_EXPORT,
                  distributor_config=export_distributor_config,
                  auto_publish=False, distributor_id=ids.EXPORT_DISTRIBUTOR_ID)
         ]

--- a/extensions_admin/test/unit/extensions/admin/iso/test_extension_admin_iso_create_update.py
+++ b/extensions_admin/test/unit/extensions/admin/iso/test_extension_admin_iso_create_update.py
@@ -264,7 +264,7 @@ class TestISORepoCreateCommand(PulpClientTests):
             constants.CONFIG_SERVE_HTTP: 'true', constants.CONFIG_SERVE_HTTPS: 'false',
             constants.CONFIG_SSL_AUTH_CA_CERT: 'This is a file.'}
         expected_distributor = {
-            'distributor_type': ids.TYPE_ID_DISTRIBUTOR_ISO,
+            'distributor_type_id': ids.TYPE_ID_DISTRIBUTOR_ISO,
             'distributor_config': expected_distributor_config,
             'auto_publish': True, 'distributor_id': ids.TYPE_ID_DISTRIBUTOR_ISO}
         self.assertEqual(args[6], [expected_distributor])
@@ -316,7 +316,7 @@ class TestISORepoCreateCommand(PulpClientTests):
         # Inspect the distributors
         expected_distributor_config = {}
         expected_distributor = {
-            'distributor_type': ids.TYPE_ID_DISTRIBUTOR_ISO,
+            'distributor_type_id': ids.TYPE_ID_DISTRIBUTOR_ISO,
             'distributor_config': expected_distributor_config,
             'auto_publish': True, 'distributor_id': ids.TYPE_ID_DISTRIBUTOR_ISO}
         self.assertEqual(args[6], [expected_distributor])

--- a/extensions_admin/test/unit/extensions/admin/test_repo_create_update.py
+++ b/extensions_admin/test/unit/extensions/admin/test_repo_create_update.py
@@ -116,7 +116,7 @@ class RpmRepoCreateCommandTests(PulpClientTests):
         # instead of index.
 
         yum_distributor = body['distributors'][0]
-        self.assertEqual(ids.TYPE_ID_DISTRIBUTOR_YUM, yum_distributor['distributor_type'])
+        self.assertEqual(ids.TYPE_ID_DISTRIBUTOR_YUM, yum_distributor['distributor_type_id'])
         self.assertEqual(True, yum_distributor['auto_publish'])
         self.assertEqual(ids.YUM_DISTRIBUTOR_ID, yum_distributor['distributor_id'])
 


### PR DESCRIPTION
Please review with all PRs listed on this BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1093429
