### PR TITLE
patch an internal function that is not tested

### DIFF
--- a/plugins/test/unit/plugins/importers/yum/test_sync.py
+++ b/plugins/test/unit/plugins/importers/yum/test_sync.py
@@ -750,7 +750,8 @@ class TestDecideRPMsToDownload(BaseSyncTest):
         mock_identify.return_value = {model.as_named_tuple: 1024}
         mock_check_repo.return_value = set([model.as_named_tuple])
 
-        ret = self.reposync._decide_rpms_to_download(self.metadata_files)
+        with mock.patch.object(self.conduit, 'search_all_units'):
+            ret = self.reposync._decide_rpms_to_download(self.metadata_files)
 
         self.assertEqual(ret, (set([model.as_named_tuple]), 1, 1024))
         mock_open.assert_called_once_with('/path/to/primary', 'r')
@@ -809,7 +810,8 @@ class TestDecideDRPMsToDownload(BaseSyncTest):
         mock_identify.return_value = {model.as_named_tuple: 1024}
         mock_check_repo.return_value = set([model.as_named_tuple])
 
-        ret = self.reposync._decide_drpms_to_download(self.metadata_files)
+        with mock.patch.object(self.conduit, 'search_all_units'):
+            ret = self.reposync._decide_drpms_to_download(self.metadata_files)
 
         self.assertEqual(ret, (set([model.as_named_tuple]), 1, 1024))
         mock_open.assert_called_once_with('/path/to/presto', 'r')


### PR DESCRIPTION
This change in pulp caused two unit tests to break in pulp_rpm:
https://github.com/pulp/pulp/pull/2037/files#diff-8613e089ba042e02761c8527b3c58905L221

In these tests using the old path, `types_db.type_definition(type_id)` returned `None`, which would cause problems except that there are no units, and iteration below never happened. This is fixed by mocking the whole function since it wasn't really being tested anyway.