### PR TITLE
1171278 - allow pulp-admin to print all packages associated with errata

### DIFF
--- a/extensions_admin/pulp_rpm/extensions/admin/contents.py
+++ b/extensions_admin/pulp_rpm/extensions/admin/contents.py
@@ -451,9 +451,11 @@ class SearchErrataCommand(BaseSearchCommand):
                     description += '\n\n'
 
         # Reformat packages affected
-        package_list = ['  %s-%s:%s-%s.%s' % (p['name'], p['epoch'], p['version'], p['release'],
-                                              p['arch'])
-                        for p in erratum_meta['pkglist'][0]['packages']]
+        package_list = []
+        for pkglist in erratum_meta['pkglist']:
+            for p in pkglist['packages']:
+                package_list.append('  %s-%s:%s-%s.%s' %
+                                    (p['name'], p['epoch'], p['version'], p['release'], p['arch']))
 
         # Reformat reboot flag
         if erratum_meta['reboot_suggested']:

--- a/extensions_admin/test/unit/extensions/admin/test_contents.py
+++ b/extensions_admin/test/unit/extensions/admin/test_contents.py
@@ -513,10 +513,26 @@ class SearchErrataCommand(PulpClientTests):
                                 'src': 'http://www.fedoraproject.org',
                                 'name': 'crow',
                                 'sum': None,
-                                'filename': 'crow-0.8-1.noarch.rpm',
-                                'epoch': None,
+                                'filename': 'crow-0.8-1.el9.noarch.rpm',
+                                'epoch': 1,
                                 'version': '0.8',
-                                'release': '1',
+                                'release': '1.el9',
+                                'arch': 'noarch'
+                            }
+                        ],
+                        'name': '1',
+                        'short': ''
+                    },
+                    {
+                        'packages': [
+                            {
+                                'src': 'http://www.fedoraproject.org',
+                                'name': 'crow',
+                                'sum': None,
+                                'filename': 'crow-0.9-1.el10.noarch.rpm',
+                                'epoch': 1,
+                                'version': '0.9',
+                                'release': '1.el10',
                                 'arch': 'noarch'
                             }
                         ],
@@ -543,3 +559,15 @@ class SearchErrataCommand(PulpClientTests):
         # Test that the formatter handles an errata list and calls write
         command.write_erratum_detail(errata_list)
         self.assertEqual(1, self.context.prompt.write.call_count)
+
+        # subclass str so we can use our own equality test. This lets us just
+        # check for the substring we are interested in.
+        class AnyStringWith(str):
+            def __eq__(self, other):
+                return self in other
+
+        # Test that both packages are printed (RHBZ #1171278)
+        self.context.prompt.write.\
+            assert_called_once_with(AnyStringWith("crow-1:0.8-1.el9.noarch"), skip_wrap=True)
+        self.context.prompt.write.\
+            assert_called_once_with(AnyStringWith("crow-1:0.9-1.el10.noarch"), skip_wrap=True)


### PR DESCRIPTION
pulp-admin was previously only looking at the first package list returned by
platform when printing package lists. Instead, it should loop over all package
lists in the erratum.