### PR TITLE
1139888 - Document the default for validate.

### DIFF
--- a/docs/tech-reference/yum-plugins.rst
+++ b/docs/tech-reference/yum-plugins.rst
@@ -428,7 +428,7 @@ configuration values are optional.
 ``validate``
  If True, as the repository is synchronized the checksum of each file will be
  verified against the metadata's expectation. Valid values to this option are
- ``True`` and ``False``; defaults to ``True``.
+ ``True`` and ``False``; defaults to ``False``.
 
 ``max_downloads``
  Number of threads used when synchronizing the repository. This count controls


### PR DESCRIPTION
We had documented the incorrect default for an importer's validate
setting. This commit corrects the documentation.

https://bugzilla.redhat.com/show_bug.cgi?id=1139888
