### PR TITLE
1171278 - update erratum when a new packagelist is encountered

### DIFF
--- a/plugins/pulp_rpm/plugins/importers/yum/sync.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/sync.py
@@ -8,7 +8,7 @@ from gettext import gettext as _
 from pulp.common.plugins import importer_constants
 from pulp.plugins.util import nectar_config as nectar_utils, verification
 
-from pulp_rpm.common import constants
+from pulp_rpm.common import constants, ids
 from pulp_rpm.plugins.db import models
 from pulp_rpm.plugins.importers.yum import existing, purge
 from pulp_rpm.plugins.importers.yum.repomd import metadata, primary, packages, updateinfo, presto, group
@@ -463,8 +463,8 @@ class RepoSync(object):
             _logger.debug('updateinfo not found')
             return
         try:
-            self.save_fileless_units(errata_file_handle, updateinfo.PACKAGE_TAG, updateinfo.process_package_element)
-
+            self.save_fileless_units(errata_file_handle, updateinfo.PACKAGE_TAG,
+                                     updateinfo.process_package_element, additive_type=True)
         finally:
             errata_file_handle.close()
 
@@ -494,7 +494,8 @@ class RepoSync(object):
         finally:
             group_file_handle.close()
 
-    def save_fileless_units(self, file_handle, tag, process_func, mutable_type=False):
+    def save_fileless_units(self, file_handle, tag, process_func, mutable_type=False,
+                                                                  additive_type=False):
         """
         Generic method for saving units parsed from a repo metadata file where
         the units do not have files to store on disk. For example, groups.
@@ -513,14 +514,25 @@ class RepoSync(object):
                                 useful for units like group and category which
                                 don't have a version, but could change
         :type  mutable_type:    bool
+        :param additive_type:   iff True, units will be updated instead of
+                                replaced. For example, if you wanted to save an
+                                errata and concatenate its package list with an
+                                existing errata, you'd set this. Note that mutable_type
+                                and additive_type are mutually exclusive.
+        :type  additive_type:   bool
         """
+
+        if mutable_type and additive_type:
+            raise RuntimeError("The mutable_type and additive_type arguments for this method are"
+                               " mutually exclusive.")
+
         # iterate through the file and determine what we want to have
         package_info_generator = packages.package_list_generator(file_handle,
                                                                  tag,
                                                                  process_func)
         # if units aren't mutable, we don't need to attempt saving units that
         # we already have
-        if not mutable_type:
+        if not mutable_type and not additive_type:
             wanted = (model.as_named_tuple for model in package_info_generator)
             # given what we want, filter out what we already have
             to_save = existing.check_repo(wanted, self.sync_conduit.get_units)
@@ -534,7 +546,51 @@ class RepoSync(object):
 
         for model in package_info_generator:
             unit = self.sync_conduit.init_unit(model.TYPE, model.unit_key, model.metadata, None)
+            if additive_type:
+                existing_unit = self.sync_conduit.find_unit_by_unit_key(model.TYPE, model.unit_key)
+                if existing_unit:
+                    unit = self._concatenate_units(existing_unit, unit)
+
             self.sync_conduit.save_unit(unit)
+
+    def _concatenate_units(self, existing_unit, new_unit):
+        """
+        Perform unit concatenation.
+
+        :param existing_unit: The unit that is already in the DB
+        :type  existing_unit: pulp.plugins.model.Unit
+
+        :param new_unit: The unit we are combining with the existing unit
+        :type  new_unit: pulp.plugins.model.Unit
+        """
+        if existing_unit.type_id != new_unit.type_id:
+            raise RuntimeError("Cannot concatenate two units of different types. Tried to "
+                               "concatenate %s with %s" % (existing_unit.type_id, new_unit.type_id))
+
+        if existing_unit.unit_key != new_unit.unit_key:
+            raise RuntimeError("Concatenated units must have the same unit key. "
+                               "Tried to concatenate %s with %s" %
+                               (existing_unit.unit_key, new_unit.unit_key))
+
+        if existing_unit.type_id == ids.TYPE_ID_ERRATA:
+            # start with the package list we have in existing_unit
+            package_lists = existing_unit.metadata['pkglist']
+
+            # add in anything from new_unit that we don't already have. We key
+            # package lists by name for this concatenation.
+            new_package_lists = []
+            existing_package_list_names = [p['name'] for p in existing_unit.metadata['pkglist']]
+
+            for possible_new_pkglist in new_unit.metadata['pkglist']:
+                if possible_new_pkglist['name'] not in existing_package_list_names:
+                    existing_unit.metadata['pkglist'] += [possible_new_pkglist]
+        else:
+            raise NotImplementedError("Concatenation of unit type %s is not supported" %
+                                      existing_unit.type_id)
+
+        # return the unit now that we've possibly modified it.
+        return existing_unit
+
 
     def finalize(self):
         """

--- a/plugins/test/unit/plugins/importers/yum/model_factory.py
+++ b/plugins/test/unit/plugins/importers/yum/model_factory.py
@@ -182,7 +182,7 @@ def errata_models(num):
             del r['checksumtype']
         ret.append(models.Errata(
             'name-%d' % count,
-            {'pkglist': [{'packages': rpms}]}
+            {'pkglist': [{'packages': rpms, 'name': 'somerepo-%d' % count}]}
         ))
         count = _errata_counter.next()
     return ret

--- a/plugins/test/unit/plugins/importers/yum/test_sync.py
+++ b/plugins/test/unit/plugins/importers/yum/test_sync.py
@@ -696,7 +696,8 @@ class TestGetErrata(BaseSyncTest):
         mock_save.assert_called_once_with(self.reposync,
                                           mock_get.return_value,
                                           updateinfo.PACKAGE_TAG,
-                                          updateinfo.process_package_element)
+                                          updateinfo.process_package_element,
+                                          additive_type=True)
 
 
 class TestGetCompsFileUnits(BaseSyncTest):
@@ -755,11 +756,16 @@ class TestGetCompsFileUnits(BaseSyncTest):
 
 
 class TestSaveFilelessUnits(BaseSyncTest):
+
     @mock.patch('pulp_rpm.plugins.importers.yum.existing.check_repo', autospec=True)
     @mock.patch('pulp_rpm.plugins.importers.yum.repomd.packages.package_list_generator', autospec=True)
-    def test_save_erratas_none_existing(self, mock_generator, mock_check_repo):
+    def test_save_fileless_units(self, mock_generator, mock_check_repo):
         """
-        test where no errata already exist, so all should be saved
+        test the "base" use case for save_fileless_units.
+
+        Note that we are using errata as the unit here, but errata are typically
+        saved with "additive_type" set to True.
+
         """
         errata = tuple(model_factory.errata_models(3))
         mock_generator.return_value = errata
@@ -781,31 +787,109 @@ class TestSaveFilelessUnits(BaseSyncTest):
         self.conduit.save_unit.assert_any_call(self.conduit.init_unit.return_value)
         self.assertEqual(self.conduit.save_unit.call_count, 3)
 
-    @mock.patch('pulp_rpm.plugins.importers.yum.existing.check_repo', autospec=True)
-    @mock.patch('pulp_rpm.plugins.importers.yum.repomd.packages.package_list_generator', autospec=True)
-    def test_save_erratas_some_existing(self, mock_generator, mock_check_repo):
+    def test_save_fileless_units_bad_args(self):
         """
-        test where some errata already exist, so only some should be saved
+        Ensure that an error is raised if save_fileless_units is called with
+        mutually exclusive args
+        """
+        self.assertRaises(RuntimeError, self.reposync.save_fileless_units,
+                          None, None, None, mutable_type=True, additive_type=True)
+
+    @mock.patch('pulp_rpm.plugins.importers.yum.repomd.packages.'
+                'package_list_generator', autospec=True)
+    @mock.patch('pulp.plugins.conduits.mixins.SearchUnitsMixin.'
+                'find_unit_by_unit_key', autospec=True)
+    @mock.patch('pulp_rpm.plugins.importers.yum.sync.RepoSync._concatenate_units', autospec=True)
+    def test_save_erratas_none_existing(self, mock_concat, mock_find_unit, mock_generator):
+        """
+        test where no errata already exist, so all should be saved
         """
         errata = tuple(model_factory.errata_models(3))
         mock_generator.return_value = errata
-        mock_check_repo.return_value = [g.as_named_tuple for g in errata[:2]]
         self.conduit.init_unit = mock.MagicMock(spec_set=self.conduit.init_unit)
         self.conduit.save_unit = mock.MagicMock(spec_set=self.conduit.save_unit)
+        # all of these units are new, find_unit_by_unit_key will return None
+        mock_find_unit.return_value = None
         file_handle = StringIO()
 
-        self.reposync.save_fileless_units(file_handle, updateinfo.PACKAGE_TAG, updateinfo.process_package_element)
+        # errata are saved with the "additive=True" flag
+        self.reposync.save_fileless_units(file_handle, updateinfo.PACKAGE_TAG,
+                                          updateinfo.process_package_element, additive_type=True)
 
         mock_generator.assert_any_call(file_handle, updateinfo.PACKAGE_TAG, updateinfo.process_package_element)
-        self.assertEqual(mock_generator.call_count, 2)
-        self.assertEqual(mock_check_repo.call_count, 1)
-        self.assertEqual(list(mock_check_repo.call_args[0][0]), [g.as_named_tuple for g in errata])
-        self.assertEqual(mock_check_repo.call_args[0][1], self.conduit.get_units)
+        self.assertEqual(mock_generator.call_count, 1)
 
-        for model in errata[:2]:
+        for model in errata:
             self.conduit.init_unit.assert_any_call(model.TYPE, model.unit_key, model.metadata, None)
         self.conduit.save_unit.assert_any_call(self.conduit.init_unit.return_value)
-        self.assertEqual(self.conduit.save_unit.call_count, 2)
+        self.assertEqual(self.conduit.save_unit.call_count, 3)
+
+    @mock.patch('pulp_rpm.plugins.importers.yum.repomd.packages.'
+                'package_list_generator', autospec=True)
+    @mock.patch('pulp.plugins.conduits.mixins.SearchUnitsMixin.'
+                'find_unit_by_unit_key', autospec=True)
+    @mock.patch('pulp_rpm.plugins.importers.yum.sync.RepoSync._concatenate_units', autospec=True)
+    def test_save_erratas_some_existing(self, mock_concat, mock_find_unit, mock_generator):
+        """
+        test where some errata already exist. When "additive_type" is set, we
+        will always init and save a unit since it may have been modified.
+        """
+        errata = tuple(model_factory.errata_models(3))
+        mock_generator.return_value = errata
+        self.conduit.init_unit = mock.MagicMock(spec_set=self.conduit.init_unit)
+        self.conduit.save_unit = mock.MagicMock(spec_set=self.conduit.save_unit)
+        # all of these units are new, find_unit_by_unit_key will return None
+        mock_find_unit.return_value = None
+        file_handle = StringIO()
+
+        find_unit_retvals = [mock.Mock(), None, mock.Mock()]
+        def _find_unit_return(*args):
+            return find_unit_retvals.pop()
+        mock_find_unit.side_effect = _find_unit_return
+
+        concat_unit_retvals = ["fake-unit-b", "fake-unit-a"]
+        def _concat_unit_return(*args):
+            return concat_unit_retvals.pop()
+        mock_concat.side_effect = _concat_unit_return
+
+        # errata are saved with the "additive=True" flag
+        self.reposync.save_fileless_units(file_handle, updateinfo.PACKAGE_TAG,
+                                          updateinfo.process_package_element, additive_type=True)
+
+        mock_generator.assert_any_call(file_handle, updateinfo.PACKAGE_TAG,
+                                       updateinfo.process_package_element)
+        # the generator is called only once since we are not rewinding the file
+        # handle or checking the repo for existing elements.
+        self.assertEqual(mock_generator.call_count, 1)
+
+        for model in errata:
+            self.conduit.init_unit.assert_any_call(model.TYPE, model.unit_key, model.metadata, None)
+
+        self.conduit.save_unit.assert_any_call("fake-unit-a")
+        self.conduit.save_unit.assert_any_call("fake-unit-b")
+        self.conduit.save_unit.assert_any_call(self.conduit.init_unit.return_value)
+        self.assertEqual(self.conduit.save_unit.call_count, 3)
+
+    @mock.patch('pulp_rpm.plugins.importers.yum.repomd.packages.'
+                'package_list_generator', autospec=True)
+    @mock.patch('pulp_rpm.plugins.importers.yum.sync.RepoSync._concatenate_units', autospec=True)
+    @mock.patch('pulp.plugins.conduits.mixins.SearchUnitsMixin.'
+                'find_unit_by_unit_key', autospec=True)
+    def test_save_erratas_update_pkglist(self, mock_find_unit, mock_concat, mock_generator):
+        """
+        test that we call _concatenate_units when we find an existing errata
+        """
+        errata = tuple(model_factory.errata_models(3))
+        mock_generator.return_value = errata
+        self.conduit.init_unit = mock.MagicMock(spec_set=self.conduit.init_unit)
+        self.conduit.save_unit = mock.MagicMock(spec_set=self.conduit.save_unit)
+        mock_find_unit.return_value = "fake unit"
+        file_handle = StringIO()
+
+        self.reposync.save_fileless_units(file_handle, updateinfo.PACKAGE_TAG,
+                                          updateinfo.process_package_element, additive_type=True)
+
+        self.assertEqual(mock_concat.call_count, 3)
 
     @mock.patch('pulp_rpm.plugins.importers.yum.existing.check_repo', autospec=True)
     @mock.patch('pulp_rpm.plugins.importers.yum.repomd.packages.package_list_generator', autospec=True)
@@ -835,10 +919,14 @@ class TestSaveFilelessUnits(BaseSyncTest):
         self.assertEqual(self.conduit.save_unit.call_count, 3)
 
     @mock.patch('pulp_rpm.plugins.importers.yum.existing.check_repo', autospec=True)
-    @mock.patch('pulp_rpm.plugins.importers.yum.repomd.packages.package_list_generator', autospec=True)
-    def test_save_erratas_all_existing(self, mock_generator, mock_check_repo):
+    @mock.patch('pulp_rpm.plugins.importers.yum.repomd.packages.'
+                'package_list_generator', autospec=True)
+    @mock.patch('pulp.plugins.conduits.mixins.SearchUnitsMixin.'
+                'find_unit_by_unit_key', autospec=True)
+    @mock.patch('pulp_rpm.plugins.importers.yum.sync.RepoSync._concatenate_units', autospec=True)
+    def test_save_erratas_all_existing(self, mock_concat, mock_find_unit, mock_generator, mock_check_repo):
         """
-        test where all errata already exist, so none should be saved
+        test where all errata already exist
         """
         errata = tuple(model_factory.errata_models(3))
         mock_generator.return_value = errata
@@ -847,16 +935,159 @@ class TestSaveFilelessUnits(BaseSyncTest):
         self.conduit.save_unit = mock.MagicMock(spec_set=self.conduit.save_unit)
         file_handle = StringIO()
 
-        self.reposync.save_fileless_units(file_handle, updateinfo.PACKAGE_TAG, updateinfo.process_package_element)
+        self.reposync.save_fileless_units(file_handle, updateinfo.PACKAGE_TAG,
+                                          updateinfo.process_package_element, additive_type=True)
 
         mock_generator.assert_any_call(file_handle, updateinfo.PACKAGE_TAG, updateinfo.process_package_element)
-        self.assertEqual(mock_generator.call_count, 2)
-        self.assertEqual(mock_check_repo.call_count, 1)
-        self.assertEqual(list(mock_check_repo.call_args[0][0]), [g.as_named_tuple for g in errata])
-        self.assertEqual(mock_check_repo.call_args[0][1], self.conduit.get_units)
+        self.assertEqual(mock_generator.call_count, 1)
 
-        self.assertEqual(self.conduit.save_unit.call_count, 0)
+        self.assertEqual(self.conduit.save_unit.call_count, 3)
 
+    def test_concatenate_units_wrong_type_id(self):
+        """
+        Ensure that we get an exception if we try to concatenate units of different types!
+        """
+        mock_erratum_model = models.Errata('RHBA-1234', metadata={})
+        mock_existing_unit = Unit(ids.TYPE_ID_ERRATA, mock_erratum_model.unit_key,
+                                  mock_erratum_model.metadata, "/fake/path")
+
+        mock_dist_model = models.Distribution('fake family', 'server', '3.11',
+                                              'baroque', metadata={})
+        mock_new_unit = Unit(ids.TYPE_ID_DISTRO, mock_dist_model.unit_key,
+                             mock_dist_model.metadata, "/fake/path")
+
+        self.assertRaises(RuntimeError, self.reposync._concatenate_units,
+                          mock_existing_unit, mock_new_unit)
+
+    def test_concatenate_units_wrong_unit_keys(self):
+        """
+        Ensure that we get an exception if we try to concatenate units with different unit_keys.
+        """
+        mock_existing_erratum_model = models.Errata('RHBA-1234', metadata={})
+        mock_existing_unit = Unit(ids.TYPE_ID_ERRATA, mock_existing_erratum_model.unit_key,
+                                  mock_existing_erratum_model.metadata, "/fake/path")
+
+        mock_new_erratum_model = models.Errata('RHBA-5678', metadata={})
+        mock_new_unit = Unit(ids.TYPE_ID_ERRATA, mock_new_erratum_model.unit_key,
+                                  mock_new_erratum_model.metadata, "/fake/path")
+
+        self.assertRaises(RuntimeError, self.reposync._concatenate_units,
+                          mock_existing_unit, mock_new_unit)
+
+    def test_concatenate_units_unsupported_type(self):
+        """
+        Ensure that we get an exception if we try to concatenate unsupported units
+        """
+        mock_existing_dist_model = models.Distribution('fake family', 'server', '3.11',
+                                              'baroque', metadata={})
+        mock_existing_dist_unit = Unit(ids.TYPE_ID_DISTRO, mock_existing_dist_model.unit_key,
+                                       mock_existing_dist_model.metadata, "/fake/path")
+        mock_new_dist_model = models.Distribution('fake family', 'server', '3.11',
+                                                  'baroque', metadata={})
+        mock_new_dist_unit = Unit(ids.TYPE_ID_DISTRO, mock_new_dist_model.unit_key,
+                                  mock_new_dist_model.metadata, "/fake/path")
+
+        self.assertRaises(RuntimeError, self.reposync._concatenate_units,
+                          mock_existing_dist_unit, mock_new_dist_unit)
+
+    def test_concatenate_units_errata(self):
+        """
+        Ensure that concatenation works
+        """
+        mock_existing_erratum_pkglist = [{'packages': [{"name": "some_package v1"},
+                                                       {"name": "another_package v1"}],
+                                          'name': 'v1 packages'}]
+        mock_existing_erratum_model = models.Errata('RHBA-1234', metadata={'pkglist':
+                                                                 mock_existing_erratum_pkglist})
+        mock_existing_unit = Unit(ids.TYPE_ID_ERRATA, mock_existing_erratum_model.unit_key,
+                                  mock_existing_erratum_model.metadata, "/fake/path")
+
+        mock_new_erratum_pkglist = [{'packages': [{"name": "some_package v2"},
+                                                  {"name": "another_package v2"}],
+                                     'name': 'v2 packages'}]
+        mock_new_erratum_model = models.Errata('RHBA-1234', metadata={'pkglist':
+                                                            mock_new_erratum_pkglist})
+        mock_new_unit = Unit(ids.TYPE_ID_ERRATA, mock_new_erratum_model.unit_key,
+                                  mock_new_erratum_model.metadata, "/fake/path")
+
+
+        concat_unit = self.reposync._concatenate_units(mock_existing_unit, mock_new_unit)
+
+        self.assertEquals(concat_unit.metadata, {'pkglist':
+                                                 [{'packages': [{'name': 'some_package v1'},
+                                                                {'name': 'another_package v1'}],
+                                                   'name': 'v1 packages'},
+                                                  {'packages': [{'name': 'some_package v2'},
+                                                                {'name': 'another_package v2'}],
+                                                   'name': 'v2 packages'}]})
+
+    def test_concatenate_units_errata_same_errata(self):
+        """
+        Ensure that we do not alter existing package lists when there is no new info
+        """
+        mock_existing_erratum_pkglist = [{'packages': [{"name": "some_package v1"},
+                                                       {"name": "another_package v1"}],
+                                          'name': 'v1 packages'}]
+        mock_existing_erratum_model = models.Errata('RHBA-1234', metadata={'pkglist':
+                                                                 mock_existing_erratum_pkglist})
+        mock_existing_unit = Unit(ids.TYPE_ID_ERRATA, mock_existing_erratum_model.unit_key,
+                                  mock_existing_erratum_model.metadata, "/fake/path")
+
+
+        # new erratum has the same package list and same ID
+        mock_new_erratum_pkglist = [{'packages': [{"name": "some_package v1"},
+                                                  {"name": "another_package v1"}],
+                                     'name': 'v1 packages'}]
+
+        mock_new_erratum_model = models.Errata('RHBA-1234', metadata={'pkglist':
+                                                            mock_new_erratum_pkglist})
+        mock_new_unit = Unit(ids.TYPE_ID_ERRATA, mock_new_erratum_model.unit_key,
+                                  mock_new_erratum_model.metadata, "/fake/path")
+
+
+        concat_unit = self.reposync._concatenate_units(mock_existing_unit, mock_new_unit)
+
+        self.assertEquals(concat_unit.metadata, {'pkglist':
+                                                 [{'packages': [{'name': 'some_package v1'},
+                                                                {'name': 'another_package v1'}],
+                                                 'name': 'v1 packages'}]})
+
+    def test_concatenate_units_errata_avoid_double_concat(self):
+        """
+        Ensure that we do not append a package list to an errata a second time
+        """
+        mock_existing_erratum_pkglist = [{'packages': [{'name': 'some_package v1'},
+                                                       {'name': 'another_package v1'}],
+                                          'name': 'v1 packages'},
+                                         {'packages': [{'name': 'some_package v2'},
+                                                       {'name': 'another_package v2'}],
+                                          'name': 'v2 packages'}]
+
+        mock_existing_erratum_model = models.Errata('RHBA-1234', metadata={'pkglist':
+                                                                 mock_existing_erratum_pkglist})
+        mock_existing_unit = Unit(ids.TYPE_ID_ERRATA, mock_existing_erratum_model.unit_key,
+                                  mock_existing_erratum_model.metadata, "/fake/path")
+
+        # new erratum has a subset of what we already know
+        mock_new_erratum_pkglist = [{'packages': [{"name": "some_package v1"},
+                                                  {"name": "another_package v1"}],
+                                     'name': 'v1 packages'}]
+
+        mock_new_erratum_model = models.Errata('RHBA-1234', metadata={'pkglist':
+                                                            mock_new_erratum_pkglist})
+        mock_new_unit = Unit(ids.TYPE_ID_ERRATA, mock_new_erratum_model.unit_key,
+                                  mock_new_erratum_model.metadata, "/fake/path")
+
+
+        concat_unit = self.reposync._concatenate_units(mock_existing_unit, mock_new_unit)
+
+        self.assertEquals(concat_unit.metadata, {'pkglist':
+                                                 [{'packages': [{'name': 'some_package v1'},
+                                                  {'name': 'another_package v1'}],
+                                                  'name': 'v1 packages'},
+                                                  {'packages': [{'name': 'some_package v2'},
+                                                  {'name': 'another_package v2'}],
+                                                  'name': 'v2 packages'}]})
 
 class TestIdentifyWantedVersions(BaseSyncTest):
     def test_keep_all(self):


### PR DESCRIPTION
Errata are typically published via updateinfo.xml in the feed repository.
However, an erratum may span across multiple repos. For example, the POODLE
erratum was for both RHEL6 and RHEL7.

Errata that span repos contain the same ID (and thus unit_key), but may have
different pkglist sets. Upstream reposotiries will typically prune the pkglist
to only contain packages in that repo. This causes issues when the same erratum
is in two or more repositories, each containing different package sets.

This patch adds a new `additive_type` flag to `save_fileless_units()`.  If the
flag is enabled, `save_fileless_units()` will detect if an existing unit
exists, and will call `_concatenate_units()` to combine the existing unit with
the new unit. The behavior of `_concatenate_units()` is dependant on the unit
type; for errata, we simply combine pkglists based on the pkglist name field.

A migration is not needed after applying this patch but users will need to
resync their repositories to correct any existing partial errata packagelists.