### PR TITLE
Add trailing slash to URL path, not the entire URL

### DIFF
--- a/plugins/pulp_rpm/plugins/importers/yum/sync.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/sync.py
@@ -9,7 +9,7 @@ import tempfile
 import traceback
 from gettext import gettext as _
 from cStringIO import StringIO
-
+from urlparse import urlparse, urlunparse
 
 from nectar.request import DownloadRequest
 
@@ -90,8 +90,13 @@ class RepoSync(object):
         if repo_url:
             repo_url_slash = repo_url
             self.tmp_dir = tempfile.mkdtemp(dir=self.working_dir)
-            if not repo_url.endswith('/'):
-                    repo_url_slash = repo_url + '/'
+            parsed = urlparse(repo_url)
+            path = parsed.path
+            if not path.endswith('/'):
+                path += '/'
+            repo_url_slash = urlunparse(
+                (parsed.scheme, parsed.netloc, path, parsed.params, parsed.query, parsed.fragment)
+            )
             try:
                 self.check_metadata(repo_url_slash)
                 return [repo_url_slash]

--- a/plugins/test/unit/plugins/importers/yum/test_sync.py
+++ b/plugins/test/unit/plugins/importers/yum/test_sync.py
@@ -220,6 +220,18 @@ class TestSyncFeed(BaseSyncTest):
 
         self.assertEqual(ret, [self.url])
 
+    @mock.patch('pulp_rpm.plugins.importers.yum.sync.RepoSync.check_metadata',
+                spec_set=RepoSync.check_metadata)
+    def test_query_without_trailing_slash(self, mock_check_metadata):
+        # it should add back the trailing slash if not present without changing the query string
+        query = '?foo=bar'
+        self.config.override_config[importer_constants.KEY_FEED] = self.url.rstrip('/') + query
+
+        ret = self.reposync.sync_feed
+        expected = [self.url + query]
+
+        self.assertEqual(ret, expected)
+
     def test_repo_url_is_none(self):
 
         self.config.override_config[importer_constants.KEY_FEED] = None


### PR DESCRIPTION
fixes #1348

This is built on some hefty changes made for 2.7, and (for the moment)
isn't wanted by anyone but me (re #928), but can find its way as far
back as pulp_rpm 2.4 if needed.