### PR TITLE
Fix issue 1264

### DIFF
--- a/plugins/pulp_rpm/plugins/importers/yum/utils.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/utils.py
@@ -52,7 +52,7 @@ def element_to_raw_xml(element, namespaces_to_register=None, default_namespace_u
 
     tree = ET.ElementTree(element)
     io = StringIO()
-    tree.write(io)
+    tree.write(io, encoding='UTF-8')
     ret = io.getvalue()
 
     for namespace in namespaces_to_register:


### PR DESCRIPTION
Python 2.6 default encoding is ascii, so we need to force UTF-8