### PR TITLE
Fix Python 2.6 compatibility for unicode encoded rpm metadata

### DIFF
--- a/plugins/pulp_rpm/plugins/distributors/yum/metadata/filelists.py
+++ b/plugins/pulp_rpm/plugins/distributors/yum/metadata/filelists.py
@@ -41,5 +41,5 @@ class FilelistsXMLFileContext(FastForwardXmlFileContext):
         """
         metadata = unit.metadata['repodata']['filelists']
         if isinstance(metadata, unicode):
-            metadata = metadata.encode(encoding='utf-8')
+            metadata = metadata.encode('utf-8')
         self.metadata_file_handle.write(metadata)

--- a/plugins/pulp_rpm/plugins/distributors/yum/metadata/other.py
+++ b/plugins/pulp_rpm/plugins/distributors/yum/metadata/other.py
@@ -41,5 +41,5 @@ class OtherXMLFileContext(FastForwardXmlFileContext):
         """
         metadata = unit.metadata['repodata']['other']
         if isinstance(metadata, unicode):
-            metadata = metadata.encode(encoding='utf-8')
+            metadata = metadata.encode('utf-8')
         self.metadata_file_handle.write(metadata)

--- a/plugins/pulp_rpm/plugins/distributors/yum/metadata/primary.py
+++ b/plugins/pulp_rpm/plugins/distributors/yum/metadata/primary.py
@@ -53,5 +53,5 @@ class PrimaryXMLFileContext(FastForwardXmlFileContext):
         """
         metadata = unit.metadata['repodata']['primary']
         if isinstance(metadata, unicode):
-            metadata = metadata.encode(encoding='utf-8')
+            metadata = metadata.encode('utf-8')
         self.metadata_file_handle.write(metadata)


### PR DESCRIPTION
As per the [bug #1176698](https://bugzilla.redhat.com/show_bug.cgi?id=1176698#c8), I would like to get this fix into the release 2.6.0 (currently targeted for 2.6.1 only).