### PR TITLE
Allow disabling the auto publish again

### DIFF
--- a/extensions_admin/pulp_rpm/extensions/admin/repo_options.py
+++ b/extensions_admin/pulp_rpm/extensions/admin/repo_options.py
@@ -105,7 +105,7 @@ def add_distributor_config_to_command(command):
     # The server-side APIs don't allow this to be updated, so hide it as an
     # option entirely; RPM repos are always published automatically with our
     # CLI until we clean that up. jdob, Sept 24, 2012
-    # publish_group.add_option(OPT_AUTO_PUBLISH)
+    publish_group.add_option(OPT_AUTO_PUBLISH)
 
     publish_group.add_option(OPT_RELATIVE_URL)
     publish_group.add_option(OPT_SERVE_HTTP)


### PR DESCRIPTION
At least allow people to give the option at creation time.

Don't want people to use plain upstream (feed) repos that are untested, skipping by the release process and then
come crying because their servers broke
build their software against wrong versions
...

Basically, if Pulp is about release management at least a little bit, still, then it has to be possible to not expose the upstreams.