### PR TITLE
Temporarily remove the call to remove_unit_duplicate_nevra.

### DIFF
--- a/plugins/pulp_rpm/plugins/importers/yum/sync.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/sync.py
@@ -598,7 +598,6 @@ class RepoSync(object):
         :type unit: pulp_rpm.plugins.db.models.RpmBase
         """
         metadata_files.add_repodata(unit)
-        purge.remove_unit_duplicate_nevra(unit, self.conduit.repo)
         unit.set_storage_path(unit.filename)
         unit.save()
         repo_controller.associate_single_unit(self.conduit.repo, unit)


### PR DESCRIPTION
This will be added back once its performance problems have been
addressed. This effort is tracked in issue 1461.