### PR TITLE
1098844 - updating yum distributor to publish rpms at the same level as ...

### DIFF
--- a/plugins/pulp_rpm/yum_plugin/util.py
+++ b/plugins/pulp_rpm/yum_plugin/util.py
@@ -81,14 +81,11 @@ def get_relpath_from_unit(unit):
     @return relative path
     @rtype str
     """
-    filename = ""
-    if unit.metadata.has_key("relativepath"):
-        relpath = unit.metadata["relativepath"]
-    elif unit.metadata.has_key("filename"):
+    if "filename" in unit.metadata:
         relpath = unit.metadata["filename"]
-    elif unit.unit_key.has_key("fileName"):
+    elif "fileName" in unit.unit_key:
         relpath = unit.unit_key["fileName"]
-    elif unit.unit_key.has_key("filename"):
+    elif "filename" in unit.unit_key:
         relpath = unit.unit_key["filename"]
     else:
         relpath = os.path.basename(unit.storage_path)

--- a/plugins/test/unit/yum_plugin/test_util.py
+++ b/plugins/test/unit/yum_plugin/test_util.py
@@ -5,6 +5,7 @@ import shutil
 import tempfile
 import unittest
 
+from pulp.plugins.model import Unit
 from pulp_rpm.devel import rpm_support_base
 from pulp_rpm.yum_plugin import util
 
@@ -61,4 +62,27 @@ class TestStringToUnicode(unittest.TestCase):
         self.assertTrue(isinstance(result, unicode))
         self.assertEqual(result, u'€')
 
+
+class TestRelativePath(unittest.TestCase):
+    def test_get_relpath_from_unit(self):
+        unit = Unit(type_id='random',
+                    unit_key={"filename": "test_unit_key_filename"},
+                    metadata={"filename": "test_metadata_filename"},
+                    storage_path="/test/storage/path")
+        self.assertEqual(util.get_relpath_from_unit(unit), "test_metadata_filename")
+        unit = Unit(type_id='random',
+                    unit_key={"filename": "test_unit_key_filename"},
+                    metadata={},
+                    storage_path="/test/storage/path")
+        self.assertEqual(util.get_relpath_from_unit(unit), "test_unit_key_filename")
+        unit = Unit(type_id='random',
+                    unit_key={"fileName": "test_unit_key_fileName"},
+                    metadata={},
+                    storage_path="/test/storage/path")
+        self.assertEqual(util.get_relpath_from_unit(unit), "test_unit_key_fileName")
+        unit = Unit(type_id='random',
+                    unit_key={},
+                    metadata={},
+                    storage_path="/test/storage/path")
+        self.assertEqual(util.get_relpath_from_unit(unit), "path")
 


### PR DESCRIPTION
...repodata directory and not as per relative path of each unit

https://bugzilla.redhat.com/show_bug.cgi?id=1098844

There were no unit tests whatsoever for this function and not enough coverage for areas which directly get affected by this function as well, so it was hard to figure out all the areas that can get affected. I have verified the areas related to 3 uses of this function through syncing, checking the location of published content and installing rpms, drpms and errata using those repos. Also added a unit test for this function. 
