### PR TITLE
1171280 - ensure packages are available when calculating applicability

### DIFF
--- a/plugins/pulp_rpm/plugins/migrations/0018_remove_old_repo_profile_applicability.py
+++ b/plugins/pulp_rpm/plugins/migrations/0018_remove_old_repo_profile_applicability.py
@@ -1,0 +1,28 @@
+"""
+There is a bug[1] related to errata applicability where extra errata were being
+applied. While newly generated errata applicability will not have this bug, the
+older incorrect cached data needs to be removed.
+
+[1] https://bugzilla.redhat.com/show_bug.cgi?id=1171280
+
+"""
+from gettext import gettext as _
+import logging
+
+from pulp.server.db import connection
+
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(*args, **kwargs):
+    """
+    Remove the repo_profile_applicability collection.
+
+    :param args:   Unused
+    :type  args:   list
+    :param kwargs: Unused
+    :type  kwargs: dict
+    """
+    rpa_collection = connection.get_collection('repo_profile_applicability')
+    rpa_collection.drop()

--- a/plugins/test/unit/plugins/migrations/test_0018_remove_old_repo_profile_applicability.py
+++ b/plugins/test/unit/plugins/migrations/test_0018_remove_old_repo_profile_applicability.py
@@ -1,0 +1,31 @@
+"""
+This module contains unit tests for
+pulp_rpm.plugins.migrations.0018_remove_old_repo_profile_applicability.
+
+"""
+import unittest
+
+from pulp.server.db.migrate.models import _import_all_the_way
+import mock
+
+migration = _import_all_the_way('pulp_rpm.plugins.migrations.0018_remove_old_'
+                                'repo_profile_applicability')
+
+
+class TestMigrate(unittest.TestCase):
+    """
+    Test the migrate() function.
+    """
+    @mock.patch('pulp_rpm.plugins.migrations.0018_remove_old_repo_profile_applicability.'
+                'connection.get_collection')
+    def test_calls_correct_functions(self, get_collection):
+        """
+        Assert that migrate() drops the collection it should
+        """
+        fake_rpa = mock.Mock()
+        get_collection.return_value = fake_rpa
+
+        migration.migrate()
+
+        get_collection.assert_called_once_with('repo_profile_applicability')
+        fake_rpa.drop.assert_called_once_with()


### PR DESCRIPTION
Previously, errata calculation only checked the consumer's installed packages
against the packages listed in the erratum to determine if the erratum was
applicable.

For example, if package "foo 1.1" was in an erratum's package list and the
consumer had "foo 1.0" installed, the erratum would show as outstanding even if
"foo 1.1" was not available. This is exacerbated when an erratum lists packages
for multiple distributions like RHEL6 and RHEL7; a RHEL6 consumer may see
packages that need to be applied that they do not have access to.

This patch alters the applicability calculation behavior. The list of
applicable packages in the erratum are filtered against the NEVRAs of packages
in the repo before applicability calculations are made.

A migration has been added to drop the `repo_profile_applicability` collection.
This contains incorrect data; dropping it will ensure that applicability is
re-calculated and cached again upon request.
