### PR TITLE
Fix repomd.xml parsing with an empty revision tag

### DIFF
--- a/plugins/pulp_rpm/plugins/importers/yum/repomd/metadata.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/repomd/metadata.py
@@ -166,7 +166,7 @@ class MetadataFiles(object):
             if element.tag == REVISION_TAG:
                 try:
                     self.revision = int(element.text)
-                except ValueError:
+                except (TypeError, ValueError):
                     _LOGGER.info('repository revision is not an integer. '
                                  'unable to consider skipping steps.')
                     self.revision = 0


### PR DESCRIPTION
The NSA SIMP 5.1.X repodata contains a <revision /> tag which busts sync
with the following splat:

 Downloading metadata from https://dl.bintray.com/simp/5.1.X/.
 Starting new HTTPS connection (1): dl.bintray.com
 Parsing metadata.
  sync failed
  Traceback (most recent call last):
    File ".../sync.py", line 142, in run
      metadata_files = self.get_metadata()
    File ".../sync.py", line 226, in get_metadata
      metadata_files.parse_repomd()
    File ".../metadata.py", line 165, in parse_repomd
      self.revision = int(element.text)
  TypeError: int() argument must be a string or a number, not 'NoneType'