### PR TITLE
treat 'epoch' as '0' when it does not exist or is null

### DIFF
--- a/plugins/pulp_rpm/plugins/profilers/yum.py
+++ b/plugins/pulp_rpm/plugins/profilers/yum.py
@@ -238,6 +238,9 @@ class YumProfiler(Profiler):
         """
         Return a list of RPMs that are referenced by an errata's pkglist
 
+        This method will translate 'null' to '0' in the epoch field. All
+        package lists should contain epoch fields but some do not.
+
         :param errata: The errata we wish to query for RPMs it contains
         :type errata:  pulp.plugins.model.Unit
         :return:       list of rpms, which are each a dict of nevra info
@@ -249,6 +252,8 @@ class YumProfiler(Profiler):
             return rpms
         for pkgs in errata.metadata['pkglist']:
             for rpm in pkgs["packages"]:
+                if 'epoch' not in rpm or rpm['epoch'] is None:
+                    rpm['epoch'] = '0'
                 rpms.append(rpm)
         return rpms
 

--- a/plugins/test/data/test_errata_install/updateinfo.xml
+++ b/plugins/test/data/test_errata_install/updateinfo.xml
@@ -22,6 +22,27 @@
 		</pkglist>
 	</update>
 	<update from="enhancements@redhat.com" status="final" type="enhancements" version="1">
+		<id>RHEA-2010:8888</id>
+		<title>test package enhancements sans epoch</title>
+		<issued date="2010-11-7 00:00:00"/>
+		<updated date="2010-11-8 00:00:00"/>
+		<description/>
+		<references/>
+		<pkglist>
+			<collection short="F13PTP">
+				<name>F13 Pulp Test Packages</name>
+				<package name="emoticons" version="0.1" release="2" arch="x86_64" src="xen-3.0.3-80.el5_3.3.src.rpm">
+					<filename>emoticons-0.1-2.x86_64.rpm</filename>
+					<sum type="md5">366bb5e73a5905eacb82c96e0578f92b</sum>
+				</package>
+				<package name="patb" version="0.1" release="2" arch="x86_64" src="xen-3.0.3-80.el5_3.3.src.rpm">
+					<filename>patb-0.1-2.x86_64.rpm</filename>
+					<sum type="md5">f3c197a29d9b66c5b65c5d62b25db5b4</sum>
+				</package>
+			</collection>
+		</pkglist>
+	</update>
+	<update from="enhancements@redhat.com" status="final" type="enhancements" version="1">
 		<id>RHEA-2014:9999</id>
 		<title>test package enhancements</title>
 		<issued date="2014-11-7 00:00:00"/>

--- a/plugins/test/unit/plugins/profilers/test_yum.py
+++ b/plugins/test/unit/plugins/profilers/test_yum.py
@@ -169,6 +169,30 @@ class TestYumProfilerErrata(rpm_support_base.PulpRPMTests):
                 self.assertTrue(r.has_key(key))
                 self.assertTrue(r[key])
 
+    def test_get_rpms_from_errata_no_epoch(self):
+        """
+        Test that we default to '0' for the epoch if one doesn't exist.
+        """
+        errata_obj = self.get_test_errata_object(eid='RHEA-2010:8888')
+        errata_unit = Unit(TYPE_ID_ERRATA, {"id": errata_obj["id"]}, errata_obj, None)
+        prof = YumProfiler()
+        rpms = prof._get_rpms_from_errata(errata_unit)
+        # Expected data:
+        # [{'src': 'xen-3.0.3-80.el5_3.3.src.rpm', 'name': 'emoticons',
+        #   'sum': ('md5', '366bb5e73a5905eacb82c96e0578f92b'),
+        #   'filename': 'emoticons-0.1-2.x86_64.rpm', 'epoch': '0',
+        #   'version': '0.1', 'release': '2', 'arch': 'x86_64'},
+        # {'src': 'xen-3.0.3-80.el5_3.3.src.rpm', 'name': 'patb',
+        #   'sum': ('md5', 'f3c197a29d9b66c5b65c5d62b25db5b4'),
+        #   'filename': 'patb-0.1-2.x86_64.rpm', 'epoch': '0',
+        #   'version': '0.1', 'release': '2', 'arch': 'x86_64'}]
+        self.assertEqual(len(rpms), 2)
+        self.assertTrue(rpms[0]["name"] in ['emoticons', 'patb'])
+        self.assertTrue(rpms[1]["name"] in ['emoticons', 'patb'])
+        for r in rpms:
+            self.assertTrue('epoch' in r)
+            self.assertTrue(r['epoch'] == '0')
+
     def test_rpms_applicable_to_consumer(self):
         errata_rpms = []
         prof = YumProfiler()


### PR DESCRIPTION
Some updateinfo.xml metadata does not contain the `epoch` field in package
records. In these cases, Pulp will not be able to find the appropriate RPM.

In these cases, we can assume that the epoch should be '0'. This allows Pulp to
find the RPM when applying packages to a system.

fixes #833