### PR TITLE
query_auth_token support

### DIFF
--- a/common/pulp_rpm/common/ids.py
+++ b/common/pulp_rpm/common/ids.py
@@ -60,3 +60,6 @@ UNIT_KEY_DRPM = (
 METADATA_DRPM = ("size", "sequence", "new_package", "relativepath")
 
 TYPE_ID_YUM_REPO_METADATA_FILE = 'yum_repo_metadata_file'
+
+# These types don't have support for the query-param auth token yet
+QUERY_AUTH_TOKEN_UNSUPPORTED = (TYPE_ID_ISO, TYPE_ID_ERRATA, TYPE_ID_DISTRO)

--- a/docs/tech-reference/yum-plugins.rst
+++ b/docs/tech-reference/yum-plugins.rst
@@ -458,6 +458,12 @@ configuration values are optional.
 ``basic_auth_password``
  Password to use for server authentication.
 
+``query_auth_token``
+ An authorization token that will be added to every request made to the feed URL's
+ server, which may be required to sync from repositories that use this method of
+ authorization (SLES 12, for example). This mechanism only supports syncing RPM
+ and deltarpm content.
+
 ``max_speed``
  The maximum download speed in bytes/sec for a task (such as a sync);
  defaults to None
@@ -509,7 +515,7 @@ Yum Distributor
 
 The Yum Distributor ID is ``yum_distributor``.
 
-Configuration Parameters 
+Configuration Parameters
 ------------------------
 
 The following options are available to the Yum Distributor configuration.

--- a/plugins/pulp_rpm/plugins/importers/yum/sync.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/sync.py
@@ -9,7 +9,6 @@ import tempfile
 import traceback
 from gettext import gettext as _
 from cStringIO import StringIO
-from urlparse import urlparse, urlunparse
 
 from nectar.request import DownloadRequest
 
@@ -20,7 +19,7 @@ from pulp.server.exceptions import PulpCodedException
 from pulp_rpm.common import constants, ids
 from pulp_rpm.plugins import error_codes
 from pulp_rpm.plugins.db import models
-from pulp_rpm.plugins.importers.yum import existing, purge
+from pulp_rpm.plugins.importers.yum import existing, purge, utils
 from pulp_rpm.plugins.importers.yum.listener import ContentListener
 from pulp_rpm.plugins.importers.yum.parse import treeinfo
 from pulp_rpm.plugins.importers.yum.repomd import (
@@ -70,6 +69,21 @@ class RepoSync(object):
         self.skip_repomd_steps = False
         self.current_revision = 0
 
+        url_modify_config = {}
+        if call_config.get('query_auth_token'):
+            url_modify_config['query_auth_token'] = call_config.get('query_auth_token')
+            skip_config = self.call_config.get(constants.CONFIG_SKIP, [])
+
+            for type_id in ids.QUERY_AUTH_TOKEN_UNSUPPORTED:
+                if type_id not in skip_config:
+                    skip_config.append(type_id)
+            self.call_config.override_config[constants.CONFIG_SKIP] = skip_config
+            _logger.info(
+                _('The following unit types do not support query auth tokens and will be skipped:'
+                  ' {skipped_types}').format(skipped_types=ids.QUERY_AUTH_TOKEN_UNSUPPORTED)
+            )
+        self._url_modify = utils.RepoURLModifier(**url_modify_config)
+
     def set_progress(self):
         """
         A convenience method to perform this very repetitive task. This is also
@@ -88,15 +102,8 @@ class RepoSync(object):
         """
         repo_url = self.call_config.get(importer_constants.KEY_FEED)
         if repo_url:
-            repo_url_slash = repo_url
+            repo_url_slash = self._url_modify(repo_url, ensure_trailing_slash=True)
             self.tmp_dir = tempfile.mkdtemp(dir=self.working_dir)
-            parsed = urlparse(repo_url)
-            path = parsed.path
-            if not path.endswith('/'):
-                path += '/'
-            repo_url_slash = urlunparse(
-                (parsed.scheme, parsed.netloc, path, parsed.params, parsed.query, parsed.fragment)
-            )
             try:
                 self.check_metadata(repo_url_slash)
                 return [repo_url_slash]
@@ -297,7 +304,8 @@ class RepoSync(object):
         :rtype:     pulp_rpm.plugins.importers.yum.repomd.metadata.MetadataFiles
         """
         _logger.info(_('Downloading metadata from %(feed)s.') % {'feed': url})
-        metadata_files = metadata.MetadataFiles(url, self.tmp_dir, self.nectar_config)
+        metadata_files = metadata.MetadataFiles(url, self.tmp_dir, self.nectar_config,
+                                                self._url_modify)
         try:
             metadata_files.download_repomd()
         except IOError, e:
@@ -563,7 +571,8 @@ class RepoSync(object):
                                                               rpms_to_download)
 
             download_wrapper = alternate.Packages(url, self.nectar_config,
-                                                  units_to_download, self.tmp_dir, event_listener)
+                                                  units_to_download, self.tmp_dir, event_listener,
+                                                  self._url_modify)
             # allow the downloader to be accessed by the cancel method if necessary
             self.downloader = download_wrapper.downloader
             _logger.info(_('Downloading %(num)s RPMs.') % {'num': len(rpms_to_download)})
@@ -588,7 +597,7 @@ class RepoSync(object):
 
                     download_wrapper = packages.Packages(url, self.nectar_config,
                                                          units_to_download, self.tmp_dir,
-                                                         event_listener)
+                                                         event_listener, self._url_modify)
                     # allow the downloader to be accessed by the cancel method if necessary
                     self.downloader = download_wrapper.downloader
                     _logger.info(_('Downloading %(num)s DRPMs.') % {'num': len(drpms_to_download)})

--- a/plugins/pulp_rpm/plugins/importers/yum/utils.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/utils.py
@@ -1,7 +1,8 @@
-from cStringIO import StringIO
-from collections import namedtuple
 import re
 import sys
+from cStringIO import StringIO
+from collections import namedtuple
+from urlparse import urljoin, urlparse, urlunparse
 
 from pulp.common.compat import check_builtin
 
@@ -99,3 +100,74 @@ def strip_ns(element, uri=None):
         element.tag = element.tag.replace('{%s}' % uri, '')
     for child in list(element):
         strip_ns(child, uri)
+
+
+class RepoURLModifier(object):
+    """
+    Repository URL Modifier
+
+    :ivar conf: URL modifier persistent configuration
+    :type conf: dict
+
+    """
+    def __init__(self, path_append=None, ensure_trailing_slash=None, query_auth_token=None):
+        """
+        :ivar conf: URL modifier persistent configuration, populated from optional keyword
+                    arguments (see :py:meth:`RepoURLModifier.__call__` for allowed options).
+        :type conf: dict
+
+        """
+        self.conf = {
+            'path_append': path_append,
+            'ensure_trailing_slash': ensure_trailing_slash,
+            'query_auth_token': query_auth_token,
+        }
+
+    def __call__(self, url, **kwargs):
+        """
+        Modify a URL based on the keys in the url modify conf
+
+        :param url:         URL to modify
+        :type:              str
+
+        :return:     The modified URL
+        :rtype:      str
+
+        URL modification config keys, which can be overridden with optional keyword args,
+        and will be processed in order as described here:
+
+            * path_append: If found, will be appended to the URL path component
+            * ensure_trailing_slash: If found and evaluates as true, add a
+              trailing slash (if needed) to the URL path component
+            * query_auth_token: If found, will become or replace the URLs
+              query string, used for authenticating to repositories like SLES 12
+              (and higher), which use this mechanism
+
+        """
+        modify_conf = self.conf.copy()
+        # validate the kwargs against modify_conf keys to keep things DRY but still valid
+        for key in kwargs:
+            if key not in modify_conf:
+                msg = ('Unknown URL modification configuration key: "{0}", '
+                       'key must be one of {1}').format(key, ', '.join(modify_conf.keys()))
+                raise LookupError(msg)
+            modify_conf[key] = kwargs[key]
+
+        scheme, netloc, path, params, query, fragment = urlparse(url)
+
+        if modify_conf['path_append']:
+            if not path.endswith('/'):
+                path += '/'
+            path = urljoin(path, modify_conf['path_append'])
+
+        if modify_conf['ensure_trailing_slash']:
+            if not path.endswith('/'):
+                path += '/'
+
+        if modify_conf['query_auth_token']:
+            query = modify_conf['query_auth_token']
+
+        url = urlunparse(
+            (scheme, netloc, path, params, query, fragment)
+        )
+        return url

--- a/plugins/test/unit/plugins/distributors/yum/test_publish.py
+++ b/plugins/test/unit/plugins/distributors/yum/test_publish.py
@@ -1044,7 +1044,7 @@ class GenerateSqliteForRepoStepTests(BaseYumDistributorPublishStepTests):
         step.process_main()
         Popen.assert_called_once_with('createrepo_c -d --update --keep-all-metadata '
                                       '--local-sqlite '
-                                     '-s sha1 '
+                                      '-s sha1 '
                                       '--skip-stat /foo',
                                       shell=True, stderr=mock.ANY, stdout=mock.ANY)
 

--- a/plugins/test/unit/plugins/importers/yum/repomd/test_metadata.py
+++ b/plugins/test/unit/plugins/importers/yum/repomd/test_metadata.py
@@ -9,6 +9,7 @@ import unittest
 import mock
 from nectar.config import DownloaderConfig
 
+from pulp_rpm.plugins.importers.yum.utils import RepoURLModifier
 from pulp_rpm.plugins.importers.yum.repomd import metadata
 
 
@@ -203,6 +204,45 @@ class TestDownloadMetadataFiles(unittest.TestCase):
         self.assertEqual(len(requests), 2)
         self.assertTrue(requests[0].destination.endswith('primary'))
         self.assertTrue(requests[1].destination.endswith('pkgtags.sqlite.gz'))
+
+
+class TestQueryAuthToken(unittest.TestCase):
+    def setUp(self):
+        self.qstring = '?foo'
+        self.url_modify = RepoURLModifier(query_auth_token=self.qstring[1:])
+        self.metadata_files = metadata.MetadataFiles('http://pulpproject.org',
+                                                     '/a/b/c',
+                                                     DownloaderConfig(),
+                                                     self.url_modify)
+
+    def test_repo_url(self):
+        self.assertTrue(self.metadata_files.repo_url.endswith(self.qstring))
+
+    # DownloadRequest is already in metadata, so it needs to be mocked in-module
+    @mock.patch('pulp_rpm.plugins.importers.yum.repomd.metadata.DownloadRequest', autospec=True)
+    def test_download_repomd(self, mock_download_request):
+        self.metadata_files.download_repomd()
+        self.assertTrue(mock_download_request.call_args[0][0].endswith(self.qstring))
+
+    def test_download_metadata_files(self):
+        self.metadata_files.metadata = {
+            'primary': file_info_factory('primary'),
+            # this one isn't "known" and thus should be downloaded
+            'pkgtags': file_info_factory('pkgtags', 'x/y/z/pkgtags.sqlite.gz'),
+        }
+
+        self.metadata_files.downloader.download = mock.MagicMock(
+            spec_set=self.metadata_files.downloader.download)
+
+        self.metadata_files.download_metadata_files()
+
+        requests = self.metadata_files.downloader.download.call_args[0][0]
+
+        # make sure both files had download requests created and passed to the
+        # downloader
+        self.assertEqual(len(requests), 2)
+        self.assertTrue(requests[0].url.endswith('primary' + self.qstring))
+        self.assertTrue(requests[1].url.endswith('pkgtags.sqlite.gz' + self.qstring))
 
 
 class TestMetadataFiles(unittest.TestCase):

--- a/plugins/test/unit/plugins/importers/yum/test_sync.py
+++ b/plugins/test/unit/plugins/importers/yum/test_sync.py
@@ -181,6 +181,9 @@ class TestInit(BaseSyncTest):
     def test_nectar_config(self):
         self.assertTrue(isinstance(self.reposync.nectar_config, DownloaderConfig))
 
+    def test_nothing_skipped(self):
+        self.assertEqual(self.reposync.call_config.get(constants.CONFIG_SKIP, []), [])
+
 
 class TestSetProgress(BaseSyncTest):
     def test_not_canceled(self):
@@ -975,6 +978,84 @@ class TestDownload(BaseSyncTest):
                          os.path.join(self.reposync.tmp_dir, drpms[1].filename))
         self.assertTrue(requests[1].data is drpms[1])
         self.assertTrue(file_handle.closed)
+
+
+class TestQueryAuthToken(BaseSyncTest):
+    def setUp(self):
+        super(TestQueryAuthToken, self).setUp()
+        self.qstring = '?letmein'
+        self.config = PluginCallConfiguration({}, {importer_constants.KEY_FEED: self.url,
+                                                   'query_auth_token': self.qstring[1:]})
+        self.reposync = RepoSync(self.repo, self.conduit, self.config)
+        self.reposync.tmp_dir = '/dev/null/tmp'
+
+    @mock.patch('pulp_rpm.plugins.importers.yum.repomd.alternate.ContentContainer')
+    @mock.patch('pulp_rpm.plugins.importers.yum.repomd.nectar_factory.create_downloader',
+                autospec=True)
+    @mock.patch.object(packages, 'package_list_generator', autospec=True)
+    def test_query_auth_token_append(
+            self, mock_package_list_generator, mock_create_downloader, mock_container):
+        """
+        test RPMs to download with auth token
+
+        tests the main feed URL and individual package URLs have the auth token applied
+        """
+        file_handle = StringIO()
+        self.metadata_files = metadata.MetadataFiles(self.url, '/foo/bar', DownloaderConfig(),
+                                                     self.reposync._url_modify)
+        self.assertEqual(self.metadata_files.repo_url, self.url + self.qstring)
+        self.metadata_files.get_metadata_file_handle = mock.MagicMock(
+            spec_set=self.metadata_files.get_metadata_file_handle,
+            side_effect=[file_handle, None, None],  # None means it will skip DRPMs
+        )
+
+        package_names = []
+        rpms = model_factory.rpm_models(3)
+        for i, rpm in enumerate(rpms):
+            package = 'package-{0}.rpm'.format(i)
+            package_names.append(package)
+            rpm.metadata['filename'] = rpm.metadata['relativepath'] = package
+
+        mock_package_list_generator.return_value = rpms
+        self.downloader.download = mock.MagicMock(spec_set=self.downloader.download)
+        mock_create_downloader.return_value = self.downloader
+
+        fake_container = mock.Mock()
+        fake_container.refresh.return_value = {}
+        mock_container.return_value = fake_container
+
+        self.reposync.download(self.metadata_files, set(m.as_named_tuple for m in rpms), set(),
+                               self.url)
+
+        requests = list(fake_container.download.call_args[0][2])
+        # the individual package urls
+        for i, request in enumerate(requests):
+            self.assertEqual(request.url, os.path.join(self.url, package_names[i]) + self.qstring)
+
+    @mock.patch('pulp_rpm.plugins.importers.yum.repomd.metadata.MetadataFiles', autospec=True)
+    def test_reposync_copies_url_modify(self, mock_metadata_files):
+        # test that RepoSync properly passes its URL modifier to MetadataFiles
+        self.assertTrue(mock_metadata_files.call_args is None)
+        self.reposync.check_metadata('blah')
+
+        # should only be one call
+        self.assertEqual(mock_metadata_files.call_count, 1)
+        self.assertTrue(mock_metadata_files.call_args[0][3] is self.reposync._url_modify)
+
+    def test_reposync_skip_config(self):
+        skip_config = self.reposync.call_config.get(constants.CONFIG_SKIP)
+        self.assertTrue(skip_config is not None)
+        for type_id in ids.QUERY_AUTH_TOKEN_UNSUPPORTED:
+            self.assertTrue(type_id in skip_config)
+
+    def test_units_skipped(self):
+        # If query_auth_token is in the importer config, the skip config must exist...
+        skip_config = self.reposync.call_config.get(constants.CONFIG_SKIP)
+        self.assertTrue(skip_config is not None)
+
+        # ...and all of the unsupported types must be configured to skip
+        for unit_type in ids.QUERY_AUTH_TOKEN_UNSUPPORTED:
+            self.assertTrue(unit_type in skip_config)
 
 
 class TestCancel(BaseSyncTest):

--- a/plugins/test/unit/test_util.py
+++ b/plugins/test/unit/test_util.py
@@ -1,5 +1,6 @@
 import re
 import unittest
+from urlparse import urlparse
 from xml.etree import cElementTree as ET
 
 from pulp_rpm.plugins.importers.yum import utils
@@ -121,6 +122,61 @@ class TestStripNS(unittest.TestCase):
         self.assertFalse(element.tag.startswith('{'))
         for child in element:
             self._check_all_elements(child)
+
+
+class TestRepoURLModify(unittest.TestCase):
+    test_url = 'scheme://user:pass@hostname/path?query#fragment'
+
+    def test_no_config(self):
+        # test that with no configuration, the URL modifier does nothing
+        url_modify = utils.RepoURLModifier()
+        modified_url = url_modify(self.test_url)
+        self.assertEqual(modified_url, self.test_url)
+
+    def test_add_trailing_slash(self):
+        # test that a trailing slash is added to the path
+        url_modify = utils.RepoURLModifier(ensure_trailing_slash=True)
+        modified_url = url_modify(self.test_url)
+        modified_url_path = urlparse(modified_url).path
+        self.assertEqual(modified_url_path, '/path/')
+
+        # for fun, try to add another trailing slash to the modified, which should make no change
+        modified_url = url_modify(modified_url)
+        modified_url_path = urlparse(modified_url).path
+        self.assertEqual(modified_url_path, '/path/')
+
+    def test_path_append(self):
+        # test that a path fragment is appended correctly
+        url_modify = utils.RepoURLModifier(path_append='appended')
+        modified_url = url_modify(self.test_url)
+        modified_url_path = urlparse(modified_url).path
+        self.assertEqual(modified_url_path, '/path/appended')
+
+    def test_query_auth_token(self):
+        # test the the query string is properly overwritten with the sles auth token
+        url_modify = utils.RepoURLModifier(query_auth_token='gabbagabbahey')
+        modified_url = url_modify(self.test_url)
+        self.assertTrue(modified_url.endswith('?gabbagabbahey#fragment'))
+
+    def test_kwargs_update(self):
+        # test that passed-in kwargs are applied and take precedence over the initial config
+        url_modify = utils.RepoURLModifier(path_append='appended')
+        modified_url = url_modify(self.test_url, path_append='updated', ensure_trailing_slash=True)
+        modified_url_path = urlparse(modified_url).path
+        self.assertEqual(modified_url_path, '/path/updated/')
+
+        # make sure the kwargs didn't overwrite the modifier config
+        self.assertEqual(url_modify.conf['path_append'], 'appended')
+        self.assertTrue(url_modify.conf['ensure_trailing_slash'] is None)
+
+    def test_bad_kwargs(self):
+        # can't instantiate with bad kwargs
+        self.assertRaises(TypeError, utils.RepoURLModifier, bad_kwarg="I'm not supported.")
+
+        # can't call with bad kwargs
+        url_modify = utils.RepoURLModifier()
+        self.assertRaises(LookupError, url_modify, 'url_goes_here',
+                          bad_kwarg="I'm not supported either.")
 
 
 PRIMARY_XML = """<?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
Added the ability to support query-string-based authorization to repos
that support it, such as a SLES 12 repo

fixes #1358

https://pulp.plan.io/issues/1358