### PR TITLE
Depend on python-pulp-oid_validation instead of python-pulp-repoauth

### DIFF
--- a/pulp-rpm.spec
+++ b/pulp-rpm.spec
@@ -157,7 +157,7 @@ A collection of modules shared among all RPM components.
 Summary: Pulp RPM plugins
 Group: Development/Languages
 Requires: python-pulp-rpm-common = %{pulp_version}
-Requires: python-pulp-repoauth >= 2.6.0
+Requires: python-pulp-oid_validation >= 2.7.0
 Requires: pulp-server = %{pulp_version}
 Requires: createrepo >= 0.9.9-21
 Requires: createrepo_c >= 0.4.1-1


### PR DESCRIPTION
Python-pulp-repoauth now supplies the repo auth framework but does not supply
any authenticatiors. The OID validation RPM supplies the actual cert check now.

This depends on https://github.com/pulp/pulp/pull/1869/.

fixes #975

https://pulp.plan.io/issues/975