### PR TITLE
1185868 - create fewer dictionaries when depsolving

### DIFF
--- a/plugins/pulp_rpm/plugins/importers/yum/associate.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/associate.py
@@ -179,18 +179,28 @@ def copy_rpms(units, import_conduit, copy_deps, solver=None):
     unit_set = set()
 
     for unit in units:
+        # we are passing in units that may have flattened "provides" metadata.
+        # This flattened field is not used by associate_unit().
         import_conduit.associate_unit(unit)
         unit_set.add(unit)
 
     if copy_deps and unit_set:
         if solver is None:
             solver = depsolve.Solver(import_conduit.get_source_units)
+
+        # This returns units that have a flattened 'provides' metadata field
+        # for memory purposes (RHBZ #1185868)
         deps = solver.find_dependent_rpms(unit_set)
+
         # remove rpms already in the destination repo
         existing_units = set(existing.get_existing_units([dep.unit_key for dep in deps],
                                                          models.RPM.UNIT_KEY_NAMES, models.RPM.TYPE,
                                                          import_conduit.get_destination_units))
+
+        # the hash comparison for Units is unit key + type_id, the metadata
+        # field is not used.
         to_copy = deps - existing_units
+
         _LOGGER.debug('Copying deps: %s' % str(sorted([x.unit_key['name'] for x in to_copy])))
         if to_copy:
             unit_set |= copy_rpms(to_copy, import_conduit, copy_deps, solver)

--- a/plugins/test/unit/plugins/importers/yum/test_depsolve.py
+++ b/plugins/test/unit/plugins/importers/yum/test_depsolve.py
@@ -139,6 +139,14 @@ class TestProvidesTree(DepsolveTestCase):
         # the source list should have been cleared
         self.assertTrue(self.solver._cached_source_with_provides is None)
 
+    def test_trim_provides(self):
+        fake_unit = mock.Mock()
+        fake_unit.metadata = {'provides': [{'name': 'foo', 'another_field': 'bar'}]}
+
+        trimmed = self.solver._trim_provides(fake_unit)
+
+        self.assertEquals(trimmed.metadata, {'provides': ['foo']})
+
 
 class TestPackagesTree(DepsolveTestCase):
     @mock.patch('pulp_rpm.plugins.importers.yum.depsolve.Solver._build_packages_tree')
@@ -178,15 +186,21 @@ class TestFindDependentRPMs(DepsolveTestCase):
         super(TestFindDependentRPMs, self).setUp()
         self.mock_search.side_effect = self._get_units
 
-    def _get_units(self, criteria):
+    def _get_units(self, criteria, as_generator=False):
         """
         Fake the conduit get_units() call. If there are unit_filters, assume they have an $or clause
         and filter self.units for the units that have the same unit keys as the or clause.
         Otherwise, return self.units.
         """
         if criteria.unit_filters:
-            return [unit for unit in self.units if unit.unit_key in criteria.unit_filters['$or']]
-        return self.units
+            units = (unit for unit in self.units if unit.unit_key in criteria.unit_filters['$or'])
+        else:
+            units = (unit for unit in self.units)
+
+        if as_generator:
+            return units
+        else:
+            return list(units)
 
     def test_one_unit_with_dependencies(self):
         """


### PR DESCRIPTION
Previously, calling `copy_rpms()` with dep solving  enabled would result in a
large number of new dictionaries. For example, copying a single erratum from
RHEL 6.6 to 6.1 would result in 1.3 million new dicts. This ate a large amount
of memory.

Instead, flatten the "provides" metadata on the unit when doing dep solving
since we only need the name of the provide, not the full dict. This reduces the
number of created dicts to 81K for the scenario mentioned above, and results in
a ~70% memory savings.

Credit for this fix goes to @mhrivnak.