### PR TITLE
if a collection has no name, use a UUID on import

### DIFF
--- a/plugins/pulp_rpm/plugins/importers/yum/repomd/updateinfo.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/repomd/updateinfo.py
@@ -2,6 +2,7 @@
 
 
 import logging
+import uuid
 
 from pulp_rpm.plugins.db import models
 
@@ -79,11 +80,16 @@ def _parse_reference(element):
 def _parse_collection(element):
     ret = {
         'packages': map(_parse_package, element.findall('package')),
-        'name': element.find('name').text,
     }
     # based on yum's parsing, this could be optional. See yum.update_md.UpdateNotice._parse_pkglist
     if 'short' in element.attrib:
         ret['short'] = element.attrib['short']
+
+    name = element.find('name')
+    if name is not None:
+        ret['name'] = name.text
+    else:
+        ret['name'] = str(uuid.uuid4())
 
     return ret
 


### PR DESCRIPTION
Fixes #1100838, some SUSE repositories don't have that name element.
