### PR TITLE
ref #1373 - support deferred (Lazy) downloading.

### DIFF
--- a/extensions_admin/pulp_rpm/extensions/admin/iso/create_update.py
+++ b/extensions_admin/pulp_rpm/extensions/admin/iso/create_update.py
@@ -61,7 +61,8 @@ class ISORepoCreateUpdateMixin(ImporterConfigMixin, ISODistributorConfigMixin):
         """
         # Add sync-related options to the create command
         ImporterConfigMixin.__init__(self, include_sync=True, include_ssl=True, include_proxy=True,
-                                     include_throttling=True, include_unit_policy=True)
+                                     include_throttling=True, include_unit_policy=True,
+                                     include_download_policy=True)
 
         ISODistributorConfigMixin.__init__(self)
 

--- a/extensions_admin/pulp_rpm/extensions/admin/repo_create_update.py
+++ b/extensions_admin/pulp_rpm/extensions/admin/repo_create_update.py
@@ -66,7 +66,8 @@ class RpmRepoCreateCommand(CreateRepositoryCommand, ImporterConfigMixin):
                                      include_proxy=True,
                                      include_basic_auth=True,
                                      include_throttling=True,
-                                     include_unit_policy=True)
+                                     include_unit_policy=True,
+                                     include_download_policy=True)
 
         # Adds all distributor config options
         repo_options.add_distributor_config_to_command(self)
@@ -200,7 +201,8 @@ class RpmRepoUpdateCommand(UpdateRepositoryCommand, ImporterConfigMixin):
                                      include_proxy=True,
                                      include_basic_auth=True,
                                      include_throttling=True,
-                                     include_unit_policy=True)
+                                     include_unit_policy=True,
+                                     include_download_policy=True)
 
         # Adds all distributor config options
         repo_options.add_distributor_config_to_command(self)

--- a/extensions_admin/test/unit/extensions/admin/iso/test_create_update.py
+++ b/extensions_admin/test/unit/extensions/admin/iso/test_create_update.py
@@ -156,7 +156,7 @@ class TestISORepoCreateCommand(PulpClientTests):
         create_repo_init.assert_called_once_with(command, self.context)
         importer_config_init.assert_called_once_with(
             command, include_sync=True, include_ssl=True, include_proxy=True,
-            include_throttling=True, include_unit_policy=True)
+            include_throttling=True, include_unit_policy=True, include_download_policy=True)
         distributor_config_init.assert_called_once_with(command)
 
         # Make sure we don't present the --retain-old-count option to the user
@@ -390,7 +390,7 @@ class TestISORepoUpdateCommand(PulpClientTests):
         update_repo_init.assert_called_once_with(command, self.context)
         importer_config_init.assert_called_once_with(
             command, include_sync=True, include_ssl=True, include_proxy=True,
-            include_throttling=True, include_unit_policy=True)
+            include_throttling=True, include_unit_policy=True, include_download_policy=True)
         distributor_config_init.assert_called_once_with(command)
 
         # Make sure we don't present the --retain-old-count option to the user

--- a/plugins/pulp_rpm/plugins/importers/yum/parse/treeinfo.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/parse/treeinfo.py
@@ -4,19 +4,24 @@ import os
 import shutil
 import tempfile
 
+from gettext import gettext as _
 from lxml import etree as ET
-import mongoengine
+from urlparse import urljoin
+
+from mongoengine import Q
+
 from nectar.listener import AggregatingEventListener
 from nectar.request import DownloadRequest
+
 from pulp.plugins.util import verification
+from pulp.server.db.model import LazyCatalogEntry, RepositoryContentUnit
 from pulp.server.exceptions import PulpCodedValidationException
 from pulp.server.controllers import repository as repo_controller
-from pulp.server.db import model as platform_models
 
 from pulp_rpm.common import constants, ids
-from pulp_rpm.plugins.db import models
+from pulp_rpm.plugins.db.models import Distribution
 from pulp_rpm.plugins import error_codes
-from pulp_rpm.plugins.importers.yum.listener import DistroFileListener
+from pulp_rpm.plugins.importers.yum.listener import DistFileListener
 from pulp_rpm.plugins.importers.yum.repomd import nectar_factory
 
 
@@ -26,363 +31,509 @@ SECTION_CHECKSUMS = 'checksums'
 KEY_PACKAGEDIR = 'packagedir'
 KEY_TIMESTAMP = 'timestamp'
 KEY_DISTRIBUTION_CONTEXT = 'distribution_context'
+RELATIVE_PATH = 'relativepath'
+CHECKSUM = 'checksum'
+CHECKSUM_TYPE = 'checksumtype'
 
-_LOGGER = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 
-def sync(repo, sync_conduit, feed, working_dir, nectar_config, report, progress_callback):
+class DownloadFailed(Exception):
+    pass
+
+
+class DistSync(object):
     """
-    Look for a distribution in the target repo and sync it if found
-
-    :param repo: The repository that is the target of the sync
-    :type repo: pulp.server.db.model.Repository
-    :param sync_conduit:        conduit provided by the platform
-    :type  sync_conduit:        pulp.plugins.conduits.repo_sync.RepoSyncConduit
-    :param feed:                URL of the yum repo being sync'd
-    :type  feed:                basestring
-    :param working_dir:         full path to the directory to which files
-                                should be downloaded
-    :type  working_dir:         basestring
-    :param nectar_config:       download config to be used by nectar
-    :type  nectar_config:       nectar.config.DownloaderConfig
-    :param report:              progress report object
-    :type  report:              pulp_rpm.plugins.importers.yum.report.DistributionReport
-    :param progress_callback:   function that takes no arguments but induces
-                                the current progress report to be sent.
+    :ivar parent: The parent sync object.
+    :type parent: pulp_rpm.plugins.importers.yum.sync.RepoSync
+    :ivar feed: The feed url.
+    :type feed: str
     """
-    tmp_dir = tempfile.mkdtemp(dir=working_dir)
-    try:
-        treefile_path = get_treefile(feed, tmp_dir, nectar_config)
-        if not treefile_path:
-            _LOGGER.debug('no treefile found')
+
+    def __init__(self, parent, feed):
+        """
+        :param parent: The parent sync object.
+        :type parent: pulp_rpm.plugins.importers.yum.sync.RepoSync
+        :param feed: The feed url.
+        :type feed: str
+        """
+        self.parent = parent
+        self.feed = feed
+
+    @property
+    def nectar_config(self):
+        """
+        The nectar configuration used for downloading.
+
+        :return: The nectar configuration.
+        :rtype: nectar.config.DownloaderConfig
+        """
+        return self.parent.nectar_config
+
+    @property
+    def working_dir(self):
+        """
+        The working directory used for downloads.
+
+        :return: The absolute path to the directory.
+        :type: str
+        """
+        return self.parent.working_dir
+
+    @property
+    def progress_report(self):
+        """
+        The distribution progress report.
+
+        :return: The progress report.
+        :type: pulp_rpm.plugins.importers.yum.report.DistributionReport
+        """
+        return self.parent.distribution_report
+
+    @property
+    def repo(self):
+        """
+        The repository being synchronized.
+
+        :return: A repository
+        :rtype: pulp.server.db.model.Repository
+        """
+        return self.parent.repo
+
+    @property
+    def download_deferred(self):
+        """
+        Test the download policy to determine if downloading is deferred.
+
+        :return: True if deferred.
+        :rtype: bool
+        """
+        return self.parent.download_deferred
+
+    def set_progress(self):
+        """
+        Send the progress report.
+        """
+        self.parent.set_progress()
+
+    def run(self):
+        """
+        Look for a distribution in the target repo and sync it if found
+        """
+        tmp_dir = tempfile.mkdtemp(dir=self.working_dir)
+        try:
+            self._run(tmp_dir)
+        finally:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+
+    def _run(self, tmp_dir):
+        """
+        Look for a distribution in the target repo and sync it if found
+
+        :param tmp_dir: The absolute path to the temporary directory
+        :type tmp_dir: str
+        """
+        treeinfo_path = self.get_treefile(tmp_dir)
+        if not treeinfo_path:
+            _logger.debug(_('No treeinfo found'))
             return
 
         try:
-            model, files = parse_treefile(treefile_path)
+            unit, files = self.parse_treeinfo_file(treeinfo_path)
         except ValueError:
-            _LOGGER.error('could not parse treefile')
-            report['state'] = constants.STATE_FAILED
+            _logger.error(_('could not parse treeinfo'))
+            self.progress_report['state'] = constants.STATE_FAILED
             return
 
         existing_units = repo_controller.find_repo_content_units(
-            repo, repo_content_unit_q=mongoengine.Q(unit_type_id=ids.TYPE_ID_DISTRO),
+            self.repo,
+            repo_content_unit_q=Q(unit_type_id=ids.TYPE_ID_DISTRO),
             yield_content_unit=True)
+
         existing_units = list(existing_units)
 
-        # skip this whole process if the upstream treeinfo file hasn't changed
-        if len(existing_units) == 1 and existing_distribution_is_current(existing_units[0], model):
-            _LOGGER.debug('upstream distribution unchanged; skipping')
+        # Continue only when the distribution has changed.
+        if len(existing_units) == 1 and \
+                self.existing_distribution_is_current(existing_units[0], unit):
+            _logger.debug(_('upstream distribution unchanged; skipping'))
             return
 
-        # Get any errors
-        dist_files = process_distribution(feed, tmp_dir, nectar_config, model, report)
+        # Process the distribution
+        dist_files = self.process_distribution(tmp_dir)
         files.extend(dist_files)
 
-        report.set_initial_values(len(files))
-        listener = DistroFileListener(report, progress_callback)
-        downloader = nectar_factory.create_downloader(feed, nectar_config, listener)
-        _LOGGER.debug('downloading distribution files')
-        downloader.download(file_to_download_request(f, feed, tmp_dir) for f in files)
-        if len(listener.failed_reports) == 0:
-            model.set_content(tmp_dir)
-            model.save()
-            # The save sets the content path, which is needed to generate the download_reports
-            # Long term this should be done by a serializer
-            model.process_download_reports(listener.succeeded_reports)
-            model.save()
+        self.update_unit_files(unit, files)
 
-            repo_controller.associate_single_unit(repo, model)
-
-            # find any old distribution units and remove them. See BZ #1150714
-            for existing_unit in existing_units:
-                if existing_unit != model:
-                    _LOGGER.info("Removing out-of-date distribution unit %s for repo %s" %
-                                 (existing_unit.unit_key, sync_conduit.repo_id))
-                    platform_models.RepositoryContentUnit.objects(
-                        repo_id=sync_conduit.repo_id,
-                        unit_type_id=models.Distribution._content_type_id.default,
-                        unit_id=existing_unit.id).delete()
+        # Download distribution files
+        if not self.download_deferred:
+            try:
+                downloaded = self.download_files(tmp_dir, files)
+            except DownloadFailed:
+                # All files must be downloaded to continue.
+                return
         else:
-            _LOGGER.error('some distro file downloads failed')
-            report['state'] = constants.STATE_FAILED
-            report['error_details'] = [(fail.url, fail.error_report) for fail in
-                                       listener.failed_reports]
-            return
-    finally:
-        shutil.rmtree(tmp_dir, ignore_errors=True)
+            unit.downloaded = False
+            downloaded = []
 
+        # Save the unit.
+        unit.save()
 
-def existing_distribution_is_current(existing_unit, model):
-    """
-    Determines if the remote model is newer than the existing unit we have in
-    the database. This uses the timestamp attribute of each's treeinfo file to
-    make that determination.
+        # Update deferred downloading catalog
+        self.update_catalog_entries(unit, files)
 
-    :param existing_unit:   unit that currently exists in the repo
-    :type  existing_unit:   pulp_rpm.plugins.db.models.Distribution
-    :param model:           this model's unit key will be searched for in the DB
-    :type  model:           pulp_rpm.plugins.db.models.Distribution
+        # The treeinfo file is always imported into platform
+        # # storage regardless of the download policy
+        unit.import_content(treeinfo_path, os.path.basename(treeinfo_path))
 
-    :return:    False if model's timestamp is greater than existing_unit's timestamp,
-                or if that comparison cannot be made because timestamp data is
-                missing. Otherwise, True.
-    :rtype:     bool
-    """
-    existing_timestamp = existing_unit.timestamp
-    remote_timestamp = model.timestamp
+        # The downloaded files are imported into platform storage.
+        for destination, location in downloaded:
+            unit.import_content(destination, location)
 
-    if existing_timestamp is None or remote_timestamp is None:
-        _LOGGER.debug('treeinfo timestamp missing; will fetch upstream distribution')
-        return False
+        # Associate the unit.
+        repo_controller.associate_single_unit(self.repo, unit)
 
-    return remote_timestamp <= existing_timestamp
+        # find any old distribution units and remove them. See BZ #1150714
+        for existing_unit in existing_units:
+            if existing_unit == unit:
+                continue
+            msg = _('Removing out-of-date distribution unit {k} for repo {r}')
+            _logger.info(msg.format(k=existing_unit.unit_key, r=self.repo.repo_id))
+            qs = RepositoryContentUnit.objects.filter(
+                repo_id=self.repo.repo_id,
+                unit_id=existing_unit.id)
+            qs.delete()
 
+    def update_catalog_entries(self, unit, files):
+        """
+        Update entries to the deferred downloading (lazy) catalog.
 
-def file_to_download_request(file_dict, feed, storage_path):
-    """
-    Takes information about a file described in a treeinfo file and turns that
-    into a download request suitable for use with nectar.
+        :param unit: A distribution model object.
+        :type unit: pulp_rpm.plugins.db.models.Distribution
+        :param files: List of distribution files.
+        :type files: list
+        """
+        for _file in files:
+            root = unit.storage_path
+            entry = LazyCatalogEntry()
+            entry.path = os.path.join(root, _file[RELATIVE_PATH])
+            entry.url = urljoin(self.feed, _file[RELATIVE_PATH])
+            entry.unit_id = unit.id
+            entry.unit_type_id = unit.type_id
+            entry.importer_id = str(self.parent.conduit.importer_object_id)
+            entry.save_revision()
 
-    :param file_dict:       dict containing keys 'relativepath', 'checksum',
-                            and 'checksumtype'.
-    :type  file_dict:       dict
-    :param feed:            URL to the base of a repository
-    :type  feed:            basestring
-    :param storage_path:    full filesystem path to where the downloaded files
-                            should be saved.
-    :type  storage_path:    basestring
+    @staticmethod
+    def update_unit_files(unit, files):
+        """
+        Update the *files* list on the unit.
 
-    :return:    new download request
-    :rtype:     nectar.request.DownloadRequest
-    """
-    savepath = os.path.join(storage_path, file_dict['relativepath'])
-    # make directories such as "images"
-    if not os.path.exists(os.path.dirname(savepath)):
-        os.makedirs(os.path.dirname(savepath))
+        :param unit: A distribution model object.
+        :type unit: pulp_rpm.plugins.db.models.Distribution
+        :param files: List of distribution files.
+        :type files: list
+        """
+        _list = []
+        if not isinstance(unit.files, list):
+            _list = list(unit.files)
+        for _file in files:
+            _list.append({
+                RELATIVE_PATH: _file[RELATIVE_PATH],
+                CHECKSUM: _file[CHECKSUM],
+                CHECKSUM_TYPE: verification.sanitize_checksum_type(_file[CHECKSUM_TYPE])})
+        unit.files = _list
 
-    return DownloadRequest(
-        os.path.join(feed, file_dict['relativepath']),
-        savepath,
-        file_dict,
-    )
+    def download_files(self, tmp_dir, files):
+        """
+        Download distribution files.
 
+        :param tmp_dir: The absolute to where the downloaded files.
+        :type tmp_dir: str
+        :param files: List of distribution dictionary files.
+        :type files: list
+        :return: generator of: (destination, location)
+            The *destination* is the absolute path to the downloaded file.
+            The *location* is the relative path within the tmp_dir.
+        :rtype: generator
+        :raise DownloadFailed: if any of the downloads fail.
+        """
+        listener = DistFileListener(self)
+        self.progress_report.set_initial_values(len(files))
+        downloader = nectar_factory.create_downloader(self.feed, self.nectar_config, listener)
+        requests = (self.file_to_download_request(f, tmp_dir) for f in files)
+        downloader.download(requests)
+        if len(listener.failed_reports):
+            _logger.error(_('some distro file downloads failed'))
+            self.progress_report['state'] = constants.STATE_FAILED
+            self.progress_report['error_details'] = [
+                (fail.url, fail.error_report) for fail in listener.failed_reports
+            ]
+            raise DownloadFailed()
+        for report in listener.succeeded_reports:
+            location = report.destination.lstrip(tmp_dir)
+            yield report.destination, location.lstrip('/')
 
-def strip_treeinfo_repomd(treeinfo_path):
-    """
-    strip repomd checksums from the treeinfo. These cause two issues:
-      * pulp thinks repomd.xml is content and not metadata if it's listed here
-      * pulp regenerates the repomd.xml file anyway, which would cause the
-        listed checksum to be wrong
+    @staticmethod
+    def process_successful_download_reports(unit, reports):
+        """
+        Once downloading is complete, add information about each file to this
+        model instance. This is required before saving the new unit.
 
-    :param treeinfo_path:            path to the on-disk treeinfo file
-    :type  treeinfo_path:            str
-    """
-    # read entire treeinfo, strip entry we don't want, and replace with our new treeinfo
-    with open(treeinfo_path, 'r+') as f:
-        original_treeinfo_data = f.readlines()
-        new_treeinfo_data = []
-        for line in original_treeinfo_data:
-            if not line.startswith('repodata/repomd.xml = '):
-                new_treeinfo_data.append(line)
-        f.seek(0)
-        f.writelines(new_treeinfo_data)
-        # truncate file to current position before closing
-        f.truncate()
+        :param reports: list of successful pulp.common.download.report.DownloadReport
+        :type reports: list
+        """
+        files = []
+        if not isinstance(unit.files, list):
+            files = list(unit.files)
+        for report in reports:
+            _file = report.data
+            files.append({
+                RELATIVE_PATH: _file[RELATIVE_PATH],
+                CHECKSUM: _file[CHECKSUM],
+                CHECKSUM_TYPE: verification.sanitize_checksum_type(_file[CHECKSUM_TYPE])})
+        unit.files = files
 
+    @staticmethod
+    def existing_distribution_is_current(existing_unit, unit):
+        """
+        Determines if the remote model is newer than the existing unit we have in
+        the database. This uses the timestamp attribute of each's treeinfo file to
+        make that determination.
 
-def get_treefile(feed, tmp_dir, nectar_config):
-    """
-    Download the treefile and return its full path on disk, or None if not found
+        :param existing_unit: unit that currently exists in the repo
+        :type existing_unit: pulp_rpm.plugins.db.models.Distribution
+        :param unit: This model's unit key will be searched for in the DB
+        :type unit: pulp_rpm.plugins.db.models.Distribution
+        :return: False if model's timestamp is greater than existing_unit's timestamp,
+            or if that comparison cannot be made because timestamp data is
+            missing. Otherwise, True.
+        :rtype: bool
+        """
+        existing_timestamp = existing_unit.timestamp
+        remote_timestamp = unit.timestamp
+        if existing_timestamp is None or remote_timestamp is None:
+            _logger.debug(_('treeinfo timestamp missing; will fetch upstream distribution'))
+            return False
+        return remote_timestamp <= existing_timestamp
 
-    :param feed:            URL to the repository
-    :type  feed:            str
-    :param tmp_dir:         full path to the temporary directory being used
-    :type  tmp_dir:         str
-    :param nectar_config:   download config to be used by nectar
-    :type  nectar_config:   nectar.config.DownloaderConfig
+    def file_to_download_request(self, file_dict, tmp_dir):
+        """
+        Takes information about a file described in a treeinfo file and turns that
+        into a download request suitable for use with nectar.
 
-    :return:        full path to treefile on disk, or None if not found
-    :rtype:         str or NoneType
-    """
-    for filename in constants.TREE_INFO_LIST:
+        :param file_dict: A dict of: {relativepath: <str>, ...}
+        :type file_dict: dict
+        :param tmp_dir: The absolute to where the downloaded files.
+        :type tmp_dir: str
+        :return: new download request
+        :rtype: nectar.request.DownloadRequest
+        """
+        destination = os.path.join(tmp_dir, file_dict[RELATIVE_PATH])
+        # make directories such as "images"
+        if not os.path.exists(os.path.dirname(destination)):
+            os.makedirs(os.path.dirname(destination))
+        return DownloadRequest(
+            os.path.join(self.feed, file_dict[RELATIVE_PATH]),
+            destination,
+            file_dict)
+
+    @staticmethod
+    def strip_treeinfo_repomd(treeinfo_path):
+        """
+        strip repomd checksums from the treeinfo. These cause two issues:
+          * pulp thinks repomd.xml is content and not metadata if it's listed here
+          * pulp regenerates the repomd.xml file anyway, which would cause the
+            listed checksum to be wrong
+
+        :param treeinfo_path: The path to the on-disk treeinfo file
+        :type treeinfo_path: str
+        """
+        # read entire treeinfo, strip entry we don't want, and replace with our new treeinfo
+        with open(treeinfo_path, 'r+') as f:
+            original_treeinfo_data = f.readlines()
+            new_treeinfo_data = []
+            for line in original_treeinfo_data:
+                if not line.startswith('repodata/repomd.xml = '):
+                    new_treeinfo_data.append(line)
+            f.seek(0)
+            f.writelines(new_treeinfo_data)
+            # truncate file to current position before closing
+            f.truncate()
+
+    def get_treefile(self, tmp_dir):
+        """
+        Download the treefile and return its full path on disk, or None if not found
+
+        :param tmp_dir: The absolute path to the temporary directory
+        :type tmp_dir: str
+        :return: The absolute path to treefile on disk, or None if not found
+        :rtype: str or None
+        """
+        for filename in constants.TREE_INFO_LIST:
+            path = os.path.join(tmp_dir, filename)
+            url = os.path.join(self.feed, filename)
+            request = DownloadRequest(url, path)
+            listener = AggregatingEventListener()
+            downloader = nectar_factory.create_downloader(self.feed, self.nectar_config, listener)
+            downloader.download([request])
+            if len(listener.succeeded_reports) == 1:
+                # bz 1095829
+                self.strip_treeinfo_repomd(path)
+                return path
+
+    def process_distribution(self, tmp_dir):
+        """
+        Get the pulp_distribution.xml file from the server and if it exists download all the
+        files it references to add them to the distribution unit.
+
+        :param tmp_dir: The absolute path to the temporary directory
+        :type tmp_dir: str
+        :return: A list of file dictionaries
+        :rtype: list
+        """
+        # Get the Distribution file
+        result = self.get_distribution_file(tmp_dir)
+        files = []
+        # If there is a Distribution file - parse it and add all files to the file_list
+        if result:
+            xsd = os.path.join(constants.USR_SHARE_DIR, 'pulp_distribution.xsd')
+            schema_doc = ET.parse(xsd)
+            xmlschema = ET.XMLSchema(schema_doc)
+            try:
+                tree = ET.parse(result)
+                xmlschema.assertValid(tree)
+            except Exception, e:
+                raise PulpCodedValidationException(validation_exceptions=[
+                    PulpCodedValidationException(
+                        error_code=error_codes.RPM1001,
+                        feed=self.feed,
+                        validation_exceptions=[e])])
+
+            # This is broken and best I can tell - not used.
+            # model.metadata[constants.CONFIG_KEY_DISTRIBUTION_XML_FILE] = \
+            #     constants.DISTRIBUTION_XML
+
+            # parse the distribution file and add all the files to the download request
+            root = tree.getroot()
+            for file_element in root.findall('file'):
+                relative_path = file_element.text
+                files.append({
+                    RELATIVE_PATH: relative_path,
+                    CHECKSUM: None,
+                    CHECKSUM_TYPE: None,
+                })
+
+            # Add the distribution file to the list of files
+            files.append({
+                RELATIVE_PATH: constants.DISTRIBUTION_XML,
+                CHECKSUM: None,
+                CHECKSUM_TYPE: None,
+            })
+        return files
+
+    def get_distribution_file(self, tmp_dir):
+        """
+        Download the pulp_distribution.xml and return its full path on disk, or None if not found
+
+        :param tmp_dir: The absolute path to the temporary directory
+        :type tmp_dir: str
+        :return: The absolute path to distribution file on disk, or None if not found
+        :rtype: str or None
+        """
+        filename = constants.DISTRIBUTION_XML
         path = os.path.join(tmp_dir, filename)
-        url = os.path.join(feed, filename)
+        url = os.path.join(self.feed, filename)
         request = DownloadRequest(url, path)
         listener = AggregatingEventListener()
-        downloader = nectar_factory.create_downloader(feed, nectar_config, listener)
+        downloader = nectar_factory.create_downloader(self.feed, self.nectar_config, listener)
         downloader.download([request])
         if len(listener.succeeded_reports) == 1:
-            # bz 1095829
-            strip_treeinfo_repomd(path)
             return path
+        return None
 
+    @staticmethod
+    def parse_treeinfo_file(path):
+        """
+        The treefile seems to be approximately in INI format, which can be read
+        by the standard library's ConfigParser.
 
-def process_distribution(feed, tmp_dir, nectar_config, model, report):
-    """
-    Get the pulp_distribution.xml file from the server and if it exists download all the
-    files it references to add them to the distribution unit.
+        :param path: The absolute path to the treefile
+        :return: instance of Distribution model, and a list of dicts
+            describing the distribution's files
+        :rtype: (pulp_rpm.plugins.db.models.Distribution, list of dict)
+        """
+        parser = ConfigParser.RawConfigParser()
+        # the default implementation of this method makes all option names lowercase,
+        # which we don't want. This is the suggested solution in the python.org docs.
+        parser.optionxform = str
+        with open(path) as fp:
+            try:
+                parser.readfp(fp)
+            except ConfigParser.ParsingError:
+                # wouldn't need this if ParsingError subclassed ValueError.
+                raise ValueError(_('could not parse treeinfo file'))
 
-    :param feed:            URL to the repository
-    :type  feed:            str
-    :param tmp_dir:         full path to the temporary directory being used
-    :type  tmp_dir:         str
-    :param nectar_config:   download config to be used by nectar
-    :type  nectar_config:   nectar.config.DownloaderConfig
-    :param model:
-    :type model:
-    :param report:
-    :type report:
-    :return: list of file dictionaries
-    :rtype: list of dict
-    """
-    # Get the Distribution file
-    result = get_distribution_file(feed, tmp_dir, nectar_config)
-    files = []
-    # If there is a Distribution file - parse it and add all files to the file_list
-    if result:
-        xsd = os.path.join(constants.USR_SHARE_DIR, 'pulp_distribution.xsd')
-        schema_doc = ET.parse(xsd)
-        xmlschema = ET.XMLSchema(schema_doc)
+        # apparently the 'variant' is optional. for example, it does not appear
+        # in the RHEL 5.9 treeinfo file. This is how the previous importer
+        # handled that.
         try:
-            tree = ET.parse(result)
-            xmlschema.assertValid(tree)
-        except Exception, e:
-            raise PulpCodedValidationException(validation_exceptions=[
-                PulpCodedValidationException(error_code=error_codes.RPM1001, feed=feed,
-                                             validation_exceptions=[e])])
-
-        model.metadata[constants.CONFIG_KEY_DISTRIBUTION_XML_FILE] = constants.DISTRIBUTION_XML
-        # parse the distribution file and add all the files to the download request
-        root = tree.getroot()
-        for file_element in root.findall('file'):
-            relative_path = file_element.text
-            files.append({
-                'relativepath': relative_path,
-                'checksum': None,
-                'checksumtype': None,
-            })
-
-        # Add the distribution file to the list of files
-        files.append({
-            'relativepath': constants.DISTRIBUTION_XML,
-            'checksum': None,
-            'checksumtype': None,
-        })
-    return files
-
-
-def get_distribution_file(feed, tmp_dir, nectar_config):
-    """
-    Download the pulp_distribution.xml and return its full path on disk, or None if not found
-
-    :param feed:            URL to the repository
-    :type  feed:            str
-    :param tmp_dir:         full path to the temporary directory being used
-    :type  tmp_dir:         str
-    :param nectar_config:   download config to be used by nectar
-    :type  nectar_config:   nectar.config.DownloaderConfig
-
-    :return:        full path to distribution file on disk, or None if not found
-    :rtype:         str or NoneType
-    """
-    filename = constants.DISTRIBUTION_XML
-
-    path = os.path.join(tmp_dir, filename)
-    url = os.path.join(feed, filename)
-    request = DownloadRequest(url, path)
-    listener = AggregatingEventListener()
-    downloader = nectar_factory.create_downloader(feed, nectar_config, listener)
-    downloader.download([request])
-    if len(listener.succeeded_reports) == 1:
-        return path
-
-    return None
-
-
-def parse_treefile(path):
-    """
-    The treefile seems to be approximately in INI format, which can be read
-    by the standard library's ConfigParser.
-
-    :param path:    full path to the treefile
-    :return:        instance of Distribution model, and a list of dicts
-                    describing the distribution's files
-    :rtype:         (pulp_rpm.plugins.db.models.Distribution, list of dict)
-    """
-    parser = ConfigParser.RawConfigParser()
-    # the default implementation of this method makes all option names lowercase,
-    # which we don't want. This is the suggested solution in the python.org docs.
-    parser.optionxform = str
-    with open(path) as open_file:
+            variant = parser.get(SECTION_GENERAL, 'variant')
+        except ConfigParser.NoOptionError:
+            variant = None
         try:
-            parser.readfp(open_file)
-        except ConfigParser.ParsingError:
-            # wouldn't need this if ParsingError subclassed ValueError.
-            raise ValueError('could not parse treeinfo file')
+            packagedir = parser.get(SECTION_GENERAL, KEY_PACKAGEDIR)
+        except ConfigParser.NoOptionError:
+            packagedir = None
 
-    # apparently the 'variant' is optional. for example, it does not appear
-    # in the RHEL 5.9 treeinfo file. This is how the previous importer
-    # handled that.
-    try:
-        variant = parser.get(SECTION_GENERAL, 'variant')
-    except ConfigParser.NoOptionError:
-        variant = None
-    try:
-        packagedir = parser.get(SECTION_GENERAL, KEY_PACKAGEDIR)
-    except ConfigParser.NoOptionError:
-        packagedir = None
+        try:
+            new_dist = Distribution(
+                family=parser.get(SECTION_GENERAL, 'family'),
+                variant=variant,
+                version=parser.get(SECTION_GENERAL, 'version'),
+                arch=parser.get(SECTION_GENERAL, 'arch'),
+                packagedir=packagedir,
+                timestamp=float(parser.get(SECTION_GENERAL, KEY_TIMESTAMP))
+            )
+            # Look for an existing distribution
+            existing_dist = Distribution.objects.filter(
+                family=new_dist.family,
+                variant=new_dist.variant,
+                version=new_dist.version,
+                arch=new_dist.arch
+            ).first()
+            if existing_dist:
+                # update with the new information:
+                existing_dist.packagedir = packagedir
+                existing_dist.timestamp = new_dist.timestamp
+                unit = existing_dist
+            else:
+                unit = new_dist
+        except (ConfigParser.NoSectionError, ConfigParser.NoOptionError):
+            raise ValueError('invalid treefile: could not find unit key components')
 
-    try:
-        new_model = models.Distribution(
-            family=parser.get(SECTION_GENERAL, 'family'),
-            variant=variant,
-            version=parser.get(SECTION_GENERAL, 'version'),
-            arch=parser.get(SECTION_GENERAL, 'arch'),
-            packagedir=packagedir,
-            timestamp=float(parser.get(SECTION_GENERAL, KEY_TIMESTAMP))
-        )
-        # Look for an existing distribution
-        existing_dist = models.Distribution.objects(
-            family=new_model.family,
-            variant=new_model.variant,
-            version=new_model.version,
-            arch=new_model.arch
-        ).first()
-        if existing_dist:
-            # update with the new information:
-            existing_dist.packagedir = packagedir
-            existing_dist.timestamp = new_model.timestamp
-            model = existing_dist
-        else:
-            model = new_model
+        files = {}
+        # this section is likely to have all the files we care about listed with
+        # checksums. But, it might not. Other sections checked below will only add
+        # files to the "files" dict if they are not already present. For those cases,
+        # there will not be checksums available.
+        if parser.has_section(SECTION_CHECKSUMS):
+            for item in parser.items(SECTION_CHECKSUMS):
+                relativepath = item[0]
+                checksumtype, checksum = item[1].split(':')
+                checksumtype = verification.sanitize_checksum_type(checksumtype)
+                files[relativepath] = {
+                    RELATIVE_PATH: relativepath,
+                    CHECKSUM: checksum,
+                    CHECKSUM_TYPE: checksumtype
+                }
+        for section_name in parser.sections():
+            if section_name.startswith('images-') or section_name == SECTION_STAGE2:
+                for item in parser.items(section_name):
+                    if item[1] not in files:
+                        relativepath = item[1]
+                        files[relativepath] = {
+                            RELATIVE_PATH: relativepath,
+                            CHECKSUM: None,
+                            CHECKSUM_TYPE: None,
+                        }
 
-    except (ConfigParser.NoSectionError, ConfigParser.NoOptionError):
-        raise ValueError('invalid treefile: could not find unit key components')
-    files = {}
-    # this section is likely to have all the files we care about listed with
-    # checksums. But, it might not. Other sections checked below will only add
-    # files to the "files" dict if they are not already present. For those cases,
-    # there will not be checksums available.
-    if parser.has_section(SECTION_CHECKSUMS):
-        for item in parser.items(SECTION_CHECKSUMS):
-            relativepath = item[0]
-            checksumtype, checksum = item[1].split(':')
-            checksumtype = verification.sanitize_checksum_type(checksumtype)
-            files[relativepath] = {
-                'relativepath': relativepath,
-                'checksum': checksum,
-                'checksumtype': checksumtype
-            }
-
-    for section_name in parser.sections():
-        if section_name.startswith('images-') or section_name == SECTION_STAGE2:
-            for item in parser.items(section_name):
-                if item[1] not in files:
-                    relativepath = item[1]
-                    files[relativepath] = {
-                        'relativepath': relativepath,
-                        'checksum': None,
-                        'checksumtype': None,
-                    }
-
-    return model, files.values()
+        return unit, files.values()

--- a/plugins/pulp_rpm/plugins/importers/yum/purge.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/purge.py
@@ -271,7 +271,7 @@ def remove_unit_duplicate_nevra(unit, repo):
     and checksum type.
 
     :param unit: The unit whose NEVRA should be removed
-    :type unit_key: subclass of ContentUnit
+    :type unit: ContentUnit
     :param repo: the repo from which units will be unassociated
     :type repo: pulp.server.db.model.Repository
     """

--- a/plugins/pulp_rpm/plugins/importers/yum/upload.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/upload.py
@@ -210,8 +210,9 @@ def _handle_yum_metadata_file(repo, type_id, unit_key, metadata, file_path, cond
     translated_data = models.YumMetadataFile.SERIALIZER().from_representation(model_data)
 
     model = models.YumMetadataFile(**translated_data)
-    model.set_content(file_relative_path)
+    model.set_storage_path(os.path.basename(file_relative_path))
     model.save()
+    model.import_content(file_relative_path)
 
     # Move the file to its final storage location in Pulp
     repo_controller.associate_single_unit(conduit.repo, model)
@@ -268,8 +269,11 @@ def _handle_group_category_comps(repo, type_id, unit_key, metadata, file_path, c
         except TypeError:
             raise ModelInstantiationError()
 
-        unit.set_content(file_path)
         unit.save()
+
+        if file_path:
+            unit.set_storage_path(os.path.basename(file_path))
+            unit.import_content(file_path)
 
         repo_controller.associate_single_unit(repo, unit)
         repo_controller.rebuild_content_unit_counts(repo)
@@ -378,8 +382,9 @@ def _handle_package(repo, type_id, unit_key, metadata, file_path, conduit, confi
     # check if the unit has duplicate nevra
     purge.remove_unit_duplicate_nevra(unit, repo)
 
-    unit.set_content(file_path)
+    unit.set_storage_path(os.path.basename(file_path))
     unit.save()
+    unit.import_content(file_path)
 
     repo_controller.associate_single_unit(repo, unit)
     repo_controller.rebuild_content_unit_counts(repo)

--- a/plugins/pulp_rpm/plugins/migrations/0015_fix_distributor_units.py
+++ b/plugins/pulp_rpm/plugins/migrations/0015_fix_distributor_units.py
@@ -7,7 +7,7 @@ import os
 from pulp.server.db.connection import get_collection
 from pulp.server import config as pulp_config
 
-from pulp_rpm.plugins.importers.yum.parse import treeinfo
+from pulp_rpm.plugins.importers.yum.parse.treeinfo import DistSync
 
 _logger = logging.getLogger('pulp_rpm.plugins.migrations.0015')
 
@@ -25,7 +25,7 @@ def _fix_treeinfo_files(distribution_dir):
             if fname.startswith('treeinfo') or fname.startswith('.treeinfo'):
                 treeinfo_file = os.path.join(root, fname)
                 _logger.info("stripping repomd.xml checksum from %s" % treeinfo_file)
-                treeinfo.strip_treeinfo_repomd(treeinfo_file)
+                DistSync.strip_treeinfo_repomd(treeinfo_file)
 
 
 def _fix_distribution_units(dist_collection):

--- a/plugins/test/unit/plugins/importers/yum/parse/test_treeinfo.py
+++ b/plugins/test/unit/plugins/importers/yum/parse/test_treeinfo.py
@@ -8,7 +8,7 @@ from pulp.server.exceptions import PulpCodedValidationException
 
 from pulp_rpm.common import constants
 from pulp_rpm.plugins.db import models
-from pulp_rpm.plugins.importers.yum.parse import treeinfo
+from pulp_rpm.plugins.importers.yum.parse.treeinfo import DistSync
 
 
 DATA_PATH = os.path.join(os.path.dirname(__file__), '..', '..', '..', '..', '..', 'data')
@@ -21,10 +21,11 @@ DISTRIBUTION_BAD_SCHEMA_VALIDATION_FILE = os.path.join(DISTRIBUTION_DATA_PATH,
 
 
 class TestRealData(unittest.TestCase):
+
     def test_rhel5(self):
         path = os.path.join(DATA_PATH, 'treeinfo-rhel5')
 
-        model, files = treeinfo.parse_treefile(path)
+        model, files = DistSync.parse_treeinfo_file(path)
 
         self.assertTrue(isinstance(model, models.Distribution))
         self.assertEqual(model.distribution_id, 'ks-Red Hat Enterprise Linux Server-foo-5.9-x86_64')
@@ -39,7 +40,7 @@ class TestRealData(unittest.TestCase):
     def test_rhel5_optional(self):
         path = os.path.join(DATA_PATH, 'treeinfo-rhel5-no-optional-keys')
 
-        model, files = treeinfo.parse_treefile(path)
+        model, files = DistSync.parse_treeinfo_file(path)
 
         self.assertTrue(isinstance(model, models.Distribution))
         self.assertEqual(model.distribution_id, 'ks-Red Hat Enterprise Linux Server-5.9-x86_64')
@@ -53,92 +54,84 @@ class TestRealData(unittest.TestCase):
 
 
 class TestExistingDistIsCurrent(unittest.TestCase):
+
     def setUp(self):
         path = os.path.join(DATA_PATH, 'treeinfo-rhel5')
 
-        self.model1, files1 = treeinfo.parse_treefile(path)
-        self.model2, files2 = treeinfo.parse_treefile(path)
+        self.model1, files1 = DistSync.parse_treeinfo_file(path)
+        self.model2, files2 = DistSync.parse_treeinfo_file(path)
 
     def test_current(self):
-        ret = treeinfo.existing_distribution_is_current(self.model1, self.model2)
-
+        ret = DistSync.existing_distribution_is_current(self.model1, self.model2)
         self.assertTrue(ret is True)
 
     def test_not_current(self):
         self.model1.timestamp = 600.0  # 10 mins after the epoch
 
-        ret = treeinfo.existing_distribution_is_current(self.model1, self.model2)
+        ret = DistSync.existing_distribution_is_current(self.model1, self.model2)
 
         self.assertTrue(ret is False)
 
     def test_current_is_none(self):
         self.model1.timestamp = None
 
-        ret = treeinfo.existing_distribution_is_current(self.model1, self.model2)
+        ret = DistSync.existing_distribution_is_current(self.model1, self.model2)
 
         self.assertTrue(ret is False)
 
     def test_remote_is_none(self):
         self.model2.timestamp = None
 
-        ret = treeinfo.existing_distribution_is_current(self.model1, self.model2)
+        ret = DistSync.existing_distribution_is_current(self.model1, self.model2)
 
         self.assertTrue(ret is False)
 
 
 class TestProcessDistribution(unittest.TestCase):
-    @patch('pulp_rpm.plugins.importers.yum.parse.treeinfo.get_distribution_file',
+
+    @patch('pulp_rpm.plugins.importers.yum.parse.treeinfo.DistSync.get_distribution_file',
            return_value=DISTRIBUTION_GOOD_FILE)
     def test_parse_good_file(self, mock_get_dist):
-        feed = Mock()
         tmp_dir = Mock()
-        nectar_config = Mock()
-        model = Mock(metadata=dict())
-        report = Mock()
-        files = treeinfo.process_distribution(feed, tmp_dir, nectar_config, model, report)
+        parent = Mock()
+        dist = DistSync(parent, '')
+        files = dist.process_distribution(tmp_dir)
 
         self.assertEquals(3, len(files))
         self.assertEquals('foo/bar.txt', files[0]['relativepath'])
         self.assertEquals('baz/qux.txt', files[1]['relativepath'])
         self.assertEquals(constants.DISTRIBUTION_XML, files[2]['relativepath'])
-        self.assertEquals(model.metadata[constants.CONFIG_KEY_DISTRIBUTION_XML_FILE],
-                          constants.DISTRIBUTION_XML)
+        # TODO: This functionality is commented out in treeinfo.py
+        # self.assertEquals(model.metadata[constants.CONFIG_KEY_DISTRIBUTION_XML_FILE],
+        #                   constants.DISTRIBUTION_XML)
 
-    @patch('pulp_rpm.plugins.importers.yum.parse.treeinfo.get_distribution_file',
+    @patch('pulp_rpm.plugins.importers.yum.parse.treeinfo.DistSync.get_distribution_file',
            return_value=None)
     def test_no_distribution(self, mock_get_dist):
-        feed = Mock()
+        parent = Mock()
         tmp_dir = Mock()
-        nectar_config = Mock()
         model = Mock(metadata=dict())
-        report = Mock()
-        files = treeinfo.process_distribution(feed, tmp_dir, nectar_config, model, report)
+        dist = DistSync(parent, '')
+        files = dist.process_distribution(tmp_dir)
 
         self.assertEquals(0, len(files))
         self.assertEquals(None, model.metadata.get(constants.CONFIG_KEY_DISTRIBUTION_XML_FILE))
 
-    @patch('pulp_rpm.plugins.importers.yum.parse.treeinfo.get_distribution_file',
+    @patch('pulp_rpm.plugins.importers.yum.parse.treeinfo.DistSync.get_distribution_file',
            return_value=DISTRIBUTION_BAD_SYNTAX_FILE)
     def test_bad_distribution_syntax(self, mock_get_dist):
-        feed = Mock()
+        parent = Mock()
         tmp_dir = Mock()
-        nectar_config = Mock()
-        model = Mock(metadata=dict())
-        report = Mock()
-        self.assertRaises(PulpCodedValidationException, treeinfo.process_distribution, feed,
-                          tmp_dir, nectar_config, model, report)
+        dist = DistSync(parent, '')
+        self.assertRaises(PulpCodedValidationException, dist.process_distribution, tmp_dir)
 
-    @patch('pulp_rpm.plugins.importers.yum.parse.treeinfo.get_distribution_file',
+    @patch('pulp_rpm.plugins.importers.yum.parse.treeinfo.DistSync.get_distribution_file',
            return_value=DISTRIBUTION_BAD_SCHEMA_VALIDATION_FILE)
     def test_bad_distribution_schema(self, mock_get_dist):
-        feed = Mock()
+        parent = Mock()
         tmp_dir = Mock()
-        nectar_config = Mock()
-        model = Mock(metadata=dict())
-        report = Mock()
-        self.assertRaises(PulpCodedValidationException, treeinfo.process_distribution, feed,
-                          tmp_dir,
-                          nectar_config, model, report)
+        dist = DistSync(parent, '')
+        self.assertRaises(PulpCodedValidationException, dist.process_distribution, tmp_dir)
 
 
 class TestGetDistributionFile(unittest.TestCase):
@@ -146,33 +139,37 @@ class TestGetDistributionFile(unittest.TestCase):
     @patch('pulp_rpm.plugins.importers.yum.parse.treeinfo.AggregatingEventListener')
     def test_get_distribution_file_exists(self, mock_listener, mock_create_downloader):
         mock_listener.return_value.succeeded_reports = ['foo']
-        working_path = '/tmp/'
+        tmp_dir = '/tmp/'
         feed = 'http://www.foo.bar/flux/'
-        file_name = treeinfo.get_distribution_file(feed, working_path, Mock())
+        parent = Mock(feed=feed)
+        dist = DistSync(parent, feed)
+        file_name = dist.get_distribution_file(tmp_dir)
         request = mock_create_downloader.return_value.method_calls[0][1][0][0]
         self.assertEquals(request.url, os.path.join(feed, constants.DISTRIBUTION_XML))
-        self.assertEquals(request.destination, os.path.join(working_path,
+        self.assertEquals(request.destination, os.path.join(tmp_dir,
                                                             constants.DISTRIBUTION_XML))
-        self.assertEquals(file_name, os.path.join(working_path, constants.DISTRIBUTION_XML))
+        self.assertEquals(file_name, os.path.join(tmp_dir, constants.DISTRIBUTION_XML))
 
     @patch('pulp_rpm.plugins.importers.yum.parse.treeinfo.nectar_factory.create_downloader')
     @patch('pulp_rpm.plugins.importers.yum.parse.treeinfo.AggregatingEventListener')
     def test_get_distribution_file_does_not_exists(self, mock_listener, mock_create_downloader):
         mock_listener.return_value.succeeded_reports = []
-        working_path = '/tmp/'
+        tmp_dir = '/tmp/'
         feed = 'http://www.foo.bar/flux/'
-        file_name = treeinfo.get_distribution_file(feed, working_path, Mock())
+        parent = Mock(feed=feed)
+        dist = DistSync(parent, feed)
+        file_name = dist.get_distribution_file(tmp_dir)
         self.assertEquals(None, file_name)
 
 
 class TestParseTreefile(unittest.TestCase):
     """
-    This class contains tests for the parse_treefile() function.
+    This class contains tests for the parse_tree_file() function.
     """
 
     @patch('__builtin__.open', MagicMock())
     @patch('pulp_rpm.plugins.importers.yum.parse.treeinfo.ConfigParser.RawConfigParser')
-    @patch('pulp_rpm.plugins.importers.yum.parse.treeinfo.models.Distribution')
+    @patch('pulp_rpm.plugins.importers.yum.parse.treeinfo.Distribution')
     def test_sanitizes_checksum_type(self, Distribution, RawConfigParser):
         """
         Ensure the the function properly sanitizes checksum types.
@@ -182,6 +179,6 @@ class TestParseTreefile(unittest.TestCase):
         parser.items.return_value = [['path', 'sha:checksum']]
         RawConfigParser.return_value = parser
 
-        model, files = treeinfo.parse_treefile('/some/path')
+        model, files = DistSync.parse_treeinfo_file('/some/path')
 
         self.assertEqual(files[0]['checksumtype'], 'sha1')

--- a/plugins/test/unit/plugins/importers/yum/test_sync.py
+++ b/plugins/test/unit/plugins/importers/yum/test_sync.py
@@ -707,10 +707,12 @@ class TestUpdateContent(BaseSyncTest):
 
     @mock.patch('pulp_rpm.plugins.importers.yum.sync.RepoSync._decide_what_to_download',
                 spec_set=RepoSync._decide_what_to_download)
-    @mock.patch('pulp_rpm.plugins.importers.yum.sync.RepoSync.download',
-                spec_set=RepoSync.download)
+    @mock.patch('pulp_rpm.plugins.importers.yum.sync.RepoSync.download_drpms',
+                spec_set=RepoSync.download_drpms)
+    @mock.patch('pulp_rpm.plugins.importers.yum.sync.RepoSync.download_rpms',
+                spec_set=RepoSync.download_rpms)
     @mock.patch('pulp_rpm.plugins.importers.yum.purge.purge_unwanted_units', autospec=True)
-    def test_workflow(self, mock_purge, mock_download, mock_decide):
+    def test_workflow(self, mock_purge, mock_download_rpms, mock_download_drpms, mock_decide):
         rpms = set([1, 2, 3])
         drpms = set([4, 5, 6])
         mock_decide.return_value = (rpms, drpms)
@@ -718,7 +720,8 @@ class TestUpdateContent(BaseSyncTest):
         self.reposync.update_content(self.metadata_files, self.url)
 
         mock_decide.assert_called_once_with(self.metadata_files)
-        mock_download.assert_called_once_with(self.metadata_files, rpms, drpms, self.url)
+        mock_download_rpms.assert_called_once_with(self.metadata_files, rpms, drpms, self.url)
+        mock_download_drpms.assert_called_once_with(self.metadata_files, rpms, drpms, self.url)
         mock_purge.assert_called_once_with(self.metadata_files, self.conduit, self.config)
 
 

--- a/plugins/test/unit/plugins/migrations/test_0015_fix_distributor_units.py
+++ b/plugins/test/unit/plugins/migrations/test_0015_fix_distributor_units.py
@@ -55,7 +55,7 @@ class MigrationTests(rpm_support_base.PulpRPMTests):
         )
 
     @patch('os.walk')
-    @patch('pulp_rpm.plugins.importers.yum.parse.treeinfo.strip_treeinfo_repomd')
+    @patch('pulp_rpm.plugins.importers.yum.parse.treeinfo.DistSync.strip_treeinfo_repomd')
     def test_treeinfo_fix(self, mock_strip_treeinfo, mock_walk):
         mock_walk.return_value = [('/some/path/', [], ['treeinfo', 'file-A'])]
         migration = _import_all_the_way('pulp_rpm.plugins.migrations.0015_fix_distributor_units')
@@ -63,7 +63,7 @@ class MigrationTests(rpm_support_base.PulpRPMTests):
         mock_strip_treeinfo.assert_called_once_with('/some/path/treeinfo')
 
     @patch('os.walk')
-    @patch('pulp_rpm.plugins.importers.yum.parse.treeinfo.strip_treeinfo_repomd')
+    @patch('pulp_rpm.plugins.importers.yum.parse.treeinfo.DistSync.strip_treeinfo_repomd')
     def test_treeinfo_fix_dot_treeinfo(self, mock_strip_treeinfo, mock_walk):
         mock_walk.return_value = [('/some/path/', [], ['file-A', '.treeinfo'])]
         migration = _import_all_the_way('pulp_rpm.plugins.migrations.0015_fix_distributor_units')


### PR DESCRIPTION
https://pulp.plan.io/issues/1425

To start: I tried not to get sucked into making general improvements.  But, in some cases, I could not help myself.  The refactor of treeinfo.py is a good example.  I decided to make that an object *mostly* to be consistent with the package sync object; and to simply things by not passing so many parameters everywhere.  So, most of the large blocks of code removed/added is git's way of dealing with the indentation change so when reviewing - keep in mind that *I did not write most of this code*.

Some other refactoring was necessary to split (but reuse) downloading and unit creation.  It was important to preserve the practice of only adding a unit after files were successfully downloaded.  When downloading is deferred (lazy), the downloading is skipped.

In all cases, the catalog is updated.

The unit tests are still a wreck.