### PR TITLE
Ensure that logging is shutdown on test teardown.

### DIFF
--- a/devel/pulp_rpm/devel/rpm_support_base.py
+++ b/devel/pulp_rpm/devel/rpm_support_base.py
@@ -52,6 +52,7 @@ class PulpRPMTests(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
+        stop_logging()
         name = config.config.get('database', 'name')
         connection._CONNECTION.drop_database(name)
         shutil.rmtree('/tmp/pulp')


### PR DESCRIPTION
Reviewed on https://github.com/pulp/pulp_rpm/pull/669 and reopened here to merge to 2.6-testing.