### PR TITLE
Handle repositories with duplicate NEVRA

### DIFF
--- a/plugins/pulp_rpm/plugins/importers/yum/listener.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/listener.py
@@ -7,6 +7,7 @@ from pulp.plugins.util import verification
 
 from pulp_rpm.common import constants
 from pulp_rpm.plugins.db import models
+from pulp_rpm.plugins.importers.yum import purge
 
 
 _logger = logging.getLogger(__name__)
@@ -79,6 +80,9 @@ class ContentListener(DownloadEventListener):
             self.metadata_files.add_repodata(model)
         # init unit, which is idempotent
         unit = self.sync_conduit.init_unit(model.TYPE, model.unit_key, model.metadata, model.relative_path)
+        # check if the unit has duplicate nevra
+        repo_id = self.sync_conduit.repo_id
+        purge.remove_unit_duplicate_nevra(unit.unit_key, unit.type_id, repo_id)
         # move to final location
         shutil.move(report.destination, unit.storage_path)
         # save unit

--- a/plugins/pulp_rpm/plugins/importers/yum/purge.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/purge.py
@@ -4,7 +4,8 @@ import logging
 
 from pulp.common.plugins import importer_constants
 from pulp.server.db.model.criteria import UnitAssociationCriteria
-from pulp.server.managers.repo.unit_association import OWNER_TYPE_IMPORTER
+from pulp.server.managers.repo.unit_association import (OWNER_TYPE_IMPORTER,
+                                                        RepoUnitAssociationManager)
 
 from pulp_rpm.plugins.db import models
 from pulp_rpm.plugins.importers.yum.repomd import packages, primary, presto, updateinfo, group
@@ -263,3 +264,29 @@ def get_remote_units(file_function, tag, process_func):
     finally:
         file_handle.close()
     return remote_named_tuples
+
+
+def remove_unit_duplicate_nevra(unit_key, type_id, repo_id):
+    """
+    Removes units from the repo that have same NEVRA, ignoring the checksum
+    and checksum type.
+
+    :param unit_key: dictionary of key:value pairs that make a unique
+                     identifier of the unit specified by the user
+    :type unit_key: dict
+    :param type_id: type of unit being checked for duplicate nevra
+    :type type_id:  str
+    :param repo_id: id of the repo from which units will be unassociated
+    :type repo_id:  str
+    """
+    nevra_filters = unit_key.copy()
+    del nevra_filters['checksum']
+    del nevra_filters['checksumtype']
+    list_filters = []
+    for i in nevra_filters.items():
+        list_filters.append(dict([i]))
+    filters = {'$and': list_filters}
+    criteria = UnitAssociationCriteria(type_ids=type_id, unit_filters=filters)
+    # unassociate unit from repo that match given criteria
+    RepoUnitAssociationManager.unassociate_by_criteria(repo_id, criteria, None, None)
+

--- a/plugins/test/unit/plugins/importers/yum/test_listener.py
+++ b/plugins/test/unit/plugins/importers/yum/test_listener.py
@@ -18,18 +18,23 @@ class TestContentListener(unittest.TestCase):
         self.report = mock.MagicMock()
 
     @mock.patch('shutil.move', autospec=True)
-    def test_download_successful(self, mock_move):
+    @mock.patch('pulp_rpm.plugins.importers.yum.listener.purge.remove_unit_duplicate_nevra')
+    def test_download_successful(self, mock_nevra, mock_move):
         self.sync_call_config.get.return_value = False
         content_listener = listener.ContentListener(self.sync_conduit, self.progress_report,
                                                     self.sync_call_config, self.metadata_files)
         content_listener.download_succeeded(self.report)
         self.progress_report['content'].success.assert_called_once_with(self.report.data)
+        mock_nevra.assert_called_once_with(self.sync_conduit.init_unit().unit_key,
+                                           self.sync_conduit.init_unit().type_id,
+                                           self.sync_conduit.repo_id)
 
     @mock.patch('__builtin__.open', autospec=True)
     @mock.patch('pulp.plugins.util.verification.verify_checksum')
     @mock.patch('pulp.plugins.util.verification.verify_size')
+    @mock.patch('pulp_rpm.plugins.importers.yum.listener.purge.remove_unit_duplicate_nevra')
     @mock.patch('shutil.move', autospec=True)
-    def test_download_successful_with_validation(self, mock_move, mock_verify_size,
+    def test_download_successful_with_validation(self, mock_move, mock_nevra, mock_verify_size,
                                                  mock_verify_checksum, mock_open):
         self.sync_call_config.get.return_value = True
         content_listener = listener.ContentListener(self.sync_conduit, self.progress_report,
@@ -39,6 +44,9 @@ class TestContentListener(unittest.TestCase):
         self.progress_report['content'].success.assert_called_once_with(self.report.data)
         mock_verify_size.assert_called_once()
         mock_verify_checksum.assert_called_once()
+        mock_nevra.assert_called_once_with(self.sync_conduit.init_unit().unit_key,
+                                           self.sync_conduit.init_unit().type_id,
+                                           self.sync_conduit.repo_id)
 
     @mock.patch('__builtin__.open', autospec=True)
     @mock.patch('pulp.plugins.util.verification.verify_checksum')

--- a/plugins/test/unit/plugins/importers/yum/test_purge.py
+++ b/plugins/test/unit/plugins/importers/yum/test_purge.py
@@ -134,6 +134,7 @@ class TestGetExistingUnits(TestPurgeBase):
 
 class TestGetRemoteUnits(TestPurgeBase):
     FAKE_TYPE = 'fake_type'
+
     def setUp(self):
         super(TestGetRemoteUnits, self).setUp()
         self.metadata_files.metadata[self.FAKE_TYPE] = {'local_path': '/a/b/c'}
@@ -288,3 +289,30 @@ class TestPurgeUnwantedUnits(TestPurgeBase):
         purge.purge_unwanted_units(self.metadata_files, self.conduit, self.config)
 
         mock_remove_old_versions.assert_called_once_with(3, self.conduit)
+
+
+class RemoveUnitDuplicateNevra(TestPurgeBase):
+
+    @mock.patch.object(purge, 'RepoUnitAssociationManager', autospec=True)
+    @mock.patch.object(purge, 'UnitAssociationCriteria', autospec=True)
+    def test_remove_unit_duplicate_nerva(self, mock_criteria, mock_association):
+        unit_key = {'name': 'test-nevra', 'epoch': 0, 'version': 1, 'release': '23',
+                    'arch': 'noarch', 'checksum': '1234abc', 'checksumtype': 'sha256'}
+        type_id = 'rpm'
+        repo_id = 'test-repo'
+        expected_filters = set([('arch', 'noarch'), ('epoch', 0), ('name', 'test-nevra'),
+                                ('release', '23'), ('version', 1)])
+
+        purge.remove_unit_duplicate_nevra(unit_key, type_id, repo_id)
+
+        # verify
+        self.assertEqual(mock_criteria.mock_calls[0][2]['type_ids'], 'rpm')
+        self.assertEqual(mock_criteria.mock_calls[0][2]['unit_filters'].keys(), ['$and'])
+        result_filters = mock_criteria.mock_calls[0][2]['unit_filters']['$and']
+        unit_filters = set()
+        for i in result_filters:
+            unit_filters.add(i.items()[0])
+        self.assertEqual(unit_filters, expected_filters)
+        mock_association.unassociate_by_criteria.assert_called_once_with(
+            repo_id,
+            mock_criteria.return_value, None, None)

--- a/plugins/test/unit/plugins/importers/yum/test_upload.py
+++ b/plugins/test/unit/plugins/importers/yum/test_upload.py
@@ -39,7 +39,7 @@ class UploadDispatchTests(unittest.TestCase):
                                self.file_path, self.conduit, self.config)
 
         # Verify
-        mock_handle.assert_called_once_with(models.RPM.TYPE, self.unit_key, self.metadata,
+        mock_handle.assert_called_once_with(None, models.RPM.TYPE, self.unit_key, self.metadata,
                                             self.file_path, self.conduit, self.config)
 
         self.assertTrue(report is not None)
@@ -52,7 +52,7 @@ class UploadDispatchTests(unittest.TestCase):
                                self.file_path, self.conduit, self.config)
 
         # Verify
-        mock_handle.assert_called_once_with(models.SRPM.TYPE, self.unit_key, self.metadata,
+        mock_handle.assert_called_once_with(None, models.SRPM.TYPE, self.unit_key, self.metadata,
                                             self.file_path, self.conduit, self.config)
 
         self.assertTrue(report is not None)
@@ -65,7 +65,7 @@ class UploadDispatchTests(unittest.TestCase):
                                self.file_path, self.conduit, self.config)
 
         # Verify
-        mock_handle.assert_called_once_with(models.PackageGroup.TYPE, self.unit_key,
+        mock_handle.assert_called_once_with(None, models.PackageGroup.TYPE, self.unit_key,
                                             self.metadata, self.file_path, self.conduit,
                                             self.config)
 
@@ -79,7 +79,7 @@ class UploadDispatchTests(unittest.TestCase):
                                self.file_path, self.conduit, self.config)
 
         # Verify
-        mock_handle.assert_called_once_with(models.PackageCategory.TYPE, self.unit_key,
+        mock_handle.assert_called_once_with(None, models.PackageCategory.TYPE, self.unit_key,
                                             self.metadata, self.file_path, self.conduit,
                                             self.config)
 
@@ -93,7 +93,7 @@ class UploadDispatchTests(unittest.TestCase):
                                self.file_path, self.conduit, self.config)
 
         # Verify
-        mock_handle.assert_called_once_with(models.Errata.TYPE, self.unit_key,
+        mock_handle.assert_called_once_with(None, models.Errata.TYPE, self.unit_key,
                                             self.metadata, self.file_path, self.conduit,
                                             self.config)
 
@@ -107,7 +107,7 @@ class UploadDispatchTests(unittest.TestCase):
                                self.file_path, self.conduit, self.config)
 
         # Verify
-        mock_handle.assert_called_once_with(models.YumMetadataFile.TYPE, self.unit_key,
+        mock_handle.assert_called_once_with(None, models.YumMetadataFile.TYPE, self.unit_key,
                                             self.metadata, self.file_path, self.conduit,
                                             self.config)
 
@@ -190,6 +190,7 @@ class UploadErratumTests(unittest.TestCase):
         unit_key = {'id': 'test-erratum'}
         metadata = {'a': 'a'}
         config = PluginCallConfiguration({}, {})
+        mock_repo = mock.MagicMock()
 
         mock_conduit = mock.MagicMock()
         inited_unit = Unit(models.Errata.TYPE, unit_key, metadata, None)
@@ -199,7 +200,7 @@ class UploadErratumTests(unittest.TestCase):
         mock_conduit.save_unit.return_value = saved_unit
 
         # Test
-        upload._handle_erratum(models.Errata.TYPE, unit_key, metadata, None,
+        upload._handle_erratum(mock_repo, models.Errata.TYPE, unit_key, metadata, None,
                                mock_conduit, config)
 
         # Verify
@@ -222,9 +223,10 @@ class UploadErratumTests(unittest.TestCase):
         config = PluginCallConfiguration({}, {},
                                          override_config={upload.CONFIG_SKIP_ERRATUM_LINK: True})
         mock_conduit = mock.MagicMock()
+        mock_repo = mock.MagicMock()
 
         # Test
-        upload._handle_erratum(models.Errata.TYPE, unit_key, metadata, None,
+        upload._handle_erratum(mock_repo, models.Errata.TYPE, unit_key, metadata, None,
                                mock_conduit, config)
 
         # Verify
@@ -233,9 +235,10 @@ class UploadErratumTests(unittest.TestCase):
     def test_handle_erratum_model_error(self):
         # Setup
         unit_key = {'foo': 'bar'}
+        mock_repo = mock.MagicMock()
 
         # Test
-        self.assertRaises(upload.ModelInstantiationError, upload._handle_erratum,
+        self.assertRaises(upload.ModelInstantiationError, upload._handle_erratum, mock_repo,
                           models.Errata.TYPE, unit_key, {}, None, None, None)
 
     def test_link_errata_to_rpms(self):
@@ -283,6 +286,7 @@ class UploadYumRepoMetadataFileTests(unittest.TestCase):
         metadata = {'local_path': 'repodata/productid', 'checksum': 'abcdef',
                     'checksumtype': 'sha256'}
         config = PluginCallConfiguration({}, {})
+        mock_repo = mock.MagicMock()
 
         mock_conduit = mock.MagicMock()
         inited_unit = Unit(models.YumMetadataFile.TYPE, unit_key, metadata,
@@ -290,7 +294,7 @@ class UploadYumRepoMetadataFileTests(unittest.TestCase):
         mock_conduit.init_unit.return_value = inited_unit
 
         # Test
-        upload._handle_yum_metadata_file(models.YumMetadataFile.TYPE, unit_key, metadata,
+        upload._handle_yum_metadata_file(mock_repo, models.YumMetadataFile.TYPE, unit_key, metadata,
                                          self.upload_source_filename, mock_conduit, config)
 
         # Verify
@@ -310,16 +314,18 @@ class UploadYumRepoMetadataFileTests(unittest.TestCase):
     def test_handle_yum_metadata_file_model_error(self):
         # Setup
         unit_key = {'foo': 'bar'}
+        mock_repo = mock.MagicMock()
 
         # Test
         self.assertRaises(upload.ModelInstantiationError, upload._handle_yum_metadata_file,
-                          models.Errata.TYPE, unit_key, {}, None, None, None)
+                          mock_repo, models.Errata.TYPE, unit_key, {}, None, None, None)
 
     def test_handle_yum_metadata_file_storage_error(self):
         # Setup
         unit_key = {'data_type': 'product-id', 'repo_id': 'test-repo'}
         metadata = {'local_path': 'repodata/productid'}
         config = PluginCallConfiguration({}, {})
+        mock_repo = mock.MagicMock()
 
         mock_conduit = mock.MagicMock()
         inited_unit = Unit(models.YumMetadataFile.TYPE, unit_key, metadata,
@@ -330,7 +336,7 @@ class UploadYumRepoMetadataFileTests(unittest.TestCase):
         mock_conduit.init_unit.return_value = inited_unit
 
         # Test
-        self.assertRaises(upload.StoreFileError, upload._handle_yum_metadata_file,
+        self.assertRaises(upload.StoreFileError, upload._handle_yum_metadata_file, mock_repo,
                           models.YumMetadataFile.TYPE, unit_key, metadata,
                           self.upload_source_filename, mock_conduit, config)
 
@@ -342,13 +348,14 @@ class GroupCategoryTests(unittest.TestCase):
         unit_key = {'id': 'test-group', 'repo_id': 'test-repo'}
         metadata = {}
         config = PluginCallConfiguration({}, {})
+        mock_repo = mock.MagicMock()
 
         mock_conduit = mock.MagicMock()
         inited_unit = Unit(models.PackageGroup.TYPE, unit_key, metadata, None)
         mock_conduit.init_unit.return_value = inited_unit
 
         # Test
-        upload._handle_group_category(models.PackageGroup.TYPE, unit_key, metadata, None,
+        upload._handle_group_category(mock_repo, models.PackageGroup.TYPE, unit_key, metadata, None,
                                       mock_conduit, config)
 
         # Verify
@@ -363,14 +370,15 @@ class GroupCategoryTests(unittest.TestCase):
         unit_key = {'id': 'test-category', 'repo_id': 'test-repo'}
         metadata = {}
         config = PluginCallConfiguration({}, {})
+        mock_repo = mock.MagicMock()
 
         mock_conduit = mock.MagicMock()
         inited_unit = Unit(models.PackageCategory.TYPE, unit_key, metadata, None)
         mock_conduit.init_unit.return_value = inited_unit
 
         # Test
-        upload._handle_group_category(models.PackageCategory.TYPE, unit_key, metadata, None,
-                                      mock_conduit, config)
+        upload._handle_group_category(mock_repo, models.PackageCategory.TYPE, unit_key, metadata,
+                                      None, mock_conduit, config)
 
         # Verify
         mock_conduit.init_unit.assert_called_once_with(models.PackageCategory.TYPE, unit_key,
@@ -382,9 +390,10 @@ class GroupCategoryTests(unittest.TestCase):
     def test_model_error(self):
         # Setup
         unit_key = {'foo': 'bar'}
+        mock_repo = mock.MagicMock()
 
         # Test
-        self.assertRaises(upload.ModelInstantiationError, upload._handle_group_category,
+        self.assertRaises(upload.ModelInstantiationError, upload._handle_group_category, mock_repo,
                           models.PackageGroup.TYPE, unit_key, {}, None, None, None)
 
 
@@ -411,8 +420,9 @@ class UploadPackageTests(unittest.TestCase):
         if os.path.exists(self.tmp_dir):
             shutil.rmtree(self.tmp_dir)
 
+    @mock.patch('pulp_rpm.plugins.importers.yum.upload.purge.remove_unit_duplicate_nevra')
     @mock.patch('pulp_rpm.plugins.importers.yum.upload._generate_rpm_data')
-    def test_handle_package(self, mock_generate):
+    def test_handle_package(self, mock_generate, mock_nevra):
         # Setup
         unit_key = {
             'name': 'walrus',
@@ -431,14 +441,15 @@ class UploadPackageTests(unittest.TestCase):
         user_unit_key = {'version': '100'}
         user_metadata = {'extra-meta': 'e'}
         config = PluginCallConfiguration({}, {})
+        mock_repo = mock.MagicMock()
 
         mock_conduit = mock.MagicMock()
         inited_unit = Unit(models.RPM.TYPE, unit_key, metadata, self.upload_dest_filename)
         mock_conduit.init_unit.return_value = inited_unit
 
         # Test
-        upload._handle_package(models.RPM.TYPE, user_unit_key, user_metadata, self.upload_src_filename,
-                               mock_conduit, config)
+        upload._handle_package(mock_repo, models.RPM.TYPE, user_unit_key, user_metadata,
+                               self.upload_src_filename, mock_conduit, config)
 
         # Verify
 
@@ -460,6 +471,9 @@ class UploadPackageTests(unittest.TestCase):
 
         mock_conduit.init_unit.assert_called_once_with(models.RPM.TYPE, full_unit_key,
                                                        full_metadata, expected_relative_path)
+
+        mock_nevra.assert_called_once_with(full_unit_key, models.RPM.TYPE, mock_repo.id)
+
         mock_conduit.save_unit.assert_called_once()
         saved_unit = mock_conduit.save_unit.call_args[0][0]
         self.assertEqual(inited_unit, saved_unit)
@@ -470,18 +484,20 @@ class UploadPackageTests(unittest.TestCase):
         class FooException(Exception):
             pass
         mock_generate.side_effect = FooException()
+        mock_repo = mock.MagicMock()
 
         # Test - Ensure we haven't blindly masked an exception
-        self.assertRaises(FooException, upload._handle_package, None, None,
+        self.assertRaises(FooException, upload._handle_package, mock_repo, None, None,
                           None, None, None, None)
 
     @mock.patch('pulp_rpm.plugins.importers.yum.upload._generate_rpm_data')
     def test_handle_model_instantiation_error(self, mock_generate):
         # Setup
         mock_generate.return_value = {}, {}  # incomplete unit key, will error
+        mock_repo = mock.MagicMock()
 
         # Test
-        self.assertRaises(upload.ModelInstantiationError, upload._handle_package,
+        self.assertRaises(upload.ModelInstantiationError, upload._handle_package, mock_repo,
                           models.RPM.TYPE, None, None, None, None, None)
 
     @mock.patch('pulp_rpm.plugins.importers.yum.upload._generate_rpm_data')
@@ -501,12 +517,13 @@ class UploadPackageTests(unittest.TestCase):
         }
         mock_generate.return_value = unit_key, metadata
         config = PluginCallConfiguration({}, {})
+        mock_repo = mock.MagicMock()
 
         mock_conduit = mock.MagicMock()
         mock_conduit.init_unit.side_effect = IOError()
 
         # Test
-        self.assertRaises(upload.StoreFileError, upload._handle_package, models.RPM.TYPE,
+        self.assertRaises(upload.StoreFileError, upload._handle_package, mock_repo, models.RPM.TYPE,
                           unit_key, metadata, self.upload_src_filename, mock_conduit, config)
 
     def test_generate_rpm_data(self):


### PR DESCRIPTION
closes#494
https://pulp.plan.io/issues/494

Units with duplicate nevra are removed from the repo in case of sync or upload.