### PR TITLE
1172887 - Support bz2 compression of repo metadata files

### DIFF
--- a/plugins/pulp_rpm/plugins/importers/yum/repomd/metadata.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/repomd/metadata.py
@@ -2,6 +2,7 @@
 
 from copy import deepcopy
 import gdbm
+import bz2
 import gzip
 import hashlib
 import logging
@@ -241,6 +242,8 @@ class MetadataFiles(object):
             file_handle = gzip.open(file_path, 'r')
         elif file_path.endswith('.xz'):
             file_handle = lzma.LZMAFile(file_path, 'r')
+        elif file_path.endswith('.bz2'):
+            file_handle = bz2.BZ2File(file_path, 'r')
         else:
             file_handle = open(file_path, 'r')
         return file_handle

--- a/plugins/pulp_rpm/plugins/importers/yum/repomd/packages.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/repomd/packages.py
@@ -48,7 +48,7 @@ def package_list_generator(xml_handle, package_tag, process_func=None):
     # I know. This is a terrible misuse of SyntaxError. Don't blame the messenger.
     except SyntaxError:
         _LOGGER.error('failed to parse XML metadata file')
-        return
+        raise
 
     for event, element in xml_iterator:
         # if we're not at a fully parsed package element, keep going


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1172887