### PR TITLE
Initialize the DB connection in the test package.

### DIFF
--- a/devel/pulp_rpm/devel/rpm_support_base.py
+++ b/devel/pulp_rpm/devel/rpm_support_base.py
@@ -5,7 +5,6 @@ import unittest
 
 from pulp.server import config
 from pulp.server.managers.auth.cert.cert_generator import SerialNumber
-from pulp.server.db import connection
 from pulp.server.logs import start_logging, stop_logging
 from pulp.server.managers import factory as manager_factory
 
@@ -43,16 +42,12 @@ class PulpRPMTests(unittest.TestCase):
         config_filename = os.path.join(TEST_DATA_DIR, 'test-override-pulp.conf')
         config.config.read(config_filename)
         start_logging()
-        name = config.config.get('database', 'name')
-        connection.initialize(name)
         manager_factory.initialize()
         constants.DISTRIBUTION_STORAGE_PATH = TEMP_DISTRO_STORAGE_DIR
 
     @classmethod
     def tearDownClass(cls):
         stop_logging()
-        name = config.config.get('database', 'name')
-        connection._CONNECTION.drop_database(name)
         shutil.rmtree('/tmp/pulp')
 
     def setUp(self):

--- a/plugins/pulp_rpm/plugins/distributors/yum/distributor.py
+++ b/plugins/pulp_rpm/plugins/distributors/yum/distributor.py
@@ -4,7 +4,7 @@ import shutil
 
 from pulp.common.config import read_json_config
 from pulp.plugins.distributor import Distributor
-from pulp.server.config import config as pulp_server_config
+from pulp.server import config as pulp_server_config
 
 import pulp_rpm.common.constants as constants
 from pulp_rpm.common.ids import (
@@ -202,8 +202,8 @@ class YumHTTPDistributor(Distributor):
         """
         payload = dict()
         payload['repo_name'] = repo.display_name
-        payload['server_name'] = pulp_server_config.get('server', 'server_name')
-        ssl_ca_path = pulp_server_config.get('security', 'ssl_ca_certificate')
+        payload['server_name'] = pulp_server_config.config.get('server', 'server_name')
+        ssl_ca_path = pulp_server_config.config.get('security', 'ssl_ca_certificate')
         try:
             payload['ca_cert'] = open(ssl_ca_path).read()
         except (OSError, IOError):

--- a/plugins/test/unit/__init__.py
+++ b/plugins/test/unit/__init__.py
@@ -1,3 +1,20 @@
 from pkgutil import extend_path
 
+from pulp.devel.unit.server import base as devel_base
+
+
 __path__ = extend_path(__path__, __name__)
+
+
+def setup():
+    """
+    Set up the database connection for the tests to use.
+    """
+    devel_base.start_database_connection()
+
+
+def teardown():
+    """
+    Drop the test database.
+    """
+    devel_base.drop_database()


### PR DESCRIPTION
Use the test package to start the database connection, rather than
relying on test superclasses to do it. This way, only one database
connection will happen during the unit tests rather than one per test
class.

https://pulp.plan.io/issues/131

re #131