### PR TITLE
1158945 - Pulp can now publish RPM packages with descriptions containing unicode characters.

### DIFF
--- a/plugins/pulp_rpm/plugins/distributors/yum/metadata/filelists.py
+++ b/plugins/pulp_rpm/plugins/distributors/yum/metadata/filelists.py
@@ -40,4 +40,6 @@ class FilelistsXMLFileContext(FastForwardXmlFileContext):
         :type  unit: pulp.plugins.model.Unit
         """
         metadata = unit.metadata['repodata']['filelists']
+        if isinstance(metadata, unicode):
+            metadata = metadata.encode(encoding='utf-8')
         self.metadata_file_handle.write(metadata)

--- a/plugins/pulp_rpm/plugins/distributors/yum/metadata/other.py
+++ b/plugins/pulp_rpm/plugins/distributors/yum/metadata/other.py
@@ -40,4 +40,6 @@ class OtherXMLFileContext(FastForwardXmlFileContext):
         :type  unit: pulp.plugins.model.Unit
         """
         metadata = unit.metadata['repodata']['other']
+        if isinstance(metadata, unicode):
+            metadata = metadata.encode(encoding='utf-8')
         self.metadata_file_handle.write(metadata)

--- a/plugins/pulp_rpm/plugins/distributors/yum/metadata/primary.py
+++ b/plugins/pulp_rpm/plugins/distributors/yum/metadata/primary.py
@@ -52,4 +52,6 @@ class PrimaryXMLFileContext(FastForwardXmlFileContext):
         :type  unit: pulp.plugins.model.Unit
         """
         metadata = unit.metadata['repodata']['primary']
+        if isinstance(metadata, unicode):
+            metadata = metadata.encode(encoding='utf-8')
         self.metadata_file_handle.write(metadata)

--- a/plugins/test/unit/plugins/distributors/yum/metadata/test_filelists.py
+++ b/plugins/test/unit/plugins/distributors/yum/metadata/test_filelists.py
@@ -28,3 +28,16 @@ class FilelistsXMLFileContextTests(unittest.TestCase):
 
         context.metadata_file_handle.write.assert_called_once_with('bar')
 
+    def test_add_unit_metadata_unicode(self):
+        """
+        Test that the filelists repodata is passed as a str even if it's a unicode object.
+        """
+        context = FilelistsXMLFileContext(self.working_dir, 3)
+        context.metadata_file_handle = mock.Mock()
+        expected_call = 'some unicode'
+        metadata = {
+            'repodata': {'filelists': unicode(expected_call)}
+        }
+
+        context.add_unit_metadata(mock.Mock(metadata=metadata))
+        context.metadata_file_handle.write.assert_called_once_with(expected_call)

--- a/plugins/test/unit/plugins/distributors/yum/metadata/test_other.py
+++ b/plugins/test/unit/plugins/distributors/yum/metadata/test_other.py
@@ -25,3 +25,14 @@ class PrimaryXMLFileContextTests(unittest.TestCase):
         self.context.add_unit_metadata(mock.Mock(metadata={'repodata': {'other': 'bar'}}))
         self.context.metadata_file_handle.write.assert_called_once_with('bar')
 
+    def test_add_unit_metadata_unicode(self):
+        """
+        Test that the other repodata is passed as a str even if it's a unicode object.
+        """
+        self.context.metadata_file_handle = mock.Mock()
+        expected_call = 'some unicode'
+        metadata = {
+            'repodata': {'other': unicode(expected_call)}
+        }
+        self.context.add_unit_metadata(mock.Mock(metadata=metadata))
+        self.context.metadata_file_handle.write.assert_called_once_with(expected_call)

--- a/plugins/test/unit/plugins/distributors/yum/metadata/test_primary.py
+++ b/plugins/test/unit/plugins/distributors/yum/metadata/test_primary.py
@@ -25,3 +25,14 @@ class PrimaryXMLFileContextTests(unittest.TestCase):
         self.context.add_unit_metadata(mock.Mock(metadata={'repodata': {'primary': 'bar'}}))
         self.context.metadata_file_handle.write.assert_called_once_with('bar')
 
+    def test_add_unit_metadata_unicode(self):
+        """
+        Test that the primary repodata is passed as a str even if it's a unicode object.
+        """
+        self.context.metadata_file_handle = mock.Mock()
+        expected_call = 'some unicode'
+        metadata = {
+            'repodata': {'primary': unicode(expected_call)}
+        }
+        self.context.add_unit_metadata(mock.Mock(metadata=metadata))
+        self.context.metadata_file_handle.write.assert_called_once_with(expected_call)


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1158945
