### PR TITLE
Fix broken unit test

### DIFF
--- a/plugins/test/unit/plugins/importers/yum/test_sync.py
+++ b/plugins/test/unit/plugins/importers/yum/test_sync.py
@@ -1068,7 +1068,7 @@ class TestTreeinfoSync(BaseSyncTest):
                                            mock_report, mock_parse_treefile, mock_get_treefile,
                                            mock_move, mock_chmod):
         mock_model = models.Distribution('fake family', 'server', '3.11', 'baroque', metadata={})
-        mock_parse_treefile.return_value = (mock_model, "fake files")
+        mock_parse_treefile.return_value = (mock_model, ["fake file 1"])
         mock_get_treefile.return_value = "/a/fake/path/to/the/treefile"
         treeinfo.sync(self.conduit, "http://some/url", "/some/tempdir", "fake-nectar-conf",
                       mock_report, lambda x: x)
@@ -1086,7 +1086,7 @@ class TestTreeinfoSync(BaseSyncTest):
         self.conduit.get_units.return_value = [mock_unit]
         self.conduit.init_unit = mock.MagicMock(spec_set=self.conduit.init_unit)
         self.conduit.init_unit.return_value = mock_unit
-        mock_parse_treefile.return_value = (mock_model, "fake files")
+        mock_parse_treefile.return_value = (mock_model, ["fake file 1"])
         mock_get_treefile.return_value = "/a/fake/path/to/the/treefile"
         treeinfo.sync(self.conduit, "http://some/url", "/some/tempdir", "fake-nectar-conf",
                       mock_report, lambda x: x)
@@ -1108,7 +1108,7 @@ class TestTreeinfoSync(BaseSyncTest):
         self.conduit.get_units.return_value = [mock_unit, mock_unit_old]
         self.conduit.init_unit = mock.MagicMock(spec_set=self.conduit.init_unit)
         self.conduit.init_unit.return_value = mock_unit
-        mock_parse_treefile.return_value = (mock_model, "fake files")
+        mock_parse_treefile.return_value = (mock_model, ["fake file 1"])
         mock_get_treefile.return_value = "/a/fake/path/to/the/treefile"
         treeinfo.sync(self.conduit, "http://some/url", "/some/tempdir", "fake-nectar-conf",
                       mock_report, lambda x: x)


### PR DESCRIPTION
This unit test worked in 2.4-\* branches but not 2.5+. Newer versions of Pulp do
additional parsing of the output of parse_treeinfo and require a mock with more
verisimilitude.
