### PR TITLE
Adds troublesooting section, and adds release notes to index

### DIFF
--- a/docs/user-guide/conf.py
+++ b/docs/user-guide/conf.py
@@ -39,7 +39,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Pulp RPM Support'
-copyright = u'2012-2013, Pulp Team'
+copyright = u'2012-2014, Pulp Team'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/user-guide/index.rst
+++ b/docs/user-guide/index.rst
@@ -15,6 +15,7 @@ Contents:
    features
    isos
    faq
+   troubleshooting
 
 
 Indices and tables

--- a/docs/user-guide/release-notes/2.5.x.rst
+++ b/docs/user-guide/release-notes/2.5.x.rst
@@ -13,6 +13,5 @@ The Alternate Content Source feature now works during an rpm sync.
 Bug Fixes
 ---------
 
-You can see the list of bugs that were fixed
-
-:fixedbugs:`here <2.5.0>`.
+You can see the list of
+`bugs that were fixed <https://bugzilla.redhat.com/buglist.cgi?bug_status=VERIFIED&bug_status=RELEASE_PENDING&bug_status=CLOSED&classification=Community&component=iso-support&component=rpm-support&list_id=2768109&product=Pulp&query_format=advanced&target_release=2.5.0>`_.

--- a/docs/user-guide/release-notes/index.rst
+++ b/docs/user-guide/release-notes/index.rst
@@ -6,6 +6,7 @@ Contents:
 .. toctree::
    :maxdepth: 2
 
+   2.5.x
    2.4.x
    2.3.x
    2.2.x


### PR DESCRIPTION
Adds troubleshooting section and release note to index.
Fixes link to bugzilla. :fixme wasn't introduced until  a later version.
Bumps copyright to 2014
