### PR TITLE
Apply docs from pulp-2.4 that were missing.

### DIFF
--- a/docs/user-guide/configuration.rst
+++ b/docs/user-guide/configuration.rst
@@ -67,20 +67,3 @@ or ``update`` command using the following options respectively:
 * ``--feed-cert``
 * ``--feed-key``
 
-
-Certificate Revocation Lists
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Pulp supports the ability to honor Certificate Revocation Lists (CRLs).
-
-The directory in which CRLs are stored is configured through the
-``[crl] location`` attribute in ``/etc/pulp/repo_auth.conf``.
-
-CRLs must be named in a specific format. The name must be the CRL issuer's hash
-ending with the suffix of .r0, r1, etc.
-
-The recommended configuration is to copy the CRL to the specified CRL directory
-on the Pulp server as described above. Once the file is in place, create a symbolic
-link with the correct naming structure using the following command::
-
-  $ ln -s Example_CRL.pem `openssl crl -hash -noout -in Example_CRL.pem`.r0

--- a/docs/user-guide/release-notes/2.4.x.rst
+++ b/docs/user-guide/release-notes/2.4.x.rst
@@ -8,6 +8,11 @@ Pulp 2.4.0
 New Features
 ------------
 
+-  When a pulp_manifest.xml is added to kickstart repositories all of the additional files listed
+   in the manifest will be downloaded as part of the repo. The command line utility available
+   at pulp_rpm/playpen/yum_distributor/generate_distribution_manifest.py can be used to help with
+   creating the manifest file. This file should be stored as a peer of the treeinfo file in a source
+   repository that is being synced by Pulp.
  - Added the ability to generate sqlite repository metadata files as part of an RPM repo
    publish.
 
@@ -30,6 +35,8 @@ attributes can be found in the technical reference.
 
 Upgrade Instructions
 --------------------
+
+ - pulp_rpm has added a dependency on python-lxml for xml parsing
 
 Please see the
 `Pulp Platform upgrade instructions <https://pulp-user-guide.readthedocs.org/en/pulp-2.4/release-notes.html>`_

--- a/docs/user-guide/release-notes/index.rst
+++ b/docs/user-guide/release-notes/index.rst
@@ -6,6 +6,7 @@ Contents:
 .. toctree::
    :maxdepth: 2
 
+   2.4.x
    2.3.x
    2.2.x
    2.1.x


### PR DESCRIPTION
This commit adds the docs changes that were present in the pulp-2.4
branch that were not present in the 2.4-release branch. The patch was
generated with this command:

$ git diff 2.4-release..pulp-2.4 docs/
