### PR TITLE
1146294 - do not import pulp.bindings.server to get DEFAULT_CA_PATH

### DIFF
--- a/handlers/pulp_rpm/handlers/repolib.py
+++ b/handlers/pulp_rpm/handlers/repolib.py
@@ -9,7 +9,7 @@ entirely on the consumer.
 from logging import getLogger
 import os
 
-from pulp.bindings.server import DEFAULT_CA_PATH
+from pulp.common.constants import DEFAULT_CA_PATH
 from pulp.common.lock import Lock
 from pulp.common.util import decode_unicode
 

--- a/handlers/test/unit/handlers/test_repolib.py
+++ b/handlers/test/unit/handlers/test_repolib.py
@@ -2,7 +2,7 @@ import os
 import shutil
 import unittest
 
-from pulp.bindings.server import DEFAULT_CA_PATH
+from pulp.common.constants import DEFAULT_CA_PATH
 from pulp.common.lock import Lock
 
 from pulp_rpm.handlers import repolib


### PR DESCRIPTION
The katello agent should not require the pulp bindings to be installed to
access this constant.
