### PR TITLE
core passes a repo tranfer unit, not a repo_obj

### DIFF
--- a/plugins/pulp_rpm/plugins/distributors/iso_distributor/distributor.py
+++ b/plugins/pulp_rpm/plugins/distributors/iso_distributor/distributor.py
@@ -61,18 +61,19 @@ class ISODistributor(FileDistributor):
         repo = transfer_repo.repo_obj
         return super(ISODistributor, self).publish_repo(repo, publish_conduit, config)
 
-    def unpublish_repo(self, repo, config):
+    def unpublish_repo(self, transfer_repo, config):
         """
         Perform actions necessary when upublishing a repo
 
         Please also see the superclass method definition for more documentation on this method.
 
-        :param repo: metadata describing the repository
-        :type  repo: pulp.server.db.model.Repository
+        :param transfer_repo: metadata describing the repo
+        :type  transfer_repo: pulp.plugins.model.Repository
 
         :param config: plugin configuration
         :type  config: pulp.plugins.config.PluginCallConfiguration
         """
+        repo = transfer_repo.repo_obj
         super(ISODistributor, self).unpublish_repo(repo, config)
         publish.remove_repository_protection(repo)
 

--- a/plugins/test/unit/plugins/distributors/iso_distributor/test_iso_distributor_distributor.py
+++ b/plugins/test/unit/plugins/distributors/iso_distributor/test_iso_distributor_distributor.py
@@ -134,7 +134,7 @@ class TestISODistributor(unittest.TestCase):
         self.iso_distributor.get_hosting_locations = MagicMock()
         self.iso_distributor.get_hosting_locations.return_value = []
         self.iso_distributor.unpublish_repo(repo, {})
-        mock_publish.assert_called_once_with(repo)
+        mock_publish.assert_called_once_with(repo.repo_obj)
 
     @patch(
         'pulp_rpm.plugins.distributors.iso_distributor.distributor.publish'


### PR DESCRIPTION
ISO will be broken by this change: https://github.com/pulp/pulp/pull/2276