### PR TITLE
Fixes BZ 1098223 -- repo deletion does not work in some cases.

### DIFF
--- a/plugins/pulp_rpm/plugins/distributors/yum/distributor.py
+++ b/plugins/pulp_rpm/plugins/distributors/yum/distributor.py
@@ -110,8 +110,9 @@ class YumHTTPDistributor(Distributor):
         symlink_list = [http_publish_dir, https_publish_dir]
 
         for symlink in symlink_list:
+            symlink_without_trailing_slash = symlink.rstrip(os.sep)
             try:
-                os.unlink(symlink)
+                os.unlink(symlink_without_trailing_slash)
             except OSError as error:
                 # If the symlink doesn't exist pass
                 if error.errno != errno.ENOENT:

--- a/plugins/test/unit/plugins/distributors/yum/test_distributor.py
+++ b/plugins/test/unit/plugins/distributors/yum/test_distributor.py
@@ -215,21 +215,21 @@ class TestDistributorDistributorRemoved(unittest.TestCase):
     def test_distributor_remove_distributor_calls_remove_cert_based_auth(self):
         self.mock_remove_cert.assert_called_once_with(self.mock_repo, self.config)
 
-    def test_distributor_uses_rmtree_to_remove_working_dir_and_master_dir(self):
+    def test_distributor_remove_distributor_uses_rmtree_to_remove_working_dir_and_master_dir(self):
         rmtree_calls = [
             call(self.mock_repo.working_dir, ignore_errors=True),
             call(self.mock_master.return_value, ignore_errors=True)
         ]
         self.mock_rmtree.assert_has_calls(rmtree_calls)
 
-    def test_distributor_uses_unlink_to_remove_http_and_https_symlinks(self):
+    def test_distributor_remove_distributor_uses_unlink_to_remove_http_and_https_symlinks(self):
         unlink_calls = [
-            call(self.mock_os.path.join.return_value),
-            call(self.mock_os.path.join.return_value)
+            call(self.mock_os.path.join.return_value.rstrip.return_value),
+            call(self.mock_os.path.join.return_value.rstrip.return_value)
         ]
         self.mock_os.unlink.assert_has_calls(unlink_calls)
 
-    def test_distributor_unlink_call_handles_OSError_raised(self):
+    def test_distributor_remove_distributor_unlink_call_handles_OSError_raised(self):
         os_error_to_raise = OSError()
         os_error_to_raise.errno = errno.ENOENT
         self.mock_os.unlink.side_effect = os_error_to_raise
@@ -238,7 +238,7 @@ class TestDistributorDistributorRemoved(unittest.TestCase):
         except Exception:
             self.fail('Distributor unlink should handle symlinks that do not exist.')
 
-    def test_distributor_unlink_call_handles_non_oserror_raised(self):
+    def test_distributor_remove_distributor_unlink_call_handles_non_oserror_raised(self):
         os_error_to_raise = OSError()
         self.mock_os.unlink.side_effect = os_error_to_raise
         self.assertRaises(OSError, self.distributor.distributor_removed, self.mock_repo,


### PR DESCRIPTION
If the relative path contains a trailing slash, then the symlink deletion would fail. Symlinks are considered files not directories, and a trailing slash causes the symlink to get treated as a directory. The docs do not encourage a trailing slash when the user specifies the relative url, but it does work, so smartening up the deletion is how I've decided to fix this.

I've adjusted a test which needed updating because of the change. That update provides an assertion of the new lines introduced.
