### PR TITLE
Fixing discrepancy "canceled" vs. "cancelled

### DIFF
--- a/docs/user-guide/isos.rst
+++ b/docs/user-guide/isos.rst
@@ -105,7 +105,7 @@ file::
 
     Starting upload of selected units. If this process is stopped through ctrl+c,
     the uploads will be paused and may be resumed later using the resume command or
-    cancelled entirely using the cancel command.
+    canceled entirely using the cancel command.
 
     Uploading: Fedora-17-x86_64-Live-Desktop.iso
     [==================================================] 100%

--- a/docs/user-guide/recipes.rst
+++ b/docs/user-guide/recipes.rst
@@ -539,7 +539,7 @@ Now that we have these two files, we can create our new errata like so::
 
     Starting upload of selected units. If this process is stopped through ctrl+c,
     the uploads will be paused and may be resumed later using the resume command or
-    cancelled entirely using the cancel command.
+    canceled entirely using the cancel command.
 
     Importing into the repository...
     ... completed
@@ -627,7 +627,7 @@ Now let's build a package group for our demo repo test files::
 
    Starting upload of selected units. If this process is stopped through ctrl+c,
    the uploads will be paused and may be resumed later using the resume command or
-   cancelled entirely using the cancel command.
+   canceled entirely using the cancel command.
 
    Importing into the repository...
    ... completed
@@ -796,7 +796,7 @@ two groups::
 
     Starting upload of selected units. If this process is stopped through ctrl+c,
     the uploads will be paused and may be resumed later using the resume command or
-    cancelled entirely using the cancel command.
+    canceled entirely using the cancel command.
 
     Importing into the repository...
     ... completed

--- a/extensions_admin/pulp_rpm/extensions/admin/iso/status.py
+++ b/extensions_admin/pulp_rpm/extensions/admin/iso/status.py
@@ -29,7 +29,7 @@ class ISOStatusRenderer(StatusRenderer):
             self._display_iso_sync_report(sync_report)
 
             if sync_report.state == sync_report.STATE_CANCELLED:
-                self.prompt.render_failure_message('The download was cancelled.', tag='cancelled')
+                self.prompt.render_failure_message('The download was canceled.', tag='canceled')
 
         if ids.TYPE_ID_DISTRIBUTOR_ISO in progress_report:
             publish_report = progress.PublishProgressReport.from_progress_report(

--- a/extensions_admin/pulp_rpm/extensions/admin/status.py
+++ b/extensions_admin/pulp_rpm/extensions/admin/status.py
@@ -77,7 +77,7 @@ class RpmStatusRenderer(StatusRenderer):
                 self.publish_steps_renderer.display_report(progress_report)
 
         except CancelException:
-            self.prompt.render_failure_message(_('Operation cancelled.'))
+            self.prompt.render_failure_message(_('Operation canceled.'))
 
     def check_for_cancelled_state(self, state):
         if state == constants.STATE_CANCELLED:

--- a/extensions_admin/test/unit/extensions/admin/iso/test_extension_admin_iso_status.py
+++ b/extensions_admin/test/unit/extensions/admin/iso/test_extension_admin_iso_status.py
@@ -127,7 +127,7 @@ class TestISOStatusRenderer(unittest.TestCase):
         # A message should have been rendered to the user about the cancellation
         self.assertEqual(renderer.prompt.render_failure_message.call_count, 1)
         self.assertEqual(renderer.prompt.render_failure_message.mock_calls[0][2]['tag'],
-                         'cancelled')
+                         'canceled')
 
     @mock.patch('pulp_rpm.extensions.admin.iso.status.ISOStatusRenderer._display_publish_report',
                 side_effect=status.ISOStatusRenderer._display_publish_report, autospec=True)


### PR DESCRIPTION
I also changed all the docs and messages not to confuse the users. I did not touch any variables' or methods' name.
closes #966
https://pulp.plan.io/issues/966