### PR TITLE
workaround for BZ#1120215

### DIFF
--- a/plugins/pulp_rpm/plugins/importers/yum/repomd/metadata.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/repomd/metadata.py
@@ -92,6 +92,7 @@ class MetadataFiles(object):
                    'filelists', 'filelists_db',
                    'other', 'other_db',
                    'primary', 'primary_db',
+                   'deltainfo', 'susedata',
                    'updateinfo', 'updateinfo_db'])
 
     def __init__(self, repo_url, dst_dir, nectar_config):


### PR DESCRIPTION
Ignore SUSE specific files for now, until those can be handled properly. While this is not nice, I can now (together with #525) import a SLES update channel, feed the published repo to zypper and it just works.
