### PR TITLE
1153378 - remove SSLInsecureRenegotation from pulp_rpm.conf

### DIFF
--- a/docs/user-guide/release-notes/2.5.x.rst
+++ b/docs/user-guide/release-notes/2.5.x.rst
@@ -1,0 +1,18 @@
+======================
+Pulp 2.5 Release Notes
+======================
+
+Pulp 2.5.1
+==========
+
+Bug Fixes
+---------
+
+The 2.5.1 release is a minor bugfix release. You can see the list of bugs that were fixed
+`here <https://bugzilla.redhat.com/buglist.cgi?bug_status=VERIFIED&bug_status=RELEASE_PENDING&bug_status=CLOSED&classification=Community&component=iso-support&component=rpm-support&list_id=2768109&product=Pulp&query_format=advanced&target_release=2.5.1>`_.
+
+`Bug #1153378 <https://bugzilla.redhat.com/show_bug.cgi?id=1153378>`_ was addressed in 2.5.1. If
+you have older (circa 2009) yum clients that fail in a way similar to what is described
+`in this bug <https://bugzilla.redhat.com/show_bug.cgi?id=647828#c1>`_, you may want to temporarily
+re-enable ``SSLInsecureRenegotation`` under ``/etc/httpd/conf.d/pulp_rpm.conf`` until your client
+systems have been updated.

--- a/docs/user-guide/release-notes/index.rst
+++ b/docs/user-guide/release-notes/index.rst
@@ -6,6 +6,7 @@ Contents:
 .. toctree::
    :maxdepth: 2
 
+   2.5.x
    2.4.x
    2.3.x
    2.2.x

--- a/plugins/etc/httpd/conf.d/pulp_rpm.conf
+++ b/plugins/etc/httpd/conf.d/pulp_rpm.conf
@@ -16,9 +16,6 @@
 AddType application/x-pkcs7-crl .crl
 AddType application/x-x509-ca-cert .crt
 
-# allow older yum clients to connect, see bz 647828
-SSLInsecureRenegotiation on
-
 # -- HTTPS Repositories ---------
 Alias /pulp/repos /var/www/pub/yum/https/repos
 


### PR DESCRIPTION
This setting was enabled for older clients but is no longer needed. Clients
updated after 2010 should not need this flag.

Further documentation on this issue is in the BZ.
