### PR TITLE
Use mongoengine repo model

### DIFF
--- a/devel/pulp_rpm/devel/rpm_support_base.py
+++ b/devel/pulp_rpm/devel/rpm_support_base.py
@@ -1,7 +1,11 @@
 from urlparse import urljoin
 import os
 import shutil
-import unittest
+
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 from pulp.server import config
 from pulp.server.managers.auth.cert.cert_generator import SerialNumber

--- a/plugins/pulp_rpm/plugins/distributors/yum/publish.py
+++ b/plugins/pulp_rpm/plugins/distributors/yum/publish.py
@@ -11,9 +11,8 @@ from pulp.plugins.conduits.repo_publish import RepoPublishConduit
 from pulp.plugins.util.publish_step import PublishStep, UnitPublishStep, CopyDirectoryStep,\
     CreatePulpManifestStep
 from pulp.plugins.util.publish_step import AtomicDirectoryPublishStep
+from pulp.server.db import model
 from pulp.server.db.model.criteria import UnitAssociationCriteria
-from pulp.server.managers.repo.query import RepoQueryManager
-import pulp.server.managers.repo._common as common_utils
 from pulp.server.exceptions import InvalidValue, PulpCodedException
 
 from pulp_rpm.common import constants
@@ -191,13 +190,12 @@ class ExportRepoGroupPublisher(PublishStep):
         else:
             repo_config = PluginCallConfiguration(flat_config, {constants.EXPORT_DIRECTORY_KEYWORD:
                                                                 realized_dir})
-        query_manager = RepoQueryManager()
 
-        repos = query_manager.find_by_id_list(repo_group.repo_ids)
+        repo_objs = model.Repository.objects(repo_id__in=repo_group.repo_ids)
         empty_repos = True
-        for repo in repos:
+        for repo_obj in repo_objs:
             empty_repos = False
-            repo = common_utils.to_transfer_repo(repo)
+            repo = repo_obj.to_transfer_repo()
             # Make sure we only publish rpm repo's
             if repo.notes['_repo-type'] != 'rpm-repo':
                 continue

--- a/plugins/pulp_rpm/plugins/migrations/0003_custom_metadata_on_scratchpad.py
+++ b/plugins/pulp_rpm/plugins/migrations/0003_custom_metadata_on_scratchpad.py
@@ -9,6 +9,7 @@ from pulp.server import config as pulp_config
 from pulp.server.managers import factory
 
 from pulp_rpm.yum_plugin import util
+from pulp.server.db.migrations.lib import managers
 
 
 _log = logging.getLogger('pulp')
@@ -88,7 +89,7 @@ def preserve_custom_metadata_on_repo_scratchpad():
      and set the the data on repo scratchpad.
     """
     factory.initialize()
-    repos = factory.repo_query_manager().find_with_importer_type("yum_importer")
+    repos = managers.RepoManager().find_with_importer_type("yum_importer")
     if not repos:
         _log.debug("No repos found to perform db migrate")
         return

--- a/plugins/test/unit/plugins/migrations/test_0016_new_yum_distributor.py
+++ b/plugins/test/unit/plugins/migrations/test_0016_new_yum_distributor.py
@@ -8,7 +8,8 @@ import mock
 from pulp.common import dateutils
 from pulp.server import config as pulp_config
 from pulp.server.db.migrate.models import _import_all_the_way
-from pulp.server.db.model.repository import Repo, RepoDistributor
+from pulp.server.db import model
+from pulp.server.db.model.repository import RepoDistributor
 
 from pulp_rpm.devel import rpm_support_base
 
@@ -20,7 +21,6 @@ class BaseMigrationTests(rpm_support_base.PulpRPMTests):
     def setUp(self):
         super(BaseMigrationTests, self).setUp()
 
-        self.repos_collection = Repo.get_collection()
         self.distributors_collection = RepoDistributor.get_collection()
 
         self.root_test_dir = tempfile.mkdtemp(prefix='test_0016_migration_')
@@ -32,7 +32,7 @@ class BaseMigrationTests(rpm_support_base.PulpRPMTests):
     def tearDown(self):
         super(BaseMigrationTests, self).tearDown()
 
-        self.repos_collection.drop()
+        model.Repository.drop_collection()
         self.distributors_collection.drop()
 
         shutil.rmtree(self.root_test_dir, ignore_errors=True)
@@ -40,9 +40,9 @@ class BaseMigrationTests(rpm_support_base.PulpRPMTests):
     # -- test data setup -------------------------------------------------------
 
     def _generate_repo(self, repo_id):
-        repo_model = Repo(repo_id, repo_id)
-        self.repos_collection.insert(repo_model)
-        return self.repos_collection.find_one({'id': repo_id})
+        repo_model = model.Repository(repo_id=repo_id, display_name=repo_id)
+        repo_model.save()
+        return repo_model
 
     def _generate_distributor(self, repo_id, config=None, previously_published=True):
         config = config or {}


### PR DESCRIPTION
This PR uses mongoengine to access repos rather than using the db directly. It also removes the use of code that was removed in https://github.com/pulp/pulp/pull/1931.

This cannot be merged until 1931 has been merged, but this code is necessary to test core if you have rpm installed.