### PR TITLE
Respond to PEP-8 changes in platform.

### DIFF
--- a/plugins/pulp_rpm/plugins/importers/iso/importer.py
+++ b/plugins/pulp_rpm/plugins/importers/iso/importer.py
@@ -1,18 +1,14 @@
-import logging
 import os
 import shutil
 
 from pulp.common import config as config_utils
 from pulp.common.plugins import importer_constants
-from pulp.plugins.conduits.mixins import UnitAssociationCriteria
 from pulp.plugins.importer import Importer
+from pulp.server.db.model.criteria import UnitAssociationCriteria
 
 from pulp_rpm.common import constants, ids
 from pulp_rpm.plugins.db import models
 from pulp_rpm.plugins.importers.iso import configuration, sync
-
-
-logger = logging.getLogger(__name__)
 
 
 # The leading '/etc/pulp/' will be added by the read_json_config method.

--- a/plugins/pulp_rpm/plugins/importers/iso/sync.py
+++ b/plugins/pulp_rpm/plugins/importers/iso/sync.py
@@ -9,14 +9,14 @@ from nectar.downloaders.threaded import HTTPThreadedDownloader
 from nectar.downloaders.local import LocalFileDownloader
 from pulp.common.plugins import importer_constants
 from pulp.common.util import encode_unicode
-from pulp.plugins.conduits.mixins import Criteria, UnitAssociationCriteria
+from pulp.server.db.model.criteria import Criteria, UnitAssociationCriteria
 
 from pulp_rpm.common import constants
 from pulp_rpm.common.progress import SyncProgressReport
 from pulp_rpm.plugins.db import models
 
 
-logger = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 
 class ISOSyncRun(listener.DownloadEventListener):
@@ -101,7 +101,7 @@ class ISOSyncRun(listener.DownloadEventListener):
         # failed for that phase.
         msg = _('Failed to download %(url)s: %(error_msg)s.')
         msg = msg % {'url': report.url, 'error_msg': report.error_msg}
-        logger.error(msg)
+        _logger.error(msg)
         if self.progress_report.state == self.progress_report.STATE_MANIFEST_IN_PROGRESS:
             self.progress_report.state = self.progress_report.STATE_MANIFEST_FAILED
             self.progress_report.error_message = report.error_report

--- a/plugins/pulp_rpm/plugins/profilers/yum.py
+++ b/plugins/pulp_rpm/plugins/profilers/yum.py
@@ -1,10 +1,11 @@
 from gettext import gettext as _
 
-from pulp.plugins.conduits.mixins import UnitAssociationCriteria
 from pulp.plugins.profiler import Profiler, InvalidUnitsRequested
+from pulp.server.db.model.criteria import UnitAssociationCriteria
 
 from pulp_rpm.common.ids import TYPE_ID_ERRATA, TYPE_ID_RPM
 from pulp_rpm.yum_plugin import util
+
 
 _logger = util.getLogger(__name__)
 

--- a/plugins/test/unit/plugins/importers/iso/test_sync.py
+++ b/plugins/test/unit/plugins/importers/iso/test_sync.py
@@ -182,8 +182,8 @@ class TestISOSyncRun(PulpRPMTests):
         self.assertEqual(self.iso_sync_run.progress_report.state,
                          SyncProgressReport.STATE_CANCELLED)
 
-    @patch('pulp_rpm.plugins.importers.iso.sync.logger')
-    def test_download_failed_during_iso_download(self, logger):
+    @patch('pulp_rpm.plugins.importers.iso.sync._logger')
+    def test_download_failed_during_iso_download(self, _logger):
         self.iso_sync_run.progress_report._state = SyncProgressReport.STATE_ISOS_IN_PROGRESS
         url = 'http://www.theonion.com/articles/american-airlines-us-airways-merge-to-form' \
               '-worlds,31302/'
@@ -194,12 +194,12 @@ class TestISOSyncRun(PulpRPMTests):
 
         self.iso_sync_run.download_failed(report)
 
-        self.assertEqual(logger.error.call_count, 1)
-        log_msg = logger.error.mock_calls[0][1][0]
+        self.assertEqual(_logger.error.call_count, 1)
+        log_msg = _logger.error.mock_calls[0][1][0]
         self.assertTrue('uh oh' in log_msg)
 
-    @patch('pulp_rpm.plugins.importers.iso.sync.logger')
-    def test_download_failed_during_manifest(self, logger):
+    @patch('pulp_rpm.plugins.importers.iso.sync._logger')
+    def test_download_failed_during_manifest(self, _logger):
         self.iso_sync_run.progress_report._state = SyncProgressReport.STATE_MANIFEST_IN_PROGRESS
         url = 'http://www.theonion.com/articles/' + \
               'american-airlines-us-airways-merge-to-form-worlds,31302/'
@@ -213,8 +213,8 @@ class TestISOSyncRun(PulpRPMTests):
         self.assertEqual(self.iso_sync_run.progress_report._state,
                          SyncProgressReport.STATE_MANIFEST_FAILED)
         self.assertEqual(self.iso_sync_run.progress_report.error_message, report.error_report)
-        self.assertEqual(logger.error.call_count, 1)
-        log_msg = logger.error.mock_calls[0][1][0]
+        self.assertEqual(_logger.error.call_count, 1)
+        log_msg = _logger.error.mock_calls[0][1][0]
         self.assertTrue('uh oh' in log_msg)
 
     @patch('pulp_rpm.plugins.importers.iso.sync.ISOSyncRun.download_failed')


### PR DESCRIPTION
Platform had some silly imports in pulp.plugins that were only there so
that plugins don't import pulp.server. These imports were angering
flake8 (for good reason). This commit fixes pulp_rpm's imports so
they import from the real place that the code lived.