### PR TITLE
1100848 - Only hand strings to ElementTree.

### DIFF
--- a/plugins/pulp_rpm/plugins/distributors/yum/metadata/updateinfo.py
+++ b/plugins/pulp_rpm/plugins/distributors/yum/metadata/updateinfo.py
@@ -6,7 +6,7 @@ from pulp_rpm.plugins.distributors.yum.metadata.metadata import (
 from pulp_rpm.yum_plugin import util
 
 
-_LOG = util.getLogger(__name__)
+_logger = util.getLogger(__name__)
 
 UPDATE_INFO_XML_FILE_NAME = 'updateinfo.xml.gz'
 
@@ -35,9 +35,13 @@ class UpdateinfoXMLFileContext(MetadataFileContext):
         self._write_root_tag_close = _write_root_tag_close_closure
 
     def add_unit_metadata(self, erratum_unit):
+        """
+        Write the XML representation of erratum_unit to self.metadata_file_handle
+        (updateinfo.xml.gx).
 
-        # XXX refactor me
-
+        :param erratum_unit: The erratum unit that should be written to updateinfo.xml.
+        :type  erratum_unit: pulp.plugins.model.AssociatedUnit
+        """
         update_attributes = {'status': erratum_unit.metadata['status'],
                              'type': erratum_unit.metadata['type'],
                              'version': erratum_unit.metadata['version'],
@@ -62,7 +66,7 @@ class UpdateinfoXMLFileContext(MetadataFileContext):
                 continue
 
             sub_element = ElementTree.SubElement(update_element, key)
-            sub_element.text = value
+            sub_element.text = unicode(value)
 
         updated = erratum_unit.metadata.get('updated')
 
@@ -118,10 +122,9 @@ class UpdateinfoXMLFileContext(MetadataFileContext):
                 reboot_element.text = str(package.get('reboot_suggested', False))
 
         # write the top-level XML element out to the file
-
         update_element_string = ElementTree.tostring(update_element, 'utf-8')
 
-        _LOG.debug('Writing updateinfo unit metadata:\n' + update_element_string)
+        _logger.debug('Writing updateinfo unit metadata:\n' + update_element_string)
 
         self.metadata_file_handle.write(update_element_string + '\n')
 

--- a/plugins/test/unit/plugins/distributors/yum/metadata/test_updateinfo.py
+++ b/plugins/test/unit/plugins/distributors/yum/metadata/test_updateinfo.py
@@ -1,0 +1,71 @@
+"""
+Tests for the pulp_rpm.plugins.distributors.yum.metadata.updateinfo module.
+"""
+import unittest
+
+from pulp.plugins import model
+import mock
+
+from pulp_rpm.common import ids
+from pulp_rpm.plugins.distributors.yum.metadata import updateinfo
+
+class UpdateinfoXMLFileContextTests(unittest.TestCase):
+    """
+    This is a test superclass for testing the UpdateinfoXMLFileContext class. It's setUp() method
+    contructs one on self.updateinfo_xml_file_context.
+    """
+    def setUp(self):
+        """
+        Build an UpdateinfoXMLFileContext and store it on self.updateinfo_xml_file_context.
+        """
+        self.updateinfo_xml_file_context = updateinfo.UpdateinfoXMLFileContext('some_working_dir')
+        # Let's fake the metadata_file_handle attribute so we can inspect calls to it.
+        self.updateinfo_xml_file_context.metadata_file_handle = mock.MagicMock()
+
+
+class AddUnitMetadataTests(UpdateinfoXMLFileContextTests):
+    """
+    Tests the UpdateinfoXMLFileContext.add_unit_metadata() method.
+    """
+    def test_handles_integer_pushcount(self):
+        """
+        We had a bug[0] wherein uploaded errata couldn't be published because the pushcount would
+        be represented as an int. Synchronized errata would have this field represented as a
+        basestring. The descrepancy between these has been filed as a separate issue[1].
+
+        [0] https://bugzilla.redhat.com/show_bug.cgi?id=1100848
+        [1] https://bugzilla.redhat.com/show_bug.cgi?id=1101728
+        """
+        type_id = ids.TYPE_ID_ERRATA
+        unit_key = {'id': 'RHSA-2014:0042'}
+        metadata = {
+            'title': 'Some Title',
+            'release': '2',
+            'rights': 'You have the right to remain silent.',
+            'description': 'A Description',
+            'solution': 'Open Source is the solution to your problems.',
+            'severity': 'High',
+            'summary': 'A Summary',
+            # Note that pushcount is an int and not a string. This should be OK (no exceptions).
+            'pushcount': 1,
+            'status': 'symbol',
+            'type': 'security',
+            'version': '2.4.1',
+            'issued': '2014-05-27',
+            'reboot_suggested': 'true',
+            'references': [],
+        }
+        storage_path = '/some/path'
+        created = '2014-04-27'
+        updated = '2014-04-28'
+        owner_type = 'soft brain\'d human'
+        owner_id = 'rbarlow'
+        erratum_unit = model.AssociatedUnit(type_id, unit_key, metadata, storage_path, created,
+                                            updated, owner_type, owner_id)
+
+        # This should not cause any Exception
+        self.updateinfo_xml_file_context.add_unit_metadata(erratum_unit)
+
+        self.assertEqual(self.updateinfo_xml_file_context.metadata_file_handle.write.call_count, 1)
+        xml = self.updateinfo_xml_file_context.metadata_file_handle.write.mock_calls[0][1][0]
+        self.assertTrue('<pushcount>1</pushcount>' in xml)


### PR DESCRIPTION
This commit fixes a bug[0] wherein uploaded erratum could not be published, because some of their metadata
fields would be integers and not strings. This commit sets them to strings before sending them through
ElementTree.

[0] https://bugzilla.redhat.com/show_bug.cgi?id=1100848
