### PR TITLE
1051700 - Don't build plugins or admin extensions on RHEL 5.

### DIFF
--- a/pulp-rpm.spec
+++ b/pulp-rpm.spec
@@ -61,6 +61,9 @@ popd
 
 %install
 rm -rf %{buildroot}
+
+mkdir -p %{buildroot}/%{_sysconfdir}/pulp
+
 pushd common
 %{__python} setup.py install -O1 --skip-build --root %{buildroot}
 popd
@@ -102,7 +105,6 @@ cp -R plugins/types %{buildroot}/%{_usr}/lib/pulp/plugins
 %endif # End pulp_server if block
 
 # Directories
-mkdir -p %{buildroot}/%{_sysconfdir}/pulp
 mkdir -p %{buildroot}/%{_sysconfdir}/pki/pulp/content
 mkdir -p %{buildroot}/%{_sysconfdir}/yum.repos.d
 mkdir -p %{buildroot}/%{_usr}/lib/pulp/consumer/extensions


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1051700
