### PR TITLE
Revert ``Errata.pushcount`` to be ``StringField``.

### DIFF
--- a/plugins/pulp_rpm/plugins/db/models.py
+++ b/plugins/pulp_rpm/plugins/db/models.py
@@ -421,7 +421,7 @@ class Errata(Package):
     updated = mongoengine.StringField(required=True, default='')
     description = mongoengine.StringField()
     issued = mongoengine.StringField()
-    pushcount = mongoengine.IntField()
+    pushcount = mongoengine.StringField()
     references = mongoengine.ListField()
     reboot_suggested = mongoengine.BooleanField()
     errata_from = mongoengine.StringField(db_field='from')


### PR DESCRIPTION
In commit d3b3e5c4d58b98930c7041489274a98c229227aa the pushcount field
in Errata was changed to be an IntField. Although the field *should* be
an integer, many errata do not provide the pushcount. Since this breaks
syncing with these repos, the change has been reverted until it can be
addressed properly. This effort is tracked in issue #1458.

closes #1455