### PR TITLE
1127298 - Alternate Content sources needs to wrap the nectar listener in...

### DIFF
--- a/plugins/pulp_rpm/plugins/importers/yum/repomd/alternate.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/repomd/alternate.py
@@ -52,7 +52,7 @@ class Packages(object):
         self.base_url = base_url
         self.units = units
         self.dst_dir = dst_dir
-        self.listener = listener
+        self.listener = ContainerListener(listener)
         self.primary = create_downloader(base_url, nectar_conf)
         self.container = ContentContainer()
         self.canceled = Event()

--- a/plugins/pulp_rpm/plugins/importers/yum/sync.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/sync.py
@@ -196,11 +196,14 @@ class RepoSync(object):
             metadata_files.download_repomd()
         except IOError, e:
             raise FailedException(str(e))
+        _logger.info(_('Parsing metadata.'))
 
         try:
             metadata_files.parse_repomd()
         except ValueError, e:
             raise FailedException(str(e))
+
+        _logger.info(_('Downloading metadata files.'))
 
         metadata_files.download_metadata_files()
         self.downloader = None

--- a/plugins/test/unit/plugins/importers/yum/repomd/test_alternate.py
+++ b/plugins/test/unit/plugins/importers/yum/repomd/test_alternate.py
@@ -42,7 +42,8 @@ class TestPackages(TestCase):
         self.assertEqual(packages.base_url, base_url)
         self.assertEqual(packages.units, units)
         self.assertEqual(packages.dst_dir, dst_dir)
-        self.assertEqual(packages.listener, listener)
+        self.assertTrue(isinstance(packages.listener, ContainerListener))
+        self.assertEqual(packages.listener.content_listener, listener)
         self.assertEqual(packages.primary, fake_create_downloader())
         self.assertEqual(packages.container, fake_container())
         self.assertEqual(packages.canceled, fake_event())
@@ -73,7 +74,7 @@ class TestPackages(TestCase):
 
         # validation
         fake_container().download.assert_called_with(
-            packages.canceled, packages.primary, fake_requests(), listener)
+            packages.canceled, packages.primary, fake_requests(), packages.listener)
 
     @patch('pulp_rpm.plugins.importers.yum.repomd.alternate.Event', Mock())
     @patch('pulp_rpm.plugins.importers.yum.repomd.alternate.create_downloader', Mock())


### PR DESCRIPTION
... a container listener to prevent exceptions when downloads fail.  

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1127298
