### PR TITLE
1099236 - add Obsoletes for python-pulp-rpm-extension

### DIFF
--- a/pulp-rpm.spec
+++ b/pulp-rpm.spec
@@ -132,6 +132,7 @@ rm -rf %{buildroot}
 Summary: Pulp RPM support common library
 Group: Development/Languages
 Requires: python-pulp-common = %{pulp_version}
+Obsoletes: python-pulp-rpm-extension <= 2.4.0
 
 %description -n python-pulp-rpm-common
 A collection of modules shared among all RPM components.


### PR DESCRIPTION
python-pulp-rpm-common now provides python-pulp-rpm-extension, the extension
rpm needs to be Obsoleted to update properly.
