### PR TITLE
Removing shutil.move and copytree where /var/chache/pulp is involved

### DIFF
--- a/plugins/pulp_rpm/plugins/importers/yum/parse/treeinfo.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/parse/treeinfo.py
@@ -86,7 +86,7 @@ def sync(sync_conduit, feed, working_dir, nectar_config, report, progress_callba
             model.process_download_reports(listener.succeeded_reports)
             # remove pre-existing dir
             shutil.rmtree(unit.storage_path, ignore_errors=True)
-            shutil.move(tmp_dir, unit.storage_path)
+            shutil.copy(tmp_dir, unit.storage_path)
             # mkdtemp is very paranoid, so we'll change to more sensible perms
             os.chmod(unit.storage_path, 0o775)
             sync_conduit.save_unit(unit)

--- a/plugins/test/unit/plugins/importers/yum/test_sync.py
+++ b/plugins/test/unit/plugins/importers/yum/test_sync.py
@@ -1674,7 +1674,7 @@ repodata/repomd.xml = sha256:9876
 
 # these tests are specifically to test bz #1150714
 @mock.patch('os.chmod', autospec=True)
-@mock.patch('shutil.move', autospec=True)
+@mock.patch('shutil.copy', autospec=True)
 @mock.patch('pulp_rpm.plugins.importers.yum.parse.treeinfo.get_treefile', autospec=True)
 @mock.patch('pulp_rpm.plugins.importers.yum.parse.treeinfo.parse_treefile', autospec=True)
 @mock.patch('pulp_rpm.plugins.importers.yum.report.DistributionReport', autospec=True)


### PR DESCRIPTION
closes #1269