### PR TITLE
Fixes related to units_erratum.pushcount field

### DIFF
--- a/docs/user-guide/release-notes/2.8.x.rst
+++ b/docs/user-guide/release-notes/2.8.x.rst
@@ -14,8 +14,36 @@ New Features
 Database Changes
 ----------------
 
-The database has renamed some field names for RPM unit models. This change should not be noticeable through the API,
-but it does come with a migration which drops some indexes. The following field names are renamed:
+The 2.8.0 release comes with strong validation enabled at the database layer. This required some
+database changes to be made. These changes should go unnoticed for most users, however, for those
+users integrating with Pulp in a deep way, this may affect you. This section recaps known changes.
+
+Database Field Type Modifications
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The following collections and fields have had some data quality fixes applied to avoid validation
+issues.
+
+========================= ====================== ============================================
+Collection                Field Name             Data Quality Fix
+========================= ====================== ============================================
+units_package_category    translated_name        Previous values of "" are now {}
+units_package_category    translated_description Previous values of "" are now {}
+units_package_environment translated_name        Previous values of "" are now {}
+units_package_environment translated_description Previous values of "" are now {}
+units_package_group       translated_name        Previous values of "" are now {}
+units_package_group       translated_description Previous values of "" are now {}
+units_erratum             pushcount              All int and floats converted to strings. All
+                                                 null values are unset.
+========================= ====================== ============================================
+
+
+Database Fields Renamed
+^^^^^^^^^^^^^^^^^^^^^^^
+
+The database has renamed some field names for RPM unit models. This change should not be noticeable
+through the API, but it does come with a migration which drops some indexes. The following field
+names are renamed:
 
 =========================  ==============  ======================
 Collection                 Old Field Name  New Field Name
@@ -28,6 +56,8 @@ units_package_category     id              package_category_id
 units_package_environment  id              package_environment_id
 =========================  ==============  ======================
 
+Database Index Changes
+^^^^^^^^^^^^^^^^^^^^^^
 
 The following indexes have been dropped:
 
@@ -46,4 +76,3 @@ units_package_environment  id_1_repo_id_1
 =========================  ==============
 
 Several indexes have been created, check your db to see what indexes are in place.
-

--- a/extensions_admin/pulp_rpm/extensions/admin/upload/errata.py
+++ b/extensions_admin/pulp_rpm/extensions/admin/upload/errata.py
@@ -140,6 +140,8 @@ class CreateErratumCommand(UploadCommand):
             self.context.prompt.render_failure_message(msg)
             return os.EX_DATAERR
 
+        pushcount_str = str(pushcount)
+
         metadata = {
             'title': title,
             'description': description,
@@ -156,7 +158,7 @@ class CreateErratumCommand(UploadCommand):
             'summary': summary,
             'solution': solution,
             'from': from_str,
-            'pushcount': pushcount,
+            'pushcount': pushcount_str,
             'reboot_suggested': reboot_suggested,
         }
 

--- a/extensions_admin/test/unit/extensions/admin/upload/test_errata.py
+++ b/extensions_admin/test/unit/extensions/admin/upload/test_errata.py
@@ -91,7 +91,7 @@ class CreateRpmCommandTests(PulpClientTests):
             'summary': 'test-summary',
             'solution': 'test-solution',
             'from': 'test-from',
-            'pushcount': 1,
+            'pushcount': '1',
             'reboot_suggested': 'test-reboot',
             'pkglist': expected_package_list,
             'references': expected_reference_list,

--- a/plugins/pulp_rpm/plugins/db/models.py
+++ b/plugins/pulp_rpm/plugins/db/models.py
@@ -421,7 +421,7 @@ class Errata(Package):
     updated = mongoengine.StringField(required=True, default='')
     description = mongoengine.StringField()
     issued = mongoengine.StringField()
-    pushcount = mongoengine.IntField()
+    pushcount = mongoengine.StringField()
     references = mongoengine.ListField()
     reboot_suggested = mongoengine.BooleanField()
     errata_from = mongoengine.StringField(db_field='from')

--- a/plugins/pulp_rpm/plugins/migrations/0024_errata_pushcount_string.py
+++ b/plugins/pulp_rpm/plugins/migrations/0024_errata_pushcount_string.py
@@ -1,0 +1,36 @@
+"""
+This migration casts the pushcount field as a String.
+
+For the units_erratum collection, any object with the field 'pushcount' storing a non-String is
+cast to a String and saved. This is required since non String values will not validate with the
+Mongoengine definition. Any 'pushcount' fields which have the value null are unset.
+"""
+from pulp.server.db import connection
+
+
+def migrate(*args, **kwargs):
+    """
+    Perform the migration as described in this module's docblock.
+
+    :param args:   unused
+    :type  args:   list
+    :param kwargs: unused
+    :type  kwargs: dict
+    """
+    db = connection.get_database()
+    errata_collection = db['units_erratum']
+
+    for erratum in errata_collection.find({'pushcount': {'$type': 10}}, {'pushcount': 1}):
+        errata_collection.update({'_id': erratum['_id']}, {'$unset': {'pushcount': ""}})
+
+    for erratum in errata_collection.find({'pushcount': {'$exists': True}}, {'pushcount': 1}):
+        changed = False
+        if not isinstance(erratum['pushcount'], basestring):
+            if isinstance(erratum['pushcount'], float):
+                erratum['pushcount'] = int(erratum['pushcount'])
+            if isinstance(erratum['pushcount'], int):
+                changed = True
+                erratum['pushcount'] = str(erratum['pushcount'])
+        if changed:
+            errata_collection.update({'_id': erratum['_id']},
+                                     {'$set': {'pushcount': erratum['pushcount']}})

--- a/plugins/test/unit/plugins/migrations/test_0024_errata_pushcount_string.py
+++ b/plugins/test/unit/plugins/migrations/test_0024_errata_pushcount_string.py
@@ -1,0 +1,48 @@
+import unittest
+
+import mock
+
+from pulp.server.db.migrate.models import _import_all_the_way
+
+
+PATH_TO_MODULE = 'pulp_rpm.plugins.migrations.0024_errata_pushcount_string'
+
+migration = _import_all_the_way(PATH_TO_MODULE)
+
+
+class TestMigrate(unittest.TestCase):
+    """
+    Test migration 0022.
+    """
+
+    @mock.patch(PATH_TO_MODULE + '.connection')
+    def test_migration_fixed_expected_collections(self, mock_connection):
+        mock_collection = mock.Mock()
+        mock_connection.get_database.return_value = {'units_erratum': mock_collection}
+        fake_erratum_pushcount_is_null = [
+            {'pushcount': None, '_id': 'nullid1'},
+            {'pushcount': None, '_id': 'nullid2'},
+        ]
+        fake_erratum_pushcount_not_null = [
+            {'pushcount': 'astring', '_id': 'id1'},
+            {'pushcount': 2.0, '_id': 'id2'},
+            {'pushcount': 1, '_id': 'id3'},
+        ]
+        mock_collection.find.side_effect = [
+            fake_erratum_pushcount_is_null,
+            fake_erratum_pushcount_not_null
+        ]
+        migration.migrate()
+        mock_connection.get_database.assert_called_once_with()
+        expected_find_calls = [
+            mock.call({'pushcount': {'$type': 10}}, {'pushcount': 1}),
+            mock.call({'pushcount': {'$exists': True}}, {'pushcount': 1}),
+        ]
+        mock_collection.find.assert_has_calls(expected_find_calls)
+        expected_update_calls = [
+            mock.call({'_id': 'nullid1'}, {'$unset': {'pushcount': ''}}),
+            mock.call({'_id': 'nullid2'}, {'$unset': {'pushcount': ''}}),
+            mock.call({'_id': 'id2'}, {'$set': {'pushcount': '2'}}),
+            mock.call({'_id': 'id3'}, {'$set': {'pushcount': '1'}}),
+        ]
+        mock_collection.update.assert_has_calls(expected_update_calls)


### PR DESCRIPTION
* Reverts units_erratum.pushcount to be an StringField

* Adds migration 24 which converts all int or float
  units_erratum.pushcount values to a string

* Adds tests for migration 24

* Adds release notes about field data quality changes

* Adjusts pulp-admin to have it submit pushcount as a string

https://pulp.plan.io/issues/1455
closes #1455