### PR TITLE
1022553 - The 'pulp-admin rpm consumer unbind' command now reports a missing binding in a more friendly way

### DIFF
--- a/extensions_admin/pulp_rpm/extensions/admin/rpm_admin_consumer/bind.py
+++ b/extensions_admin/pulp_rpm/extensions/admin/rpm_admin_consumer/bind.py
@@ -1,5 +1,8 @@
+from gettext import gettext as _
+
 from pulp.client.commands.consumer.bind import (
     ConsumerBindCommand, ConsumerUnbindCommand)
+from pulp.client.extensions.exceptions import ExceptionHandler, CODE_NOT_FOUND
 
 
 YUM_DISTRIBUTOR_ID = 'yum_distributor'
@@ -16,9 +19,50 @@ class YumConsumerBindCommand(ConsumerBindCommand):
 
 class YumConsumerUnbindCommand(ConsumerUnbindCommand):
 
+    def __init__(self, context, name=None, description=None):
+        """
+        Create a new YumConsumerUnbindCommand
+
+        :param context:     The context to use for this command
+        :type  context:     pulp.client.extensions.core.ClientContext
+        :param name:        The name to use for this command
+        :type  name:        str
+        :param description: The description for this command
+        :type  description: str
+        """
+        ConsumerUnbindCommand.__init__(self, context, name, description)
+        self.context.exception_handler = UnbindExceptionHandler(self.prompt, context.config)
+
     def add_distributor_option(self):
         pass
 
     def get_distributor_id(self, kwargs):
         return YUM_DISTRIBUTOR_ID
 
+
+class UnbindExceptionHandler(ExceptionHandler):
+    """
+    Override the default exception handler so we can report the missing binding
+    in a user-friendly way.
+    """
+
+    def handle_not_found(self, e):
+        """
+        Handles a not found (HTTP 404) error from the server.
+
+        :param e: An exception to handle
+        :type  e: pulp.bindings.exceptions.NotFoundException
+
+        :return: The appropriate exit code (in this case os.EX_DATAERR)
+        :rtype:  int
+        """
+        if 'resources' in e.extra_data and 'bind_id' in e.extra_data['resources']:
+            # The binding doesn't exist, but the way the server reports this is not
+            # rendered in a user-friendly way by the default handler.
+            self._log_server_exception(e)
+            msg = _('The binding could not be found.')
+            self.prompt.render_failure_message(msg)
+        else:
+            ExceptionHandler.handle_not_found(self, e)
+
+        return CODE_NOT_FOUND

--- a/extensions_admin/test/unit/extensions/admin/rpm_admin_consumer/test_bind.py
+++ b/extensions_admin/test/unit/extensions/admin/rpm_admin_consumer/test_bind.py
@@ -1,0 +1,53 @@
+"""
+This module contains tests for the pulp_rpm.extensions.admin.rpm_admin_consumer.bind module
+"""
+from gettext import gettext as _
+import unittest
+
+import mock
+
+from pulp.bindings.exceptions import NotFoundException
+from pulp.client.extensions.exceptions import CODE_NOT_FOUND
+from pulp_rpm.extensions.admin.rpm_admin_consumer.bind import YumConsumerUnbindCommand, UnbindExceptionHandler
+
+
+class TestYumConsumerUnbindCommand(unittest.TestCase):
+
+    def test_init(self):
+        """
+        Assert that the exception handler is the custom unbind handler
+        """
+        mock_context = mock.MagicMock()
+        command = YumConsumerUnbindCommand(mock_context)
+
+        self.assertTrue(isinstance(command.context.exception_handler, UnbindExceptionHandler))
+
+
+class TestUnbindExceptionHandler(unittest.TestCase):
+
+    def test_handle_not_found_bind_id(self):
+        """
+        Test that when the bind_id is returned, a user-friendly message is printed
+        """
+        # Setup
+        exception = NotFoundException({'resources': {'bind_id': 'much unfriendly'}})
+        mock_prompt = mock.Mock()
+        handler = UnbindExceptionHandler(mock_prompt, mock.Mock())
+
+        result = handler.handle_not_found(exception)
+        self.assertEquals(result, CODE_NOT_FOUND)
+        mock_prompt.render_failure_message.assert_called_once_with(_('The binding could not be found.'))
+
+    @mock.patch('pulp.client.extensions.exceptions.ExceptionHandler.handle_not_found', autospec=True)
+    def test_handle_not_found_default(self, mock_super_not_found):
+        """
+        Test that for all other cases, the parent class handler is called
+        """
+        # Setup
+        exception = NotFoundException({})
+        handler = UnbindExceptionHandler(mock.Mock(), mock.Mock())
+
+        result = handler.handle_not_found(exception)
+        self.assertEquals(result, CODE_NOT_FOUND)
+        mock_super_not_found.assert_called_once_with(handler, exception)
+


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1022553
