### PR TITLE
1147073 - when a distribution hasn't changed, sync no longer re-donwnloads its files

### DIFF
--- a/docs/tech-reference/yum-plugins.rst
+++ b/docs/tech-reference/yum-plugins.rst
@@ -226,7 +226,7 @@ Metadata
  Flag indicating if this erratum is installed it will require a reboot of the system
 
 Distribution
--------------
+------------
 
 The distribution type's ID is ``distribution``.
 
@@ -249,10 +249,13 @@ Unit Key
  Arch of the distribution tree. For example: x86_64
 
 Metadata
-^^^^^^^^^
+^^^^^^^^
 
 ``files``
  Files associated with the distribution tree.
+
+``timestamp``
+ The ``timestamp`` value as taken from the treeinfo file.
 
 Package Group
 -------------

--- a/docs/user-guide/release-notes/2.6.x.rst
+++ b/docs/user-guide/release-notes/2.6.x.rst
@@ -5,6 +5,13 @@ Pulp 2.6 Release Notes
 Pulp 2.6.0
 ==========
 
+New Behaviors
+-------------
+
+When doing a ``sync`` operation, if the upstream "distribution" unit has not
+changed since the last sync, pulp will no longer attempt to download additional
+distribution-related files.
+
 Bug Fixes
 ---------
 

--- a/plugins/pulp_rpm/plugins/migrations/0019_add_timestamp_to_distribution.py
+++ b/plugins/pulp_rpm/plugins/migrations/0019_add_timestamp_to_distribution.py
@@ -1,0 +1,60 @@
+import ConfigParser
+import logging
+import os
+
+from pulp.server.db.connection import get_collection
+
+
+_logger = logging.getLogger('pulp_rpm.plugins.migrations.0019')
+
+
+def _get_timestamp(distribution):
+    """
+    Given a distribution unit, tries to get the timestamp from its treeinfo
+    file on disk. If any trouble happens, this returns 0.0 as a default, which
+    will cause the next sync to re-fetch the treeinfo file.
+
+    :param distribution:    distribution object from the DB that must include
+                            the key '_storage_path'
+    :type  distribution:    dict
+
+    :return:    timestamp as read from the [general] section of a file named
+                either 'treeinfo' or '.treeinfo'. If the file does not exist or
+                is not parsable, returns 0.0 as the default.
+    :rtype:     float
+    """
+    parser = ConfigParser.RawConfigParser()
+    # the default implementation of this method makes all option names lowercase,
+    # which we don't want. This is the suggested solution in the python.org docs.
+    parser.optionxform = str
+
+    path = distribution['_storage_path']
+    for filename in ('treeinfo', '.treeinfo'):
+        try:
+            treeinfo_path = os.path.join(path, filename)
+            with open(treeinfo_path) as open_file:
+                parser.readfp(open_file)
+                timestamp = parser.get('general', 'timestamp')
+                return float(timestamp)
+        except:
+            # if anything goes wrong reading 'treeinfo', try '.treeinfo'
+            continue
+    # this default will ensure that the next sync will re-fetch
+    # the treeinfo file, which should correct any problems encountered in reading
+    # or parsing the current one
+    _logger.warning('problem reading treeinfo file at %s' % path)
+    _logger.info('using default timestamp of 0.0 for distribution with bad/missing treeinfo file')
+    return 0.0
+
+
+def migrate(*args, **kwargs):
+    """
+    Add the timestamp attribute to distribution units. The value comes
+    from the treeinfo file.
+    """
+    dist_collection = get_collection('units_distribution')
+    for distribution in dist_collection.find({}, {'_storage_path': 1}):
+        timestamp = _get_timestamp(distribution)
+
+        dist_collection.update({'_id': distribution['_id']},
+                               {'$set': {'timestamp': timestamp}}, safe=True)

--- a/plugins/test/data/test_dot_treeinfo/.treeinfo
+++ b/plugins/test/data/test_dot_treeinfo/.treeinfo
@@ -1,0 +1,35 @@
+[images-x86_64]
+kernel = images/pxeboot/vmlinuz
+server_filelists.xml.gz = Server/repodata/101ecad62a146f3ab4e06ca16104cdb90b225a48-filelists.xml.gz
+server_primary.xml.gz = Server/repodata/d984304da8889ba9e906d8a0455418f4b7edc206-primary.xml.gz
+server_other.sqlite.bz2 = Server/repodata/53939e47b5c6e5e960f18fc7c209d60ce37ccc01-other.sqlite.bz2
+diskboot.img = images/diskboot.img
+server_comps-rhel5-server-core.xml = Server/repodata/8700492668c730742984ec61666e4f3499c07713-comps-rhel5-server-core.xml
+server_updateinfo.xml.gz = Server/repodata/329cf55bc21b6c16fcc54fbcb0edd91bcf27d3bd-updateinfo.xml.gz
+server_primary.sqlite.bz2 = Server/repodata/908500781155e417f50c845157ee922d22008961-primary.sqlite.bz2
+server_comps-rhel5-server-core.xml.gz = Server/repodata/61c1abdd05c1bf5abfb346f7d0b55abb8a519817-comps-rhel5-server-core.xml.gz
+boot.iso = images/boot.iso
+initrd = images/pxeboot/initrd.img
+server_repomd = Server/repodata/repomd.xml
+server_productid.gz = Server/repodata/productid.gz
+server_filelists.sqlite.bz2 = Server/repodata/289101a61191454ff75fe12046e26e85b0e2f482-filelists.sqlite.bz2
+server_other.xml.gz = Server/repodata/4ec225f636e39c137f8330c4ac2618f0020e85d6-other.xml.gz
+
+[images-xen]
+initrd = images/xen/initrd.img
+kernel = images/xen/vmlinuz
+
+[stage2]
+instimage = images/minstg2.img
+mainimage = images/stage2.img
+
+[general]
+family = Red Hat Enterprise Linux Server
+timestamp = 1354213090
+totaldiscs = 1
+label = RHEL-5.9-Server-RC-3.0
+variant = foo
+version = 5.9
+discnum = 1
+packagedir = Server
+arch = x86_64

--- a/plugins/test/data/test_treeinfo/treeinfo
+++ b/plugins/test/data/test_treeinfo/treeinfo
@@ -1,0 +1,35 @@
+[images-x86_64]
+kernel = images/pxeboot/vmlinuz
+server_filelists.xml.gz = Server/repodata/101ecad62a146f3ab4e06ca16104cdb90b225a48-filelists.xml.gz
+server_primary.xml.gz = Server/repodata/d984304da8889ba9e906d8a0455418f4b7edc206-primary.xml.gz
+server_other.sqlite.bz2 = Server/repodata/53939e47b5c6e5e960f18fc7c209d60ce37ccc01-other.sqlite.bz2
+diskboot.img = images/diskboot.img
+server_comps-rhel5-server-core.xml = Server/repodata/8700492668c730742984ec61666e4f3499c07713-comps-rhel5-server-core.xml
+server_updateinfo.xml.gz = Server/repodata/329cf55bc21b6c16fcc54fbcb0edd91bcf27d3bd-updateinfo.xml.gz
+server_primary.sqlite.bz2 = Server/repodata/908500781155e417f50c845157ee922d22008961-primary.sqlite.bz2
+server_comps-rhel5-server-core.xml.gz = Server/repodata/61c1abdd05c1bf5abfb346f7d0b55abb8a519817-comps-rhel5-server-core.xml.gz
+boot.iso = images/boot.iso
+initrd = images/pxeboot/initrd.img
+server_repomd = Server/repodata/repomd.xml
+server_productid.gz = Server/repodata/productid.gz
+server_filelists.sqlite.bz2 = Server/repodata/289101a61191454ff75fe12046e26e85b0e2f482-filelists.sqlite.bz2
+server_other.xml.gz = Server/repodata/4ec225f636e39c137f8330c4ac2618f0020e85d6-other.xml.gz
+
+[images-xen]
+initrd = images/xen/initrd.img
+kernel = images/xen/vmlinuz
+
+[stage2]
+instimage = images/minstg2.img
+mainimage = images/stage2.img
+
+[general]
+family = Red Hat Enterprise Linux Server
+timestamp = 1354213090.94
+totaldiscs = 1
+label = RHEL-5.9-Server-RC-3.0
+variant = foo
+version = 5.9
+discnum = 1
+packagedir = Server
+arch = x86_64

--- a/plugins/test/unit/plugins/importers/yum/test_sync.py
+++ b/plugins/test/unit/plugins/importers/yum/test_sync.py
@@ -1135,6 +1135,30 @@ class TestTreeinfoSync(BaseSyncTest):
                       mock_report, lambda x: x)
         self.assertEqual(self.conduit.remove_unit.call_count, 0)
 
+    # The "usual" case of one existing distribution unit on the repo. Ensure
+    # that we didn't try to remove anything.
+    def test_treeinfo_sync_unchanged(self, mock_nectar, mock_tempfile, mock_rmtree,
+                                     mock_report, mock_parse_treefile, mock_get_treefile,
+                                     mock_move, mock_chmod):
+        # return one unit that is the same as what we saved. No removal should occur
+        metadata = {treeinfo.KEY_TIMESTAMP: 1354213090.94}
+        mock_model = models.Distribution('fake family', 'server', '3.11', 'baroque',
+                                         metadata=metadata.copy())
+        mock_unit = Unit(ids.TYPE_ID_DISTRO, mock_model.unit_key, metadata.copy(),
+                         "/fake/path")
+        self.conduit.get_units = mock.MagicMock(spec_set=self.conduit.get_units)
+        self.conduit.get_units.return_value = [mock_unit]
+        self.conduit.init_unit = mock.MagicMock(spec_set=self.conduit.init_unit)
+        self.conduit.init_unit.return_value = mock_unit
+        mock_parse_treefile.return_value = (mock_model, ["fake file 1"])
+        mock_get_treefile.return_value = "/a/fake/path/to/the/treefile"
+        treeinfo.sync(self.conduit, "http://some/url", "/some/tempdir", "fake-nectar-conf",
+                      mock_report, lambda x: x)
+        self.assertEqual(self.conduit.remove_unit.call_count, 0)
+        mock_report.__setitem__.assert_called_once_with('state', constants.STATE_COMPLETE)
+        # make sure the workflow did not proceed by making sure this call didn't happen
+        self.assertEqual(mock_report.set_initial_values.call_count, 0)
+
     # This is the case that occurs when symlinks like "6Server" are updated for
     # a new release. Pulp will have created a new distribution unit and we need
     # to remove any old units

--- a/plugins/test/unit/plugins/migrations/test_0019_add_timestamp_to_distribution.py
+++ b/plugins/test/unit/plugins/migrations/test_0019_add_timestamp_to_distribution.py
@@ -1,0 +1,78 @@
+import os.path
+import unittest
+
+from pulp.server.db.migrate.models import _import_all_the_way
+import mock
+
+
+migration = _import_all_the_way('pulp_rpm.plugins.migrations.0019_add_timestamp_'
+                                'to_distribution')
+
+
+class TestMigrate(unittest.TestCase):
+    """
+    Test the migrate() function.
+    """
+    @mock.patch.object(migration, 'get_collection')
+    def test_calls_correct_functions(self, mock_get_collection):
+        """
+        """
+        mock_get_collection.return_value.find.return_value = [
+            fake_distribution1,
+        ]
+
+        migration.migrate()
+
+        self.assertEqual(mock_get_collection.call_count, 1)
+        mock_get_collection.return_value.update.assert_called_once_with(
+            {'_id': fake_distribution1['_id']}, {'$set': {'timestamp': 1354213090.94}},
+            safe=True
+        )
+
+class TestGetTimestamp(unittest.TestCase):
+    def test_treeinfo(self):
+        expected = 1354213090.94
+
+        ret = migration._get_timestamp(fake_distribution1)
+
+        self.assertEqual(ret, expected)
+        self.assertTrue(isinstance(ret, float))
+
+    def test_dot_treeinfo(self):
+        expected = 1354213090.0
+
+        ret = migration._get_timestamp(fake_distribution2)
+
+        self.assertEqual(ret, expected)
+        self.assertTrue(isinstance(ret, float))
+
+    def test_no_treeinfo(self):
+        ret = migration._get_timestamp(bad_distribution1)
+
+        self.assertEqual(ret, 0.0)
+        self.assertTrue(isinstance(ret, float))
+
+    @mock.patch('ConfigParser.RawConfigParser.readfp', side_effect=ValueError)
+    def test_unparsable_treeinfo(self, mock_readfp):
+        ret = migration._get_timestamp(fake_distribution1)
+
+        self.assertEqual(ret, 0.0)
+        self.assertTrue(isinstance(ret, float))
+
+
+fake_distribution1 = {
+    '_id': 'abc123',
+    '_storage_path': os.path.join(os.path.dirname(__file__), '../../../data/test_treeinfo/')
+}
+
+
+fake_distribution2 = {
+    '_id': 'xyz789',
+    '_storage_path': os.path.join(os.path.dirname(__file__), '../../../data/test_dot_treeinfo/')
+}
+
+
+bad_distribution1 = {
+    '_id': 'abc123',
+    '_storage_path': '/a/b/c/d/e/',
+}


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1147073

Since this is needed downstream, I think it should be included in 2.6.0.