### PR TITLE
617 - pulp-consumer rpm repo unbind non-existent repo fails with unexpected error

### DIFF
--- a/extensions_consumer/pulp_rpm/extensions/consumer/pulp_cli.py
+++ b/extensions_consumer/pulp_rpm/extensions/consumer/pulp_cli.py
@@ -1,7 +1,6 @@
-
 from gettext import gettext as _
 
-from pulp.bindings.exceptions import NotFoundException
+from pulp.bindings.exceptions import BadRequestException, NotFoundException
 from pulp.client.commands.repo.query import RepoSearchCommand
 from pulp.client.consumer_utils import load_consumer_id
 from pulp.client.extensions.extensions import PulpCliCommand, PulpCliOption, PulpCliFlag
@@ -16,6 +15,7 @@ YUM_DISTRIBUTOR_TYPE_ID = 'yum_distributor'
 RPM_SECTION = 'rpm'
 SECTION_DESC = _('manage RPM-related features')
 SEARCH_NAME = 'repos'
+
 
 def initialize(context):
 
@@ -60,16 +60,13 @@ class BindCommand(PulpCliCommand):
             self.context.prompt.render_success_message(msg)
             tasks = [dict(task_id=str(t.task_id)) for t in response.response_body.spawned_tasks]
             self.context.prompt.render_document_list(tasks)
-        except NotFoundException, e:
-            resources = e.extra_data['resources']
-            if 'consumer' in resources:
-                r_type = _('Consumer')
-                r_id = consumer_id
+        except BadRequestException, e:
+            property_names = e.extra_data['property_names']
+            if 'repo_id' in property_names:
+                msg = _('Repository [%(r)s] does not exist on the server')
             else:
-                r_type = _('Repository')
-                r_id = repo_id
-            msg = _('%(t)s [%(id)s] does not exist on the server')
-            self.context.prompt.write(msg % {'t': r_type, 'id': r_id}, tag='not-found')
+                msg = _('Repository [%(r)s] does not have a distributor')
+            self.context.prompt.render_failure_message(msg % {'r': repo_id}, tag='not-found')
 
 
 class UnbindCommand(PulpCliCommand):
@@ -79,7 +76,8 @@ class UnbindCommand(PulpCliCommand):
         self.context = context
         self.prompt = context.prompt
         self.add_option(PulpCliOption('--repo-id', 'repository id', required=True))
-        self.add_option(PulpCliFlag('--force', 'delete the binding immediately and discontinue tracking consumer actions'))
+        self.add_option(PulpCliFlag('--force', 'delete the binding immediately and discontinue '
+                                               'tracking consumer actions'))
 
     def unbind(self, **kwargs):
         consumer_id = load_consumer_id(self.context)
@@ -92,16 +90,21 @@ class UnbindCommand(PulpCliCommand):
         force = kwargs['force']
 
         try:
-            response = self.context.server.bind.unbind(consumer_id, repo_id, YUM_DISTRIBUTOR_TYPE_ID, force)
+            response = self.context.server.bind.unbind(consumer_id, repo_id,
+                                                       YUM_DISTRIBUTOR_TYPE_ID, force)
             msg = _('Unbind tasks successfully created:')
             self.context.prompt.render_success_message(msg)
             tasks = [dict(task_id=str(t.task_id)) for t in response.response_body.spawned_tasks]
             self.context.prompt.render_document_list(tasks)
         except NotFoundException, e:
-            bind_id = e.extra_data['resources']['bind_id']
-            m = _('Binding [consumer: %(c)s, repository: %(r)s] does not exist on the server')
-            d = {
-                'c': bind_id['consumer_id'],
-                'r': bind_id['repo_id'],
-            }
-            self.context.prompt.write(m % d, tag='not-found')
+            resources = e.extra_data['resources']
+            if 'repo_id' in resources:
+                m = _('Repository [%(r)s] does not exist on the server')
+                d = {'r': repo_id}
+            else:
+                m = _('Binding [consumer: %(c)s, repository: %(r)s] does not exist on the server')
+                d = {
+                    'c': consumer_id,
+                    'r': repo_id,
+                }
+            self.context.prompt.render_failure_message(m % d, tag='not-found')

--- a/extensions_consumer/test/unit/extensions/consumer/test_pulp_cli.py
+++ b/extensions_consumer/test/unit/extensions/consumer/test_pulp_cli.py
@@ -1,0 +1,146 @@
+import mock
+
+from pulp.bindings.exceptions import BadRequestException, NotFoundException
+from pulp.devel.unit import base
+
+from pulp_rpm.extensions.consumer.pulp_cli import BindCommand, UnbindCommand
+
+LOAD_CONSUMER_API = 'pulp_rpm.extensions.consumer.pulp_cli.load_consumer_id'
+
+
+class TestBindCommand(base.PulpClientTests):
+
+    OPTION_NAMES = set(['--repo-id'])
+
+    def setUp(self):
+        super(TestBindCommand, self).setUp()
+        self.command = BindCommand(self.context, 'bind', 'desc')
+
+    def test_structure(self):
+        # Ensure the correct method is wired up
+        self.assertEqual(self.command.method, self.command.bind)
+
+    def test_options_present(self):
+        options_present = set([option.name for option in self.command.options])
+        self.assertEqual(self.OPTION_NAMES, options_present)
+
+    def test_name(self):
+        self.assertEqual(self.command.name, 'bind')
+        self.assertEqual(self.command.description, 'desc')
+
+    @mock.patch('pulp.bindings.consumer.BindingsAPI.bind')
+    @mock.patch(LOAD_CONSUMER_API, return_value='c1')
+    def test_bind_no_repo(self, mock_consumer, mock_bind):
+        mock_bind.side_effect = BadRequestException({'property_names': ['repo_id']})
+        self.context.prompt = mock.MagicMock()
+
+        # Test
+        data = {'repo-id': 'repo1'}
+        self.command.bind(**data)
+
+        # Verify
+        self.assertEqual(self.context.server.bind.bind.call_count, 1)
+        self.assertEqual(self.context.prompt.render_success_message.call_count, 0)
+        self.assertEqual(self.context.prompt.render_failure_message.call_count, 1)
+        m = ('Repository [repo1] does not exist on the server')
+        self.context.prompt.render_failure_message.assert_called_once_with(m, tag='not-found')
+
+    @mock.patch('pulp.bindings.consumer.BindingsAPI.bind')
+    @mock.patch(LOAD_CONSUMER_API, return_value='c1')
+    def test_bind_no_dist(self, mock_consumer, mock_bind):
+        mock_bind.side_effect = BadRequestException({'property_names': ['distributor_id']})
+        self.context.prompt = mock.MagicMock()
+
+        # Test
+        data = {'repo-id': 'repo1'}
+        self.command.bind(**data)
+
+        # Verify
+        self.assertEqual(self.context.server.bind.bind.call_count, 1)
+        self.assertEqual(self.context.prompt.render_success_message.call_count, 0)
+        self.assertEqual(self.context.prompt.render_failure_message.call_count, 1)
+        m = ('Repository [repo1] does not have a distributor')
+        self.context.prompt.render_failure_message.assert_called_once_with(m, tag='not-found')
+
+    @mock.patch(LOAD_CONSUMER_API, return_value=None)
+    def test_unbind_no_registered_consumer(self, mock_consumer):
+        self.command.prompt = mock.MagicMock()
+
+        # Test
+        data = {'repo-id': 'repo1'}
+        self.command.bind(**data)
+
+        # Verify
+        self.assertEqual(self.command.prompt.render_success_message.call_count, 0)
+        self.assertEqual(self.command.prompt.render_failure_message.call_count, 1)
+        m = ('This consumer is not registered to the Pulp server')
+        self.command.prompt.render_failure_message.assert_called_once_with(m)
+
+
+class TestUnbindCommand(base.PulpClientTests):
+
+    OPTION_NAMES = set(['--repo-id', '--force'])
+
+    def setUp(self):
+        super(TestUnbindCommand, self).setUp()
+        self.command = UnbindCommand(self.context, 'unbind', 'desc')
+
+    def test_structure(self):
+        # Ensure the correct method is wired up
+        self.assertEqual(self.command.method, self.command.unbind)
+
+    def test_options_present(self):
+        options_present = set([option.name for option in self.command.options])
+        self.assertEqual(self.OPTION_NAMES, options_present)
+
+    def test_name(self):
+        self.assertEqual(self.command.name, 'unbind')
+        self.assertEqual(self.command.description, 'desc')
+
+    @mock.patch('pulp.bindings.consumer.BindingsAPI.unbind')
+    @mock.patch(LOAD_CONSUMER_API, return_value='c1')
+    def test_unbind_no_repo(self, mock_consumer, mock_unbind):
+        mock_unbind.side_effect = NotFoundException({'resources': ['repo_id']})
+        self.context.prompt = mock.MagicMock()
+
+        # Test
+        data = {'repo-id': 'repo1', 'force': 'false'}
+        self.command.unbind(**data)
+
+        # Verify
+        self.assertEqual(self.context.server.bind.unbind.call_count, 1)
+        self.assertEqual(self.context.prompt.render_success_message.call_count, 0)
+        self.assertEqual(self.context.prompt.render_failure_message.call_count, 1)
+        m = ('Repository [repo1] does not exist on the server')
+        self.context.prompt.render_failure_message.assert_called_once_with(m, tag='not-found')
+
+    @mock.patch('pulp.bindings.consumer.BindingsAPI.unbind')
+    @mock.patch(LOAD_CONSUMER_API, return_value='c1')
+    def test_unbind_no_binding(self, mock_consumer, mock_unbind):
+        mock_unbind.side_effect = NotFoundException({'resources': ['bind_id']})
+        self.context.prompt = mock.MagicMock()
+
+        # Test
+        data = {'repo-id': 'repo1', 'force': 'false'}
+        self.command.unbind(**data)
+
+        # Verify
+        self.assertEqual(self.context.server.bind.unbind.call_count, 1)
+        self.assertEqual(self.context.prompt.render_success_message.call_count, 0)
+        self.assertEqual(self.context.prompt.render_failure_message.call_count, 1)
+        m = ('Binding [consumer: c1, repository: repo1] does not exist on the server')
+        self.context.prompt.render_failure_message.assert_called_once_with(m, tag='not-found')
+
+    @mock.patch(LOAD_CONSUMER_API, return_value=None)
+    def test_unbind_no_registered_consumer(self, mock_consumer):
+        self.command.prompt = mock.MagicMock()
+
+        # Test
+        data = {'repo-id': 'repo1', 'force': 'false'}
+        self.command.unbind(**data)
+
+        # Verify
+        self.assertEqual(self.command.prompt.render_success_message.call_count, 0)
+        self.assertEqual(self.command.prompt.render_failure_message.call_count, 1)
+        m = ('This consumer is not registered to the Pulp server')
+        self.command.prompt.render_failure_message.assert_called_once_with(m)


### PR DESCRIPTION
closes [617] (https://pulp.plan.io/issues/617)