### PR TITLE
sync errors now use PulpCodedException for better error reporting

### DIFF
--- a/plugins/pulp_rpm/plugins/error_codes.py
+++ b/plugins/pulp_rpm/plugins/error_codes.py
@@ -10,3 +10,6 @@ RPM1001 = Error("RPM1001", _("Error occurred parsing pulp_distribution.xml from 
                 ['feed'])
 RPM1002 = Error("RPM1002", _("Error uploading an RPM.  The specified file is a source rpm"), [])
 RPM1003 = Error("RPM1003", _("Error uploading an SRPM.  The specified file is a binary rpm"), [])
+RPM1004 = Error("RPM1004", _("Error retrieving metadata: %(reason)s"), ['reason'])
+RPM1005 = Error("RPM1005", _("Unable to sync a repository that has no feed."), [])
+RPM1006 = Error("RPM1006", _("Could not parse repository metadata"), [])


### PR DESCRIPTION
This depends on changes in pulp that better-handle PulpCodedException
reporting.

refs #702
refs #652 

https://pulp.plan.io/issues/652
https://pulp.plan.io/issues/702

https://github.com/pulp/pulp/pull/1772