### PR TITLE
638 - Process build_time & time values for uploaded RPMs

### DIFF
--- a/plugins/pulp_rpm/plugins/importers/yum/upload.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/upload.py
@@ -2,6 +2,7 @@ import hashlib
 import logging
 import os
 import shutil
+import stat
 from xml.etree import cElementTree as ET
 
 import rpm
@@ -398,6 +399,11 @@ def _generate_rpm_data(type_id, rpm_filename, user_metadata=None):
     metadata['license'] = headers['license']
     metadata['vendor'] = headers['vendor']
     metadata['description'] = headers['description']
+    metadata['build_time'] = headers[rpm.RPMTAG_BUILDTIME]
+    # Use the mtime of the file to match what is in the generated xml from
+    # rpm_parse.get_package_xml(..)
+    file_stat = os.stat(rpm_filename)
+    metadata['time'] = file_stat[stat.ST_MTIME]
 
     return unit_key, metadata
 

--- a/plugins/test/unit/plugins/importers/yum/test_upload.py
+++ b/plugins/test/unit/plugins/importers/yum/test_upload.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import stat
 import tempfile
 import unittest
 
@@ -528,6 +529,9 @@ class UploadPackageTests(unittest.TestCase):
         self.assertEqual(metadata['license'], 'GPLv2')
         self.assertEqual(metadata['relativepath'], 'walrus-5.21-1.noarch.rpm')
         self.assertEqual(metadata['vendor'], None)
+        time_val = os.stat(self.upload_src_filename)[stat.ST_MTIME]
+        self.assertEqual(metadata['build_time'], 1331831368)
+        self.assertEqual(metadata['time'], time_val)
 
     def test_generate_rpm_data_user_checksum(self):
         # Test


### PR DESCRIPTION
The build_time & time values for uploaded rpms have not been
saved on the model and they are being saved for synced rpms.
Update the processing code to calculate these values upon upload.

closes #638