### PR TITLE
1152633 - Pulp Yum plugin can now find consumer.conf settings correctly

### DIFF
--- a/handlers/usr/lib/yum-plugins/pulp-profile-update.py
+++ b/handlers/usr/lib/yum-plugins/pulp-profile-update.py
@@ -5,13 +5,12 @@ from rhsm.profile import get_profile
 from pulp.bindings.server import PulpConnection
 from pulp.bindings.bindings import Bindings
 from pulp.common.bundle import Bundle as BundleImpl
-from pulp.common.config import Config
+from pulp.client.consumer.config import read_config
 
 
 requires_api_version = '2.5'
 plugin_type = (TYPE_CORE,)
-cfg = Config('/etc/pulp/consumer/consumer.conf')
-cfg = cfg.graph()
+cfg = read_config()
 
 #
 # Pulp Integration
@@ -24,8 +23,8 @@ class Bundle(BundleImpl):
 
     def __init__(self):
         path = os.path.join(
-            cfg.filesystem.id_cert_dir,
-            cfg.filesystem.id_cert_filename)
+            cfg['filesystem']['id_cert_dir'],
+            cfg['filesystem']['id_cert_filename'])
         BundleImpl.__init__(self, path)
 
 
@@ -35,11 +34,11 @@ class PulpBindings(Bindings):
     """
 
     def __init__(self):
-        host = cfg.server.host
-        port = int(cfg.server.port)
+        host = cfg['server']['host']
+        port = int(cfg['server']['port'])
         cert = os.path.join(
-            cfg.filesystem.id_cert_dir,
-            cfg.filesystem.id_cert_filename)
+            cfg['filesystem']['id_cert_dir'],
+            cfg['filesystem']['id_cert_filename'])
         connection = PulpConnection(host, port, cert_filename=cert)
         Bindings.__init__(self, connection)
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1152633

This change adjusts the Pulp Yum plugin to use the read_config method. This area of the code has no test coverage I can find today, and with this small of a change I don't think this is worth writing test code for.

I tested the behavior, and the profile works as expected with this change.

There are 3 tests that do fail, but those are already broken in the parent of this commit. The broken parent is 59edf68e74d63298e63dcc70a00ca19ffd59be88.
