### PR TITLE
Block attempts to load server.conf when running unittests

### DIFF
--- a/plugins/test/unit/__init__.py
+++ b/plugins/test/unit/__init__.py
@@ -5,6 +5,9 @@ from pulp.devel.unit.server import base as devel_base
 
 __path__ = extend_path(__path__, __name__)
 
+# prevent attempts to load the server conf during testing
+devel_base.block_load_conf()
+
 
 def setup():
     """


### PR DESCRIPTION
This is potentially the first of many, since at a minimum anything that uses celery triggers a load of server.conf, and everything celery, so we'll need this addition to be made to every plugin's tests.

I'll fire off the PRs for all the other plugins if this looks good, but it seemed prudent to do this one as a test PR before opening one for every plugin.