### PR TITLE
1125388 - ensure we save storage_path when saving units

### DIFF
--- a/plugins/pulp_rpm/plugins/importers/yum/existing.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/existing.py
@@ -120,6 +120,9 @@ def check_all_and_associate(wanted, sync_conduit):
                 relative_path = get_relpath_from_unit(unit)
             downloaded_unit = sync_conduit.init_unit(unit_type, unit.unit_key,
                                                      unit.metadata, relative_path)
+
+            # 1125388 - make sure we keep storage_path on the new unit model obj
+            downloaded_unit.storage_path = unit.storage_path
             sync_conduit.save_unit(downloaded_unit)
 
             # Discard already downloaded unit from the return value.

--- a/plugins/test/unit/plugins/importers/yum/test_sync.py
+++ b/plugins/test/unit/plugins/importers/yum/test_sync.py
@@ -907,6 +907,10 @@ class TestAlreadyDownloadedUnits(BaseSyncTest):
             unit.storage_path = "existing_storage_path"
         result = check_all_and_associate(input_units, self.conduit)
         self.assertEqual(len(list(result)), 0)
+        # verify we are saving the storage path
+        for c in mock_save.mock_calls:
+            (conduit, unit) = c[1]
+            self.assertEquals(unit.storage_path, "existing_storage_path")
 
     @mock.patch('pulp.plugins.conduits.repo_sync.RepoSyncConduit.search_all_units', autospec=True)
     @mock.patch('pulp.plugins.conduits.repo_sync.RepoSyncConduit.save_unit', autospec=True)


### PR DESCRIPTION
The code inside `check_all_and_associate()` works with units to ensure they are
downloaded if the unit exists but the file is not on-disk, and to associate the
unit with the repo if the unit already exists.

The unit gets re-created from an RPM model object, which can create issues
since the existing `storage_path` on the unit may not be what pulp thinks the
`storage_path` should be. For example, if a user upgrades from 2.3 to 2.4, the
`storage_path` of new units has changed but old units stays the same.

This fix ensures that the storage_path is copied over onto the unit before
saving.
