### PR TITLE
add ropeproject to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ docs/_build
 
 # Vim
 *.swp
+
+*.ropeproject


### PR DESCRIPTION
Flake8 raised a lot of problems related to .ropeproject directory, so I missed a legitimate PEP-8 violation. This tells flake8 to ignore dotfiles and fixes that PEP-8 violation. Also adds .ropeproject  to the gitignore.