### PR TITLE
Remove cancel from the alternate content source usage.

### DIFF
--- a/plugins/pulp_rpm/plugins/importers/yum/repomd/alternate.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/repomd/alternate.py
@@ -1,6 +1,5 @@
 import os
 
-from threading import Event
 from urlparse import urljoin
 from logging import getLogger
 from gettext import gettext as _
@@ -34,8 +33,6 @@ class Packages(object):
     :type primary: nectar.downloaders.base.Downloader
     :ivar container: A content container.
     :type container: ContentContainer
-    :ivar canceled: An event that signals the running download has been canceled.
-    :type canceled: threading.Event
     """
 
     def __init__(self, base_url, nectar_conf, units, dst_dir, listener):
@@ -55,7 +52,6 @@ class Packages(object):
         self.listener = ContainerListener(listener)
         self.primary = create_downloader(base_url, nectar_conf)
         self.container = ContentContainer()
-        self.canceled = Event()
 
     @property
     def downloader(self):
@@ -90,15 +86,8 @@ class Packages(object):
         """
         Download packages using alternate content source container.
         """
-        report = self.container.download(
-            self.canceled, self.primary, self.get_requests(), self.listener)
+        report = self.container.download(self.primary, self.get_requests(), self.listener)
         _log.info(CONTAINER_REPORT, dict(r=report.dict(), u=self.base_url))
-
-    def cancel(self):
-        """
-        Cancel a running download.
-        """
-        self.canceled.set()
 
 
 class ContainerListener(Listener):

--- a/plugins/test/unit/plugins/importers/yum/repomd/test_alternate.py
+++ b/plugins/test/unit/plugins/importers/yum/repomd/test_alternate.py
@@ -21,10 +21,9 @@ class Unit(object):
 
 
 class TestPackages(TestCase):
-    @patch('pulp_rpm.plugins.importers.yum.repomd.alternate.Event')
     @patch('pulp_rpm.plugins.importers.yum.repomd.alternate.ContentContainer')
     @patch('pulp_rpm.plugins.importers.yum.repomd.alternate.create_downloader')
-    def test_construction(self, fake_create_downloader, fake_container, fake_event):
+    def test_construction(self, fake_create_downloader, fake_container):
         base_url = str(uuid4())
         nectar_conf = Mock()
         units = Mock()
@@ -44,7 +43,6 @@ class TestPackages(TestCase):
         self.assertEqual(packages.listener.content_listener, listener)
         self.assertEqual(packages.primary, fake_create_downloader())
         self.assertEqual(packages.container, fake_container())
-        self.assertEqual(packages.canceled, fake_event())
 
     def test_downloader(self):
         # test
@@ -53,7 +51,6 @@ class TestPackages(TestCase):
         # validation
         self.assertEqual(packages.downloader, packages)
 
-    @patch('pulp_rpm.plugins.importers.yum.repomd.alternate.Event', Mock())
     @patch('pulp_rpm.plugins.importers.yum.repomd.alternate.create_downloader', Mock())
     @patch('pulp_rpm.plugins.importers.yum.repomd.alternate.ContentContainer')
     @patch('pulp_rpm.plugins.importers.yum.repomd.alternate.Packages.get_requests')
@@ -72,9 +69,8 @@ class TestPackages(TestCase):
 
         # validation
         fake_container().download.assert_called_with(
-            packages.canceled, packages.primary, fake_requests(), packages.listener)
+            packages.primary, fake_requests(), packages.listener)
 
-    @patch('pulp_rpm.plugins.importers.yum.repomd.alternate.Event', Mock())
     @patch('pulp_rpm.plugins.importers.yum.repomd.alternate.create_downloader', Mock())
     @patch('pulp_rpm.plugins.importers.yum.repomd.alternate.ContentContainer', Mock())
     @patch('pulp_rpm.plugins.importers.yum.repomd.alternate.Request')
@@ -101,7 +97,6 @@ class TestPackages(TestCase):
                              os.path.join(packages.dst_dir, units[n].relative_path))
         self.assertEqual(len(requests), len(units))
 
-    @patch('pulp_rpm.plugins.importers.yum.repomd.alternate.Event', Mock())
     @patch('pulp_rpm.plugins.importers.yum.repomd.alternate.create_downloader', Mock())
     @patch('pulp_rpm.plugins.importers.yum.repomd.alternate.ContentContainer', Mock())
     @patch('pulp_rpm.plugins.importers.yum.repomd.alternate.Request')
@@ -131,16 +126,6 @@ class TestPackages(TestCase):
             self.assertEqual(call[1]['destination'],
                              os.path.join(packages.dst_dir, units[n].relative_path))
         self.assertEqual(len(requests), len(units))
-
-    def test_cancel(self):
-        packages = Packages('http://none', None, [], '', None)
-        self.assertFalse(packages.canceled.is_set())
-
-        # test
-        packages.cancel()
-
-        # validation
-        self.assertTrue(packages.canceled.is_set())
 
 
 class TestListener(TestCase):

--- a/plugins/test/unit/plugins/importers/yum/test_sync.py
+++ b/plugins/test/unit/plugins/importers/yum/test_sync.py
@@ -903,7 +903,7 @@ class TestDownload(BaseSyncTest):
         self.assertEqual(mock_package_list_generator.call_count, 1)
 
         # verify that the download requests were correct
-        requests = list(fake_container.download.call_args[0][2])
+        requests = list(fake_container.download.call_args[0][1])
         self.assertEqual(len(requests), 2)
         self.assertEqual(requests[0].url, os.path.join(self.url, self.RELATIVEPATH))
         self.assertEqual(requests[0].destination,


### PR DESCRIPTION
This was removed as part of making alternate content sources
thread-safe.