### PR TITLE
Handle repositories with duplicate NEVRA

### DIFF
--- a/plugins/pulp_rpm/plugins/importers/yum/listener.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/listener.py
@@ -7,6 +7,7 @@ from pulp.plugins.util import verification
 
 from pulp_rpm.common import constants
 from pulp_rpm.plugins.db import models
+from pulp_rpm.plugins.importers.yum import purge
 
 
 _logger = logging.getLogger(__name__)
@@ -80,6 +81,9 @@ class ContentListener(DownloadEventListener):
         # init unit, which is idempotent
         unit = self.sync_conduit.init_unit(model.TYPE, model.unit_key, model.metadata,
                                            model.relative_path)
+        # check if the unit has duplicate nevra
+        repo_id = self.sync_conduit.repo_id
+        purge.remove_unit_duplicate_nevra(unit.unit_key, unit.type_id, repo_id)
         # move to final location.
         # we cannot use here shutil.move because it preserves all the file attributes,
         # even the selinux labels from the the source directory, that has different label

--- a/plugins/pulp_rpm/plugins/importers/yum/purge.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/purge.py
@@ -4,6 +4,7 @@ import logging
 
 from pulp.common.plugins import importer_constants
 from pulp.server.db.model.criteria import UnitAssociationCriteria
+from pulp.server.managers.repo.unit_association import RepoUnitAssociationManager
 
 from pulp_rpm.plugins.db import models
 from pulp_rpm.plugins.importers.yum.repomd import packages, primary, presto, updateinfo, group
@@ -260,3 +261,27 @@ def get_remote_units(file_function, tag, process_func):
     finally:
         file_handle.close()
     return remote_named_tuples
+
+
+def remove_unit_duplicate_nevra(unit_key, type_id, repo_id):
+    """
+    Removes from the repo units that have same NEVRA.
+
+    :param unit_key: dictionary of key:value pairs that make a unique
+                     identifier of the unit specified by the user
+    :type unit_key: dict
+    :param type_id: type of unit being checked for duplicate nevra
+    :type type_id:  str
+    :param repo_id: id of the repo from which units will be unassociated
+    :type repo_id:  str
+    """
+    nevra_filters = unit_key.copy()
+    del nevra_filters['checksum']
+    del nevra_filters['checksumtype']
+    list_filters = []
+    for i in nevra_filters.items():
+        list_filters.append(dict([i]))
+    filters = {'$and': list_filters}
+    criteria = UnitAssociationCriteria(type_ids=type_id, unit_filters=filters)
+    # unassociate unit from repo with same nevra
+    RepoUnitAssociationManager.unassociate_by_criteria(repo_id, criteria)

--- a/plugins/pulp_rpm/plugins/importers/yum/upload.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/upload.py
@@ -13,7 +13,7 @@ from pulp.server.exceptions import PulpCodedValidationException, PulpCodedExcept
 
 from pulp_rpm.plugins.db import models
 from pulp_rpm.plugins import error_codes
-from pulp_rpm.plugins.importers.yum import utils
+from pulp_rpm.plugins.importers.yum import purge, utils
 from pulp_rpm.plugins.importers.yum.parse import rpm as rpm_parse
 from pulp_rpm.plugins.importers.yum.repomd import primary, group, packages
 
@@ -312,7 +312,8 @@ def _handle_package(repo, type_id, unit_key, metadata, file_path, conduit, confi
     unit.metadata['repodata'] = rpm_parse.get_package_xml(unit.storage_path,
                                                           sumtype=new_unit_key['checksumtype'])
     _update_provides_requires(unit)
-
+    # check if the unit has duplicate nevra
+    purge.remove_unit_duplicate_nevra(unit.unit_key, unit.type_id, repo.id)
     # Save the unit in Pulp
     conduit.save_unit(unit)
 

--- a/plugins/test/unit/plugins/importers/yum/test_listener.py
+++ b/plugins/test/unit/plugins/importers/yum/test_listener.py
@@ -18,7 +18,8 @@ class TestContentListener(unittest.TestCase):
         self.report = mock.MagicMock()
 
     @mock.patch('shutil.copy', autospec=True)
-    def test_download_successful(self, mock_copy):
+    @mock.patch('pulp_rpm.plugins.importers.yum.listener.purge.remove_unit_duplicate_nevra')
+    def test_download_successful(self, mock_copy, mock_nevra):
         self.sync_call_config.get.return_value = False
         content_listener = listener.ContentListener(self.sync_conduit, self.progress_report,
                                                     self.sync_call_config, self.metadata_files)
@@ -28,8 +29,9 @@ class TestContentListener(unittest.TestCase):
     @mock.patch('__builtin__.open', autospec=True)
     @mock.patch('pulp.plugins.util.verification.verify_checksum')
     @mock.patch('pulp.plugins.util.verification.verify_size')
+    @mock.patch('pulp_rpm.plugins.importers.yum.listener.purge.remove_unit_duplicate_nevra')
     @mock.patch('shutil.copy', autospec=True)
-    def test_download_successful_with_validation(self, mock_copy, mock_verify_size,
+    def test_download_successful_with_validation(self, mock_copy, mock_nevra, mock_verify_size,
                                                  mock_verify_checksum, mock_open):
         self.sync_call_config.get.return_value = True
         content_listener = listener.ContentListener(self.sync_conduit, self.progress_report,

--- a/plugins/test/unit/plugins/importers/yum/test_purge.py
+++ b/plugins/test/unit/plugins/importers/yum/test_purge.py
@@ -294,3 +294,21 @@ class TestPurgeUnwantedUnits(TestPurgeBase):
         purge.purge_unwanted_units(self.metadata_files, self.conduit, self.config)
 
         mock_remove_old_versions.assert_called_once_with(3, self.conduit)
+
+
+class RemoveUnitDuplicateNevra(TestPurgeBase):
+
+    @mock.patch.object(purge, 'RepoUnitAssociationManager', autospec=True)
+    @mock.patch.object(purge, 'UnitAssociationCriteria', autospec=True)
+    def test_remove_unit_duplicate_nerva(self, mock_criteria, mock_association):
+        unit_key = {'name': 'test-nevra', 'epoch': 0, 'version': 1, 'release': '23',
+                    'arch': 'noarch', 'checksum': '1234abc', 'checksumtype': 'sha256'}
+        type_id = 'rpm'
+        repo_id = 'test-repo'
+        mock_criteria.return_value = {'$and': [{'some': 'criteria'}]}
+
+        purge.remove_unit_duplicate_nevra(unit_key, type_id, repo_id)
+
+        mock_association.unassociate_by_criteria.assert_called_once_with(
+            repo_id,
+            mock_criteria.return_value)

--- a/plugins/test/unit/plugins/importers/yum/test_upload.py
+++ b/plugins/test/unit/plugins/importers/yum/test_upload.py
@@ -470,8 +470,9 @@ class UploadPackageTests(unittest.TestCase):
         if os.path.exists(self.tmp_dir):
             shutil.rmtree(self.tmp_dir)
 
+    @mock.patch('pulp_rpm.plugins.importers.yum.upload.purge.remove_unit_duplicate_nevra')
     @mock.patch('pulp_rpm.plugins.importers.yum.upload._generate_rpm_data')
-    def test_handle_package(self, mock_generate):
+    def test_handle_package(self, mock_generate, mock_nevra):
         # Setup
         unit_key = {
             'name': 'walrus',


### PR DESCRIPTION
closes#494
https://pulp.plan.io/issues/494

Units with duplicate nevra are removed from the repo in case of sync or upload.