### PR TITLE
577 - Fix the the --serve-https to observe defaults.

### DIFF
--- a/extensions_admin/pulp_rpm/extensions/admin/repo_create_update.py
+++ b/extensions_admin/pulp_rpm/extensions/admin/repo_create_update.py
@@ -172,27 +172,15 @@ class RpmRepoCreateCommand(CreateRepositoryCommand, ImporterConfigMixin):
         Both http and https must be specified in the distributor config, so make sure they are
         initially set here (default to only https).
         """
-        if 'http' not in yum_distributor_config and 'https' not in yum_distributor_config:
-            yum_distributor_config['https'] = True
-            yum_distributor_config['http'] = False
-
-        # Make sure both are referenced
-        for k in ('http', 'https'):
-            if k not in yum_distributor_config:
-                yum_distributor_config[k] = False
+        yum_distributor_config['https'] = yum_distributor_config.get('https', True)
+        yum_distributor_config['http'] = yum_distributor_config.get('http', False)
 
     def process_export_distributor_serve_protocol(self, export_distributor_config):
         """
         Ensure default values for http and https for export distributor if they are not set.
         """
-        if 'http' not in export_distributor_config and 'https' not in export_distributor_config:
-            export_distributor_config['https'] = True
-            export_distributor_config['http'] = False
-
-        # Make sure both are referenced
-        for k in ('http', 'https'):
-            if k not in export_distributor_config:
-                export_distributor_config[k] = False
+        export_distributor_config['https'] = export_distributor_config.get('https', True)
+        export_distributor_config['http'] = export_distributor_config.get('http', False)
 
 
 class RpmRepoUpdateCommand(UpdateRepositoryCommand, ImporterConfigMixin):

--- a/extensions_admin/test/unit/extensions/admin/test_repo_create_update.py
+++ b/extensions_admin/test/unit/extensions/admin/test_repo_create_update.py
@@ -203,6 +203,54 @@ class RpmRepoCreateCommandTests(PulpClientTests):
         self.assertTrue('relative_url' in distributor_config)
         self.assertEqual(distributor_config['relative_url'], 'wombat')
 
+    def test_process_yum_distributor_serve_protocol_defaults(self):
+        # Setup
+        distributor_config = {}  # will be populated in this call
+        command = repo_create_update.RpmRepoCreateCommand(self.context)
+
+        # Test
+        command.process_yum_distributor_serve_protocol(distributor_config)
+
+        # Verify
+        self.assertEqual(distributor_config['http'], False)
+        self.assertEqual(distributor_config['https'], True)
+
+    def test_process_yum_distributor_serve_protocol_new_values(self):
+        # Setup
+        distributor_config = {'http': True, 'https': False}
+        command = repo_create_update.RpmRepoCreateCommand(self.context)
+
+        # Test
+        command.process_yum_distributor_serve_protocol(distributor_config)
+
+        # Verify
+        self.assertEqual(distributor_config['http'], True)
+        self.assertEqual(distributor_config['https'], False)
+
+    def test_process_export_distributor_serve_protocol_defaults(self):
+        # Setup
+        distributor_config = {}  # will be populated in this call
+        command = repo_create_update.RpmRepoCreateCommand(self.context)
+
+        # Test
+        command.process_export_distributor_serve_protocol(distributor_config)
+
+        # Verify
+        self.assertEqual(distributor_config['http'], False)
+        self.assertEqual(distributor_config['https'], True)
+
+    def test_process_export_distributor_serve_protocol_new_values(self):
+        # Setup
+        distributor_config = {'http': True, 'https': False}
+        command = repo_create_update.RpmRepoCreateCommand(self.context)
+
+        # Test
+        command.process_export_distributor_serve_protocol(distributor_config)
+
+        # Verify
+        self.assertEqual(distributor_config['http'], True)
+        self.assertEqual(distributor_config['https'], False)
+
 
 class RpmRepoUpdateCommandTests(PulpClientTests):
 


### PR DESCRIPTION
If the --serve-http flag is set to true the default value of --serve-https was
improperly being set to false.  This fixes it to maintain the default
value even if the --serve-http flag is set.

closes #577 
https://pulp.plan.io/issues/577