### PR TITLE
1183784 - clean hosting directories on repo distributor delete

### DIFF
--- a/plugins/pulp_rpm/plugins/migrations/0021_clean_http_directories.py
+++ b/plugins/pulp_rpm/plugins/migrations/0021_clean_http_directories.py
@@ -1,0 +1,71 @@
+import logging
+import os
+
+from pulp.common.config import read_json_config
+from pulp_rpm.plugins.distributors.yum import configuration
+from pulp_rpm.common.ids import TYPE_ID_DISTRIBUTOR_YUM
+
+
+_logger = logging.getLogger(__name__)
+
+
+CONF_FILE_PATH = 'server/plugins.conf.d/%s.json' % TYPE_ID_DISTRIBUTOR_YUM
+config = read_json_config(CONF_FILE_PATH)
+
+def walk_and_clean_directories(base_directory):
+    """
+    Walk through all of the directories inside of the base dir and clean the orphaned directories.
+    The leaves should be directories with a listing file and a symlink. If there is no symlink,
+    the directory is part of the relative url of a repo that has been deleted and it should be
+    removed.
+
+    :param base_directory: directory to search for orphaned directories
+    :type  base_directory: str
+
+    :raises: OSError can occur if migration occurs durring a concurrent publish
+    """
+
+    for path, dirs, files in os.walk(base_directory):
+        is_orphan = not dirs and (files == ['listing'] or files == [])
+        if is_orphan and path != base_directory:
+            clean_simple_hosting_directories(path, base_directory)
+
+def clean_simple_hosting_directories(leaf, containing_dir):
+    """
+    Recursively clean the directory structure starting with an orphaned leaf and stopping when
+    the directory is no longer an orphan or is outside of the containing_dir. Does not remove
+    anything outside of the containing directory. The dirs are artifacts of the relative paths of
+    repos that were deleted.
+
+    :param leaf: path to a leaf directory
+    :type  leaf: str
+    :param containing_dir: path to the location of published repos
+    :type  containing_dir: str
+    """
+
+    # This function is potentially dangerous so it is important to restrict it to the
+    # containing dir, which should be the publish directories.
+    if containing_dir not in os.path.dirname(leaf):
+        return
+
+    # If the only file is the listing file, it is safe to delete the file and containing dir.
+    if os.listdir(leaf) == ['listing']:
+        listing_path = os.path.join(leaf, 'listing')
+        _logger.debug("Cleaning up orphaned listing file: %s" % listing_path)
+        os.remove(listing_path)
+
+    # Some leafs may have a listing file, some may not.
+    if os.listdir(leaf) == []:
+        # We do not need to check for concurrent delete on migration.
+        _logger.debug("Cleaning up orphaned directory: %s" % leaf)
+        os.rmdir(leaf)
+
+    up_dir = os.path.dirname(leaf)
+    clean_simple_hosting_directories(up_dir, containing_dir)
+
+def migrate():
+    """Clean up published orphaned directory structure."""
+    _logger.debug("Cleaning up published https yum directories.")
+    walk_and_clean_directories(configuration.get_https_publish_dir(config))
+    _logger.debug("Cleaning up published yum http yum directories.")
+    walk_and_clean_directories(configuration.get_http_publish_dir(config))

--- a/plugins/test/unit/plugins/distributors/yum/test_distributor.py
+++ b/plugins/test/unit/plugins/distributors/yum/test_distributor.py
@@ -7,6 +7,7 @@ import unittest
 
 import mock
 from mock import Mock, patch, call
+from pulp.devel.unit import util
 from pulp.devel.unit.util import compare_dict
 from pulp.plugins.conduits.repo_config import RepoConfigConduit
 from pulp.plugins.conduits.repo_publish import RepoPublishConduit
@@ -179,6 +180,9 @@ class TestDistributorDistributorRemoved(unittest.TestCase):
         self.patch_g = patch(DISTRIBUTOR + '.os')
         self.mock_os = self.patch_g.start()
 
+        self.patch_h = patch(DISTRIBUTOR + '.YumHTTPDistributor.clean_simple_hosting_directories')
+        self.mock_clean = self.patch_h.start()
+
     def setUp(self):
         self._apply_mock_patches()
         self.working_dir = tempfile.mkdtemp()
@@ -195,6 +199,7 @@ class TestDistributorDistributorRemoved(unittest.TestCase):
         self.patch_e.stop()
         self.patch_f.stop()
         self.patch_g.stop()
+        self.patch_h.stop()
 
     def test_distributor_remove_distributor_calls_get_master_publish_dir(self):
         self.mock_master.assert_called_once_with(self.mock_repo, TYPE_ID_DISTRIBUTOR_YUM)
@@ -214,6 +219,9 @@ class TestDistributorDistributorRemoved(unittest.TestCase):
 
     def test_distributor_remove_distributor_calls_remove_cert_based_auth(self):
         self.mock_remove_cert.assert_called_once_with(self.mock_repo, self.config)
+
+    def test_distributor_remove_distributor_calls_clean_simple_hosting_directories(self):
+        self.assertEqual(self.mock_clean.call_count, 2)
 
     def test_distributor_remove_distributor_uses_rmtree_to_remove_working_dir_and_master_dir(self):
         rmtree_calls = [
@@ -243,6 +251,68 @@ class TestDistributorDistributorRemoved(unittest.TestCase):
         self.mock_os.unlink.side_effect = os_error_to_raise
         self.assertRaises(OSError, self.distributor.distributor_removed, self.mock_repo,
                           self.config)
+
+
+class TestCleanSimpleHostingDirectories(unittest.TestCase):
+    """Test the clean_simple_hosting_directories method."""
+
+    def setUp(self):
+        """Setup a publish base"""
+        self.working_dir = tempfile.mkdtemp()
+        self.publish_base = os.path.join(self.working_dir, 'publish', 'dir')
+        util.touch(os.path.join(self.publish_base, 'listing'))
+        self.distributor = distributor.YumHTTPDistributor()
+
+    def tearDown(self):
+        """Cleanup the publish base"""
+        shutil.rmtree(self.working_dir, ignore_errors=True)
+
+    def test_clean_ophaned_leaf(self):
+        """
+        Test that an orphaned leaf is removed.
+        """
+        listing_file_a = os.path.join(self.publish_base, 'a', 'listing')
+        listing_file_b = os.path.join(self.publish_base, 'a', 'b', 'listing')
+        listing_file_c = os.path.join(self.publish_base, 'a', 'b', 'c', 'listing')
+        util.touch(listing_file_a)
+        util.touch(listing_file_b)
+        util.touch(listing_file_c)
+        old_symlink = os.path.join(self.publish_base, 'a', 'b', 'c', 'path_to_removed_symlink')
+        self.distributor.clean_simple_hosting_directories(old_symlink, self.publish_base)
+        self.assertFalse(os.path.isdir(os.path.join(self.publish_base, 'a')))
+
+    def test_clean_only_ophaned_leaf(self):
+        """
+        Test partially shared path, only unshared portion of ophan path should be removed.
+        """
+        listing_file_a = os.path.join(self.publish_base, 'a', 'listing')
+        listing_file_b = os.path.join(self.publish_base, 'a', 'b', 'listing')
+        listing_file_c = os.path.join(self.publish_base, 'a', 'b', 'c', 'listing')
+        non_orphan_listing = os.path.join(self.publish_base, 'a', 'other', 'listing')
+        non_orphan_file = os.path.join(self.publish_base, 'a', 'other', 'otherfile')
+        util.touch(listing_file_a)
+        util.touch(listing_file_b)
+        util.touch(listing_file_c)
+        util.touch(non_orphan_listing)
+        util.touch(non_orphan_file)
+        old_symlink = os.path.join(self.publish_base, 'a', 'b', 'c', 'path_to_removed_symlink')
+        self.distributor.clean_simple_hosting_directories(old_symlink, self.publish_base)
+        self.assertTrue(os.path.isdir(os.path.join(self.publish_base, 'a')))
+        self.assertFalse(os.path.isdir(os.path.join(self.publish_base, 'a', 'b')))
+
+    @mock.patch('pulp_rpm.plugins.distributors.yum.distributor.util')
+    @mock.patch('pulp_rpm.plugins.distributors.yum.distributor.os.rmdir')
+    def test_clean_with_concurrent_file_creation(self, mock_rmdir, mock_util):
+        """
+        Clean directories when a dir cannot be removed during orphaned directory removal.
+        """
+        mock_rmdir.side_effect = OSError()
+        listing_file_a = os.path.join(self.publish_base, 'a', 'listing')
+        updir = os.path.join(self.publish_base, 'a')
+        util.touch(listing_file_a)
+        old_symlink = os.path.join(self.publish_base, 'a', 'path_to_removed_symlink')
+        self.distributor.clean_simple_hosting_directories(old_symlink, self.publish_base)
+        mock_util.generate_listing_files.assert_called_once_with(updir, updir)
 
 
 class TestEntryPoint(unittest.TestCase):

--- a/plugins/test/unit/plugins/migrations/test_0021_clean_http_directories.py
+++ b/plugins/test/unit/plugins/migrations/test_0021_clean_http_directories.py
@@ -1,0 +1,115 @@
+import logging
+import os
+import shutil
+import tempfile
+import unittest
+
+import mock
+
+from pulp.devel.unit import util
+from pulp.server.db.migrate.models import _import_all_the_way
+
+
+migration = _import_all_the_way('pulp_rpm.plugins.migrations.0021_clean_http_directories')
+
+
+class TestMigrate(unittest.TestCase):
+    """
+    Test migration 0021.
+    """
+    @mock.patch('pulp_rpm.plugins.migrations.0021_clean_http_directories.'
+                'configuration')
+    @mock.patch('pulp_rpm.plugins.migrations.0021_clean_http_directories.'
+                'walk_and_clean_directories')
+    def test_walk_correct_directories(self, mock_walk, mock_conf):
+        """Migration should check http and https simple serve directories"""
+        mock_conf.get_http_publish_dir.return_value = 'http'
+        mock_conf.get_https_publish_dir.return_value = 'https'
+        migration.migrate()
+        mock_walk.assert_has_calls([mock.call('https'), mock.call('http')])
+
+    def setUp(self):
+        """Setup a publish base"""
+        self.working_dir = tempfile.mkdtemp()
+        self.publish_base = os.path.join(self.working_dir, 'publish', 'dir')
+        util.touch(os.path.join(self.publish_base, 'listing'))
+
+    def tearDown(self):
+        """Cleanup the publish base"""
+        shutil.rmtree(self.working_dir, ignore_errors=True)
+
+    @mock.patch('pulp_rpm.plugins.migrations.0021_clean_http_directories.'
+                'clean_simple_hosting_directories')
+    def test_walk_recognizes_leaf(self, mock_clean):
+        """
+        Test that an orphaned leaf is detected.
+        """
+        leaf = os.path.join(self.publish_base, 'a', 'b', 'c', 'listing')
+        non_orphan = os.path.join(self.publish_base, 'not', 'leaf', 'listing')
+        other_file = os.path.join(self.publish_base, 'not', 'leaf', 'notlisting')
+        util.touch(leaf)
+        util.touch(non_orphan)
+        util.touch(other_file)
+        migration.walk_and_clean_directories(self.publish_base)
+        expected_leaf = os.path.join(self.publish_base, 'a', 'b', 'c')
+        mock_clean.assert_called_once_with(expected_leaf, self.publish_base)
+
+    @mock.patch('pulp_rpm.plugins.migrations.0021_clean_http_directories.'
+                'clean_simple_hosting_directories')
+    def test_walk_does_not_recognize_non_leaf(self, mock_clean):
+        """
+        Test that non orphaned leafs are not cleaned.
+        """
+        non_orphan = os.path.join(self.publish_base, 'not', 'orphan', 'listing')
+        other_file = os.path.join(self.publish_base, 'not', 'orphan', 'notlisting')
+        util.touch(non_orphan)
+        util.touch(other_file)
+        migration.walk_and_clean_directories(self.publish_base)
+        self.assertEqual(mock_clean.call_count, 0)
+
+    @mock.patch('pulp_rpm.plugins.migrations.0021_clean_http_directories.'
+                'clean_simple_hosting_directories')
+    def test_walk_does_not_detect_empty_publish_base(self, mock_clean):
+        """
+        Clean should not be called if there are no directories.
+        """
+        migration.walk_and_clean_directories(self.publish_base)
+        self.assertEqual(mock_clean.call_count, 0)
+
+    def test_clean_ophaned_leaf(self):
+        """
+        Test that an orphaned leaf is removed.
+        """
+        leaf = os.path.join(self.publish_base, 'a', 'b', 'c', 'listing')
+        leaf_dir = os.path.dirname(leaf)
+        util.touch(leaf)
+        self.assertTrue(os.path.isfile(leaf))
+        migration.clean_simple_hosting_directories(leaf_dir, self.publish_base)
+        self.assertFalse(os.path.isdir(os.path.join(self.publish_base, 'a')))
+
+    def test_clean_only_ophaned_leaf(self):
+        """
+        Test partially shared path, only unshared ophan should be removed.
+        """
+        leaf = os.path.join(self.publish_base, 'a', 'b', 'c', 'listing')
+        non_orphan = os.path.join(self.publish_base, 'a', 'other', 'listing')
+        other_file = os.path.join(self.publish_base, 'a', 'other', 'otherfile')
+        leaf_dir = os.path.dirname(leaf)
+        util.touch(leaf)
+        util.touch(non_orphan)
+        util.touch(other_file)
+
+        # Not truly necessary, but shows that the files exist before operation.
+        self.assertTrue(os.path.isfile(leaf))
+        self.assertTrue(os.path.isfile(non_orphan))
+        self.assertTrue(os.path.isfile(other_file))
+        migration.clean_simple_hosting_directories(leaf_dir, self.publish_base)
+
+        # Show that this dir has been removed.
+        self.assertFalse(os.path.isdir(os.path.join(self.publish_base, 'a', 'b')))
+
+        # Non orphan has been preserved.
+        self.assertTrue(os.path.isdir(os.path.join(self.publish_base, 'a')))
+        self.assertTrue(os.path.isfile(non_orphan))
+        self.assertTrue(os.path.isfile(other_file))
+


### PR DESCRIPTION
When repos are deleted, the simple hosting directory structure that matches their relative url is not cleaned up, which leaves the opportunity to conflict with sub-urls of deleted repos.

[BZ-1183784](https://bugzilla.redhat.com/show_bug.cgi?id=1183784)

This patch cleans up this directory structure when a repo is deleted. There is also a migration to clean already existing orphaned directories.