### PR TITLE
RepoImporter model was removed in mongoengine switch

### DIFF
--- a/plugins/pulp_rpm/plugins/migrations/0007_inventoried_custom_metadata.py
+++ b/plugins/pulp_rpm/plugins/migrations/0007_inventoried_custom_metadata.py
@@ -9,7 +9,7 @@ from xml.etree import ElementTree
 from pulp.plugins.types import database as types_database
 from pulp.server import config as pulp_config
 from pulp.server.db.connection import get_collection
-from pulp.server.db.model.repository import RepoImporter, RepoContentUnit
+from pulp.server.db.model.repository import RepoContentUnit
 
 
 _LOG = logging.getLogger('pulp')
@@ -99,7 +99,7 @@ def migrate_repo(repo):
 # -- pulp utilities ------------------------------------------------------------
 
 def repositories_with_yum_importers():
-    repo_importer_collection = RepoImporter.get_collection()
+    repo_importer_collection = get_collection('repo_importers')
     repo_yum_importers = repo_importer_collection.find({'importer_type_id': _TYPE_YUM_IMPORTER},
                                                        fields=['repo_id'])
     yum_repo_ids = [i['repo_id'] for i in repo_yum_importers]

--- a/plugins/test/unit/plugins/migrations/test_0004_migrate.py
+++ b/plugins/test/unit/plugins/migrations/test_0004_migrate.py
@@ -3,7 +3,8 @@ import mock
 from pulp.plugins.types import database as types_db
 from pulp.plugins.types.model import TypeDefinition
 from pulp.server.db import model
-from pulp.server.db.model.repository import RepoContentUnit, RepoImporter
+from pulp.server.db.connection import get_collection
+from pulp.server.db.model.repository import RepoContentUnit
 from pulp.server.db.migrate.models import _import_all_the_way
 from pulp.server.managers import factory
 
@@ -38,11 +39,11 @@ class Migration0004Tests(rpm_support_base.PulpRPMTests):
         dest_repo = model.Repository(repo_id=self.dest_repo_id)
         dest_repo.save()
 
-        source_importer = RepoImporter(self.source_repo_id, 'yum_importer', 'yum_importer', {})
-        RepoImporter.get_collection().insert(source_importer)
+        source_importer = model.Importer(self.source_repo_id, 'yum_importer', {})
+        source_importer.save()
 
-        dest_importer = RepoImporter(self.dest_repo_id, 'yum_importer', 'yum_importer', {})
-        RepoImporter.get_collection().insert(dest_importer)
+        dest_importer = model.Importer(self.dest_repo_id, 'yum_importer', {})
+        dest_importer.save()
 
     def tearDown(self):
         super(Migration0004Tests, self).tearDown()
@@ -51,7 +52,7 @@ class Migration0004Tests(rpm_support_base.PulpRPMTests):
         types_db.clean()
 
         RepoContentUnit.get_collection().remove()
-        RepoImporter.get_collection().remove()
+        get_collection('repo_importers').remove()
         model.Repository.drop_collection()
 
     def test_migrate_duplicates(self):


### PR DESCRIPTION
Remove the use of a model that no longer exists in master.