### PR TITLE
Fix catalog entries to use the relativepath attribute.

### DIFF
--- a/plugins/pulp_rpm/plugins/importers/yum/sync.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/sync.py
@@ -584,7 +584,7 @@ class RepoSync(object):
             entry.importer_id = str(self.conduit.importer_object_id)
             entry.unit_id = unit.id
             entry.unit_type_id = unit.type_id
-            entry.url = urljoin(base_url, unit.filename)
+            entry.url = urljoin(base_url, unit.relativepath)
             entry.save_revision()
             yield unit
 


### PR DESCRIPTION
RPMs are not necessarily located at baseurl/filename. The primary.xml
file may contain a relative path (from the baseurl) to the RPM itself.