### PR TITLE
workaround for BZ#1120215

### DIFF
--- a/plugins/pulp_rpm/plugins/importers/yum/repomd/metadata.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/repomd/metadata.py
@@ -93,6 +93,7 @@ class MetadataFiles(object):
                    'filelists', 'filelists_db',
                    'other', 'other_db',
                    'primary', 'primary_db',
+                   'deltainfo', 'susedata', # ignore those SUSE specific files, as there's no handling yet and just copying creates broken repos
                    'updateinfo', 'updateinfo_db'])
 
     def __init__(self, repo_url, dst_dir, nectar_config):


### PR DESCRIPTION
Ignore SUSE specific files for now, until those can be handled properly. While this is not nice, I can now (together with #568) import a SLES update channel, feed the published repo to zypper and it just works.

New PR for #527.
