### PR TITLE
1175616 - Remove the index on the title field from erratum units

### DIFF
--- a/plugins/types/rpm_support.json
+++ b/plugins/types/rpm_support.json
@@ -26,7 +26,7 @@
         "unit_key" :
                 ["id"],
         "search_indexes" : [
-            "id", "title", "version", "release", "type",
+            "id",  "version", "release", "type",
             "status", "updated", "issued", "severity", "references"
         ],
         "referenced_types" : ["rpm"]


### PR DESCRIPTION
This is because the title index is not used for internal pulp queries and is causing errors during syncing for erratum with long titles.  