### PR TITLE
ensure that logging is shutdown on test teardown.

### DIFF
--- a/devel/pulp_rpm/devel/rpm_support_base.py
+++ b/devel/pulp_rpm/devel/rpm_support_base.py
@@ -52,6 +52,7 @@ class PulpRPMTests(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
+        stop_logging()
         name = config.config.get('database', 'name')
         connection._CONNECTION.drop_database(name)
         shutil.rmtree('/tmp/pulp')


### PR DESCRIPTION
Fixes unit test failures but needs: https://github.com/pulp/pulp/pull/1769 to work.