### PR TITLE
1147078 - fix error reporting for treeinfo files

### DIFF
--- a/extensions_admin/pulp_rpm/extensions/admin/status.py
+++ b/extensions_admin/pulp_rpm/extensions/admin/status.py
@@ -151,9 +151,9 @@ class RpmStatusRenderer(StatusRenderer):
                     error = data['error_details'][i]
 
                     message_data = {
-                        'filename' : error[0],
-                        'message' : error[1]['error_message'],
-                        'code' : error[1]['error_code'],
+                        'filename': error[0],
+                        'message': error[1].get('error_message'),
+                        'code': error[1].get('error_code'),
                     }
 
                     template  = 'File: %(filename)s\n'

--- a/plugins/pulp_rpm/plugins/importers/yum/parse/treeinfo.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/parse/treeinfo.py
@@ -92,7 +92,8 @@ def sync(sync_conduit, feed, working_dir, nectar_config, report, progress_callba
         else:
             _LOGGER.error('some distro file downloads failed')
             report['state'] = constants.STATE_FAILED
-            report['error_details'] = [(fail.url, fail.error_report) for fail in listener.failed_reports]
+            report['error_details'] = [(fail.url, {'error_message': fail.error_msg})
+                                       for fail in listener.failed_reports]
             return
         report['state'] = constants.STATE_COMPLETE
     finally:


### PR DESCRIPTION
[bz - 1147078](https://bugzilla.redhat.com/show_bug.cgi?id=1147078)

If a treeinfo file pointed to nonexistent files, pulp-admin failed.

This is addressed in two ways. First, I put the needed information in "error_details". Secondly, I made the error message and error code more flexible by using .get() to prevent similar issues from breaking pulp-admin.