### PR TITLE
1138475 - yum distributor now always includes "description" element for errata

### DIFF
--- a/plugins/pulp_rpm/plugins/distributors/yum/metadata/updateinfo.py
+++ b/plugins/pulp_rpm/plugins/distributors/yum/metadata/updateinfo.py
@@ -57,13 +57,24 @@ class UpdateinfoXMLFileContext(MetadataFileContext):
         reboot_element = ElementTree.SubElement(update_element, 'reboot_suggested')
         reboot_element.text = str(erratum_unit.metadata['reboot_suggested'])
 
-        for key in ('title', 'release', 'rights', 'description', 'solution',
+        # these elements are optional
+        for key in ('title', 'release', 'rights', 'solution',
                     'severity', 'summary', 'pushcount'):
 
             value = erratum_unit.metadata.get(key)
 
             if not value:
                 continue
+
+            sub_element = ElementTree.SubElement(update_element, key)
+            sub_element.text = unicode(value)
+
+        # these elements must be present even if text is empty
+        for key in ('description',):
+
+            value = erratum_unit.metadata.get(key)
+            if value is None:
+                value = ''
 
             sub_element = ElementTree.SubElement(update_element, key)
             sub_element.text = unicode(value)


### PR DESCRIPTION
This resolves an issue where pulp could not sync an EPEL5 repo that had been
published by pulp. The upstream repository included an empty description
element, so the distributor was changed to produce XML with a similar empty
element.

https://bugzilla.redhat.com/show_bug.cgi?id=1138475
