### PR TITLE
Refs: #820 - raise coded exception when no RPM profiles exist.

### DIFF
--- a/docs/user-guide/release-notes/2.6.x.rst
+++ b/docs/user-guide/release-notes/2.6.x.rst
@@ -2,6 +2,19 @@
 Pulp 2.6 Release Notes
 ======================
 
+Pulp 2.6.2
+==========
+
+New Behaviors
+-------------
+Install errata tasks will fail during unit translation when the consumer
+does not have an RPM profile.
+
+Bug Fixes
+---------
+
+See the list of :fixedbugs:`2.6.2`
+
 Pulp 2.6.1
 ==========
 

--- a/plugins/pulp_rpm/plugins/profilers/yum.py
+++ b/plugins/pulp_rpm/plugins/profilers/yum.py
@@ -93,6 +93,9 @@ class YumProfiler(Profiler):
             if unit['type_id'] == TYPE_ID_RPM:
                 translated_units.append(unit)
             elif unit['type_id'] == TYPE_ID_ERRATA:
+                if TYPE_ID_RPM not in consumer.profiles:
+                    reason = _('Consumer has no RPM unit profile')
+                    raise InvalidUnitsRequested(units, reason)
                 values, upgrade_details = YumProfiler._translate_erratum(
                     unit, conduit.get_bindings(consumer.id), consumer, conduit)
                 if values:

--- a/plugins/test/unit/plugins/profilers/test_yum.py
+++ b/plugins/test/unit/plugins/profilers/test_yum.py
@@ -3,8 +3,10 @@ import os
 import shutil
 import tempfile
 
-from pulp.plugins.model import Consumer, Unit
 import mock
+
+from pulp.plugins.model import Consumer, Unit
+from pulp.plugins.profiler import InvalidUnitsRequested
 
 from pulp_rpm.common.ids import TYPE_ID_ERRATA, TYPE_ID_RPM
 from pulp_rpm.devel import rpm_support_base
@@ -360,6 +362,24 @@ class TestYumProfilerErrata(rpm_support_base.PulpRPMTests):
         for u in translated_units:
             rpm_unit_key = u["unit_key"]
             self.assertTrue(rpm_unit_key in expected)
+
+    def test_install_units_no_profile(self):
+        """
+        Test the InvalidUnitsRequested is raised when the consumer has no RPM profile.
+        """
+        config = {}
+        options = {}
+        conduit = mock.Mock()
+        consumer = mock.Mock(profiles={'OTHER': {}})
+        units = [{'type_id': TYPE_ID_ERRATA}]
+        self.assertRaises(
+            InvalidUnitsRequested,
+            YumProfiler.install_units,
+            consumer,
+            units,
+            options,
+            config,
+            conduit)
 
     def test_install_units_unit_not_in_repo(self):
         """


### PR DESCRIPTION
https://pulp.plan.io/issues/820

When the consumer does not have an RPM unit profile, the profiler will fail to translate the ERRATA unit into RPM units.

Example using the CLI:
```
[jortel@localhost pulp]$ pulp-admin rpm consumer errata install run --consumer-id=jeff -e foo
Consumer has no RPM unit profile
```