### PR TITLE
Add support for extlinks

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,6 +16,13 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #sys.path.insert(0, os.path.abspath('.'))
 
+# this var should refer to where intersphinx should pull inv files from. For
+# example, this would be set to '2.6-release' for the 2.6 branches, which would
+# pull objects.inv from http://pulp.readthedocs.org/en/2.6-release/objects.inv.
+# For master, this should point to 'latest'.
+
+rtd_builder = 'latest'
+
 # -- General configuration -----------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
@@ -23,7 +30,7 @@
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.intersphinx']
+extensions = ['sphinx.ext.intersphinx', 'sphinx.ext.extlinks']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -239,6 +246,11 @@ texinfo_documents = [
 # How to display URL addresses: 'footnote', 'no', or 'inline'.
 #texinfo_show_urls = 'footnote'
 
-# Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {'python': ('http://docs.python.org/2.7/', None),
-                       'pulp': ('http://pulp.readthedocs.org/en/latest', None)}
+                       'platform': (("http://pulp.readthedocs.org/en/%s/" % rtd_builder), None)}
+
+extlinks = {'bz': ('https://bugzilla.redhat.com/show_bug.cgi?id=%s', 'RHBZ #'),
+            'fixedbugs': ('https://bugzilla.redhat.com/buglist.cgi?bug_status=VERIFIED'\
+                          '&bug_status=RELEASE_PENDING&bug_status=CLOSED&classificatio'\
+                          'n=Community&component=iso-support&component=rpm-support&lis'\
+                          't_id=2768109&product=Pulp&version=%s', None)}

--- a/docs/user-guide/index.rst
+++ b/docs/user-guide/index.rst
@@ -13,3 +13,4 @@ User Guide
    features
    isos
    faq
+   troubleshooting

--- a/docs/user-guide/installation.rst
+++ b/docs/user-guide/installation.rst
@@ -2,9 +2,9 @@ Installation
 ============
 
 .. note::
-  If you followed the Pulp :ref:`installation <pulp:server_installation>` instructions
-  you already have RPM features installed. If not, this document will walk you
-  through the installation.
+  If you followed the Pulp :ref:`installation <platform:server_installation>`
+  instructions you already have RPM features installed. If not, this document
+  will walk you through the installation.
 
 Prerequisites
 -------------

--- a/docs/user-guide/release-notes/2.1.x.rst
+++ b/docs/user-guide/release-notes/2.1.x.rst
@@ -20,18 +20,17 @@ worry about finding and retrieving the RPMs referenced by each group.
 Noteworthy Bugs Fixed
 ---------------------
 
-`873313 <https://bugzilla.redhat.com/show_bug.cgi?id=873313>`_ - Very high memory usage during repo sync
+:bz:`873313` - Very high memory usage during repo sync
 
-`947208 <https://bugzilla.redhat.com/show_bug.cgi?id=947208>`_ - RFE: Add proxy server support to the ISO
-importer
+:bz:`947208` - RFE: Add proxy server support to the ISO importer
 
-`949004 <https://bugzilla.redhat.com/show_bug.cgi?id=949004>`_ - The ISO Importer does not build the URL for the
-PULP_MANIFEST correctly
+:bz:`949004` - The ISO Importer does not build the URL for the PULP_MANIFEST
+correctly
 
-`949008 <https://bugzilla.redhat.com/show_bug.cgi?id=949008>`_ - The ISO importer set the SSL_VERIFY_HOST value
-to 1, when it should be 2
+:bz:`949008` - The ISO importer set the SSL_VERIFY_HOST value to 1, when it
+should be 2
 
-`953665 <https://bugzilla.redhat.com/show_bug.cgi?id=953665>`_ - Copying large repo uses tons of RAM and takes too long
+:bz:`953665` - Copying large repo uses tons of RAM and takes too long
 
 Upgrade Instructions
 --------------------

--- a/docs/user-guide/release-notes/2.2.x.rst
+++ b/docs/user-guide/release-notes/2.2.x.rst
@@ -115,14 +115,12 @@ Pulp 2.2.1
 ==========
 
 Multiple proxy-related issues related to authentication and HTTPS to the proxy
-were fixed in
-`1022662 <https://bugzilla.redhat.com/show_bug.cgi?id=1022662>`_ and
-`1014368 <https://bugzilla.redhat.com/show_bug.cgi?id=1014368>`_.
+were fixed in :bz:`1022662` and :bz:`1014368`.
 
-A `version comparison bug <https://bugzilla.redhat.com/show_bug.cgi?id=1026907>`_
-that caused recursive copies to not copy all dependencies was fixed.
+A :bz:`version comparison bug <1026907>` that caused recursive copies to not
+copy all dependencies was fixed.
 
-A race condition with XML namespace parsing `was fixed <https://bugzilla.redhat.com/show_bug.cgi?id=1019865>`_.
+A race condition with XML namespace parsing :bz:`was fixed <1019865>`.
 
 Several ISO-related bugs were fixed. They can be seen in the list of
-`all fixed bugs <https://bugzilla.redhat.com/buglist.cgi?bug_status=VERIFIED&classification=Community&product=Pulp&query_format=advanced&target_release=2.2.1>`_
+:fixedbugs:`all fixed bugs <2.2.1>`.

--- a/docs/user-guide/release-notes/2.3.x.rst
+++ b/docs/user-guide/release-notes/2.3.x.rst
@@ -30,14 +30,14 @@ Client Changes
 Notable Bug Fixes
 -----------------
 
--  In some cases, `repo groups were displayed with a translated name only
-   <https://bugzilla.redhat.com/show_bug.cgi?id=1021656>`_. This is fixed in 2.3,
+-  In some cases, :bz:`repo groups were displayed with a translated name only
+   <1021656>`. This is fixed in 2.3,
    but a re-sync is required of any affected repository.
 
--  Consumers are `now notified <https://bugzilla.redhat.com/show_bug.cgi?id=975980>`_
+-  Consumers are :bz:`now notified <975980>`
    when the relative path of a bound repository is changed.
 
--  It is now `far more intuitive <https://bugzilla.redhat.com/show_bug.cgi?id=979587>`_
+-  It is now :bz:`far more intuitive <979587>`
    to update all packages on a consumer from ``pulp-admin``.
 
 
@@ -45,7 +45,7 @@ All Bugs
 --------
 
 You can see the complete list of over 100 bugs that were
-`fixed in Pulp 2.3.0 <https://bugzilla.redhat.com/buglist.cgi?bug_status=VERIFIED&classification=Community&list_id=1927252&product=Pulp&query_format=advanced&target_release=2.3.0>`_.
+:fixedbugs:`fixed in Pulp 2.3.0 <2.3.0>`.
 
 
 Known Issues
@@ -62,10 +62,10 @@ Pulp 2.3.1
 Bugs Fixed
 ----------
 
-- `SRPM copy <https://bugzilla.redhat.com/show_bug.cgi?id=1045100>`_ is now supported
+- :bz:`SRPM copy <1045100>` is now supported
   by ``pulp-admin``.
 
-- REST API clients could `see incorrect behavior <https://bugzilla.redhat.com/show_bug.cgi?id=1038309>`_
+- REST API clients could :bz:`see incorrect behavior <1038309>`
   if using a ``distributor_id`` value different from the ``distributor_type_id``
   when adding a distributor to a repository. This issue did not affect users who
   only use ``pulp-admin`` to interact with the REST API.

--- a/docs/user-guide/release-notes/2.4.x.rst
+++ b/docs/user-guide/release-notes/2.4.x.rst
@@ -9,7 +9,7 @@ Bug Fixes
 ---------
 
 The 2.4.2 release is a minor bugfix release. You can see the list of bugs that were fixed
-`here <https://bugzilla.redhat.com/buglist.cgi?bug_status=VERIFIED&bug_status=RELEASE_PENDING&bug_status=CLOSED&classification=Community&component=iso-support&component=rpm-support&list_id=2768109&product=Pulp&query_format=advanced&target_release=2.4.2>`_.
+:fixedbugs:`here <2.4.2>`.
 
 Pulp 2.4.1
 ==========
@@ -28,7 +28,7 @@ Bug Fixes
 ---------
 
 The 2.4.1 release is a minor bugfix release. You can see the list of bugs that were fixed
-`here <https://bugzilla.redhat.com/buglist.cgi?bug_status=VERIFIED&bug_status=RELEASE_PENDING&bug_status=CLOSED&classification=Community&component=iso-support&component=rpm-support&list_id=2768109&product=Pulp&query_format=advanced&target_release=2.4.1>`_.
+:fixedbugs:`here <2.4.1>`.
 
 Upgrade Instructions
 --------------------
@@ -53,7 +53,7 @@ Pulp 2.4.0
 New Features
 ------------
 
--  When a pulp_manifest.xml is added to kickstart repositories all of the additional files listed
+ - When a pulp_manifest.xml is added to kickstart repositories all of the additional files listed
    in the manifest will be downloaded as part of the repo. The command line utility available
    at pulp_rpm/playpen/yum_distributor/generate_distribution_manifest.py can be used to help with
    creating the manifest file. This file should be stored as a peer of the treeinfo file in a source

--- a/docs/user-guide/release-notes/2.5.x.rst
+++ b/docs/user-guide/release-notes/2.5.x.rst
@@ -9,10 +9,10 @@ Bug Fixes
 ---------
 
 The 2.5.1 release is a minor bugfix release. You can see the list of bugs that were fixed
-`here <https://bugzilla.redhat.com/buglist.cgi?bug_status=VERIFIED&bug_status=RELEASE_PENDING&bug_status=CLOSED&classification=Community&component=iso-support&component=rpm-support&list_id=2768109&product=Pulp&query_format=advanced&target_release=2.5.1>`_.
+:fixedbugs:`here <2.5.1>`.
 
-`Bug #1153378 <https://bugzilla.redhat.com/show_bug.cgi?id=1153378>`_ was addressed in 2.5.1. If
+:bz:`1153378` was addressed in 2.5.1. If
 you have older (circa 2009) yum clients that fail in a way similar to what is described
-`in this bug <https://bugzilla.redhat.com/show_bug.cgi?id=647828#c1>`_, you may want to temporarily
+:bz:`in this bug <647828#c1>`, you may want to temporarily
 re-enable ``SSLInsecureRenegotation`` under ``/etc/httpd/conf.d/pulp_rpm.conf`` until your client
 systems have been updated.


### PR DESCRIPTION
This commit adds support for extlinks, which has been used to condense BZ links
as well as link to documents in platform. Extlinks is preferred if you need to
link to an entire URL instead of to a specific ref.

Some sphinx build warnings have also been addressed.
