### PR TITLE
1147078 - fix error reporting for treeinfo files

### DIFF
--- a/extensions_admin/pulp_rpm/extensions/admin/status.py
+++ b/extensions_admin/pulp_rpm/extensions/admin/status.py
@@ -151,9 +151,9 @@ class RpmStatusRenderer(StatusRenderer):
                     error = data['error_details'][i]
 
                     message_data = {
-                        'filename' : error[0],
-                        'message' : error[1]['error_message'],
-                        'code' : error[1]['error_code'],
+                        'filename': error[0],
+                        'message': error[1].get('error_message'),
+                        'code': error[1].get('error_code'),
                     }
 
                     template  = 'File: %(filename)s\n'

--- a/extensions_admin/test/unit/extensions/admin/test_status.py
+++ b/extensions_admin/test/unit/extensions/admin/test_status.py
@@ -45,3 +45,48 @@ class RpmStatusRendererTests(client_base.PulpClientTests):
                         self.prompt.render_failure_message.mock_calls[0][1][0])
         self.assertTrue('invalid checksum type (non_existing_checksum)' in \
                         self.prompt.render_failure_message.mock_calls[1][1][0])
+
+    def test_render_distribution_sync_step_with_error(self):
+        """
+        Assert that the expected messages are passed to render_failure_message in the event of a
+        failed state.
+        """
+        self.prompt.render_failure_message = mock.MagicMock()
+        error1 = ('mock_filename', {'error_message': 'mock_message', 'error_code': 'mock_code'})
+
+        progress_report = {'yum_importer': {
+            'distribution': {'state': constants.STATE_FAILED, 'error_details': [error1]}
+        }}
+
+        renderer = status.RpmStatusRenderer(self.context)
+
+        renderer.render_distribution_sync_step(progress_report)
+        expected_message = 'File: mock_filename\n'\
+                           'Error Code:   mock_code\n'\
+                           'Error Message: mock_message'
+
+        self.prompt.render_failure_message.assert_has_calls(mock.call(expected_message))
+
+    def test_render_distribution_sync_step_with_errors_with_missing_information(self):
+        """
+        Covers bugfix 1147078, tests that errors that do not have an error message or error code
+        do not crash the sync.
+        """
+        self.prompt.render_failure_message = mock.MagicMock()
+
+        # Incomplete error raised a KeyError
+        error1 = ('mock_filename', {})
+
+        progress_report = {'yum_importer': {
+            'distribution': {'state': constants.STATE_FAILED, 'error_details': [error1]}
+        }}
+
+        renderer = status.RpmStatusRenderer(self.context)
+
+        renderer.render_distribution_sync_step(progress_report)
+        expected_message = 'File: mock_filename\n'\
+                           'Error Code:   None\n'\
+                           'Error Message: None'
+
+        self.prompt.render_failure_message.assert_has_calls(mock.call(expected_message))
+


### PR DESCRIPTION
[bz - 1147078](https://bugzilla.redhat.com/show_bug.cgi?id=1147078)

If a treeinfo file pointed to nonexistent files, pulp-admin failed.

This is addressed in two ways. First, I put the needed information in "error_details". Secondly, I made the error message and error code more flexible by using .get() to prevent similar issues from breaking pulp-admin.

Now against 2.6 rather than [master](https://github.com/pulp/pulp_rpm/pull/621)