### PR TITLE
1097790 - check task details of erratum upload to determine if task succeeded

### DIFF
--- a/extensions_admin/pulp_rpm/extensions/admin/upload/errata.py
+++ b/extensions_admin/pulp_rpm/extensions/admin/upload/errata.py
@@ -198,6 +198,23 @@ class CreateErratumCommand(UploadCommand):
             references.append(refdict)
         return references
 
+    def succeeded(self, task):
+        """
+        Called when a task has completed with a status indicating success.
+
+        :param task: full task report for the task being displayed
+        :type  task: pulp.bindings.responses.Task
+        """
+        # Check for any errors in the details block of the task
+        if task.result and task.result.get('details') and task.result.get('details').get('errors'):
+
+            self.prompt.render_failure_message(_('Task Failed'))
+            for error in task.result.get('details').get('errors'):
+                self.prompt.render_failure_message(error)
+        else:
+            super(CreateErratumCommand, self).succeeded(task)
+
+
 # -- utilities ----------------------------------------------------------------
 
 class ParseException(Exception):

--- a/extensions_admin/test/unit/extensions/admin/upload/test_errata.py
+++ b/extensions_admin/test/unit/extensions/admin/upload/test_errata.py
@@ -1,6 +1,7 @@
 import os
 
 import mock
+from pulp.bindings.responses import Task
 from pulp.client.commands.repo.upload import UploadCommand, FLAG_VERBOSE
 from pulp.client.commands.options import OPTION_REPO_ID
 from pulp.client.commands.polling import FLAG_BACKGROUND
@@ -97,3 +98,15 @@ class CreateRpmCommandTests(PulpClientTests):
         }
         self.assertEqual(expected, metadata)
 
+    def test_succeeded(self):
+        self.command.prompt = mock.Mock()
+        task = Task({})
+        self.command.succeeded(task)
+        self.assertTrue(self.command.prompt.render_success_message.called)
+
+    # testing for #1097790
+    def test_succeeded_error_in_result(self):
+        self.command.prompt = mock.Mock()
+        task = Task({'result': {'details': {'errors': ['foo']}}})
+        self.command.succeeded(task)
+        self.assertTrue(self.command.prompt.render_failure_message.called)


### PR DESCRIPTION
Previously, failing erratum uploads were being shown as succeeded in
pulp-admin.

This commit checks for task.details.error, and if it is populated, assumes that
the task failed.

NOTE: this is very similar to 1fef7b67, which was bcourt's fix for rpm upload
error checking.
