### PR TITLE
set distribution filename to PULP_DISTRIBUTION.xml

### DIFF
--- a/common/pulp_rpm/common/constants.py
+++ b/common/pulp_rpm/common/constants.py
@@ -119,7 +119,7 @@ DISTRIBUTION_STORAGE_PATH = '/var/lib/pulp/content/distribution/'
 # During publish we need to lookup and make sure the treeinfo exists; since the treeinfo
 # can be '.treeinfo' or 'treeinfo' (in cdn case) we need to check which one exists
 TREE_INFO_LIST = ['.treeinfo', 'treeinfo']
-DISTRIBUTION_XML = '.pulp_distribution.xml'
+DISTRIBUTION_XML = 'PULP_DISTRIBUTION.xml'
 CONFIG_KEY_DISTRIBUTION_XML_FILE = 'pulp_distribution_xml_file'
 
 # Configuration constants for export distributors


### PR DESCRIPTION
change this to a filename that does not start with a "." since some upstream repos do not support hidden files.  
