### PR TITLE
Enable basic auth as an option when syncing repos

### DIFF
--- a/docs/tech-reference/yum-plugins.rst
+++ b/docs/tech-reference/yum-plugins.rst
@@ -447,6 +447,12 @@ configuration values are optional.
 ``proxy_password``
  Password to use for proxy server authentication.
 
+``basic_auth_username``
+ Username to pass to the feed URL's server if it requires authentication.
+
+``basic_auth_password``
+ Password to use for server authentication.
+
 ``max_speed``
  The maximum download speed in bytes/sec for a task (such as a sync);
  defaults to None

--- a/docs/user-guide/recipes.rst
+++ b/docs/user-guide/recipes.rst
@@ -195,6 +195,10 @@ the "Download" link from the "Entitlement Certificate" column to retrieve the
 certificate and key, bundled into a single file. You can pass that same file as
 the ``--feed-cert`` and ``--feed-key`` options when you create the repo.
 
+It is also possible to sync a repo that is protected via basic authentication.
+The ``--basicauth-user`` and ``--basicauth-pass`` options are used for this
+during repo creation or update.
+
 .. _export-repos:
 
 Export Repositories and Repository Groups

--- a/docs/user-guide/release-notes/2.7.x.rst
+++ b/docs/user-guide/release-notes/2.7.x.rst
@@ -8,7 +8,11 @@ Pulp 2.7.0
 New Features
 ------------
 
-The repo authentication functionality associated with pulp_rpm has been moved
-into platform. This allows other plugins to take advantage of this
-functionality.
+* The repo authentication functionality associated with pulp_rpm has been moved
+  into platform. This allows other plugins to take advantage of this
+  functionality.
+
+* The RPM plugin supports basic auth when fetching data from upstream repos.
+  This can be configured via ``basicauth-user`` and ``basicauth-pass`` when
+  creating or updating a repository.
 

--- a/extensions_admin/pulp_rpm/extensions/admin/repo_create_update.py
+++ b/extensions_admin/pulp_rpm/extensions/admin/repo_create_update.py
@@ -64,6 +64,7 @@ class RpmRepoCreateCommand(CreateRepositoryCommand, ImporterConfigMixin):
                                      include_sync=True,
                                      include_ssl=True,
                                      include_proxy=True,
+                                     include_basic_auth=True,
                                      include_throttling=True,
                                      include_unit_policy=True)
 
@@ -197,6 +198,7 @@ class RpmRepoUpdateCommand(UpdateRepositoryCommand, ImporterConfigMixin):
                                      include_sync=True,
                                      include_ssl=True,
                                      include_proxy=True,
+                                     include_basic_auth=True,
                                      include_throttling=True,
                                      include_unit_policy=True)
 

--- a/extensions_admin/test/unit/extensions/admin/test_repo_create_update.py
+++ b/extensions_admin/test/unit/extensions/admin/test_repo_create_update.py
@@ -59,6 +59,8 @@ class RpmRepoCreateCommandTests(PulpClientTests):
             self.options_bundle.opt_proxy_port.keyword: 80,
             self.options_bundle.opt_proxy_user.keyword: 'user',
             self.options_bundle.opt_proxy_pass.keyword: 'pass',
+            self.options_bundle.opt_basic_auth_user.keyword: 'basicuser',
+            self.options_bundle.opt_basic_auth_pass.keyword: 'basicpass',
             self.options_bundle.opt_max_speed.keyword: 1024,
             self.options_bundle.opt_max_downloads.keyword: 8,
             self.options_bundle.opt_feed_ca_cert.keyword: ca_cert,
@@ -104,6 +106,8 @@ class RpmRepoCreateCommandTests(PulpClientTests):
         self.assertEqual(importer_config[constants.KEY_PROXY_PORT], 80)
         self.assertEqual(importer_config[constants.KEY_PROXY_USER], 'user')
         self.assertEqual(importer_config[constants.KEY_PROXY_PASS], 'pass')
+        self.assertEqual(importer_config[constants.KEY_BASIC_AUTH_USER], 'basicuser')
+        self.assertEqual(importer_config[constants.KEY_BASIC_AUTH_PASS], 'basicpass')
         self.assertEqual(importer_config[constants.KEY_MAX_SPEED], 1024)
         self.assertEqual(importer_config[constants.KEY_MAX_DOWNLOADS], 8)
         self.assertEqual(importer_config[repo_create_update.CONFIG_KEY_SKIP], [ids.TYPE_ID_RPM])

--- a/plugins/test/unit/plugins/distributors/yum/test_publish.py
+++ b/plugins/test/unit/plugins/distributors/yum/test_publish.py
@@ -587,7 +587,7 @@ class PublishDrpmStepTests(BaseYumDistributorPublishStepTests):
 
         self.assertTrue(step.is_skipped())
 
-    @mock.patch('pulp.server.db.model.dispatch.TaskStatus')
+    @mock.patch('pulp.server.db.model.TaskStatus')
     @mock.patch('pulp.plugins.conduits.repo_publish.RepoPublishConduit.get_units')
     def test_publish_drpms(self, mock_get_units, mock_update):
         self.publisher.repo.content_unit_counts = {TYPE_ID_DRPM: 2}
@@ -651,7 +651,7 @@ class PublishDistributionStepTests(BaseYumDistributorPublishStepTests):
 
         return Unit(TYPE_ID_DISTRO, unit_key, unit_metadata, storage_path)
 
-    @mock.patch('pulp.server.db.model.dispatch.TaskStatus')
+    @mock.patch('pulp.server.db.model.TaskStatus')
     @mock.patch('pulp_rpm.plugins.distributors.yum.publish.PublishDistributionStep.'
                 '_publish_distribution_packages_link')
     @mock.patch('pulp_rpm.plugins.distributors.yum.publish.PublishDistributionStep.'
@@ -674,7 +674,7 @@ class PublishDistributionStepTests(BaseYumDistributorPublishStepTests):
         mock_packages.assert_called_once_with(units[0])
         self.assertEquals(step.state, reporting_constants.STATE_COMPLETE)
 
-    @mock.patch('pulp.server.db.model.dispatch.TaskStatus')
+    @mock.patch('pulp.server.db.model.TaskStatus')
     @mock.patch('pulp_rpm.plugins.distributors.yum.publish.PublishDistributionStep.'
                 '_publish_distribution_treeinfo')
     @mock.patch('pulp.plugins.conduits.repo_publish.RepoPublishConduit.get_units')
@@ -856,7 +856,7 @@ class PublishRepoMetaDataStep(BaseYumDistributorPublishTests):
 
 class PublishRpmStepTests(BaseYumDistributorPublishStepTests):
 
-    @mock.patch('pulp.server.db.model.dispatch.TaskStatus')
+    @mock.patch('pulp.server.db.model.TaskStatus')
     @mock.patch('pulp.plugins.conduits.repo_publish.RepoPublishConduit.get_units')
     def test_publish_rpms(self, mock_get_units, mock_update):
         self.publisher.repo.content_unit_counts = {TYPE_ID_RPM: 3}
@@ -878,7 +878,7 @@ class PublishRpmStepTests(BaseYumDistributorPublishStepTests):
         self.assertTrue(os.path.exists(os.path.join(self.working_dir, 'repodata/other.xml.gz')))
         self.assertTrue(os.path.exists(os.path.join(self.working_dir, 'repodata/primary.xml.gz')))
 
-    @mock.patch('pulp.server.db.model.dispatch.TaskStatus')
+    @mock.patch('pulp.server.db.model.TaskStatus')
     @mock.patch('pulp.plugins.conduits.repo_publish.RepoPublishConduit.get_units')
     def test_process_unit_links_package_dir(self, mock_get_units, mock_update):
         unit = self._generate_rpm('one')
@@ -951,7 +951,7 @@ class PublishMetadataStepTests(BaseYumDistributorPublishStepTests):
 
         return Unit(TYPE_ID_YUM_REPO_METADATA_FILE, unit_key, unit_metadata, storage_path)
 
-    @mock.patch('pulp.server.db.model.dispatch.TaskStatus')
+    @mock.patch('pulp.server.db.model.TaskStatus')
     @mock.patch('pulp.plugins.conduits.repo_publish.RepoPublishConduit.get_units')
     def test_publish_metadata(self, mock_get_units, mock_update):
         # Setup


### PR DESCRIPTION
This requires https://github.com/pulp/pulp/pull/1821.

fixes #163