### PR TITLE
Update repository units from platform

### DIFF
--- a/plugins/pulp_rpm/plugins/importers/iso/importer.py
+++ b/plugins/pulp_rpm/plugins/importers/iso/importer.py
@@ -150,7 +150,7 @@ class ISOImporter(Importer):
         iso.import_content(file_path)
 
         repo_controller.associate_single_unit(transfer_repo.repo_obj, iso)
-        repo_controller.update_unit_count(transfer_repo.repo_obj.repo_id, iso._content_type_id, 1)
+
         return {'success_flag': True, 'summary': None, 'details': None}
 
     def validate_config(self, repo, config):

--- a/plugins/pulp_rpm/plugins/importers/yum/sync.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/sync.py
@@ -278,8 +278,6 @@ class RepoSync(object):
             finally:
                 # clean up whatever we may have left behind
                 shutil.rmtree(self.tmp_dir, ignore_errors=True)
-                # recalculate all the unit counts
-                repo_controller.rebuild_content_unit_counts(self.repo)
 
             self.save_repomd_revision()
             _logger.info(_('Sync complete.'))

--- a/plugins/pulp_rpm/plugins/importers/yum/upload.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/upload.py
@@ -218,7 +218,6 @@ def _handle_yum_metadata_file(repo, type_id, unit_key, metadata, file_path, cond
     model.import_content(file_path)
 
     repo_controller.associate_single_unit(conduit.repo, model)
-    repo_controller.update_unit_count(repo, model._content_type_id, 1)
 
 
 def _handle_group_category_comps(repo, type_id, unit_key, metadata, file_path, conduit, config):
@@ -279,7 +278,6 @@ def _handle_group_category_comps(repo, type_id, unit_key, metadata, file_path, c
             unit.import_content(file_path)
 
         repo_controller.associate_single_unit(repo, unit)
-        repo_controller.rebuild_content_unit_counts(repo)
 
 
 def _get_and_save_file_units(filename, processing_function, tag, conduit, repo_id):
@@ -390,7 +388,6 @@ def _handle_package(repo, type_id, unit_key, metadata, file_path, conduit, confi
     unit.import_content(file_path)
 
     repo_controller.associate_single_unit(repo, unit)
-    repo_controller.rebuild_content_unit_counts(repo)
 
 
 def _update_provides_requires(unit):


### PR DESCRIPTION
Updating repository units from platform, due to them
not being reliably updated by plugins.  The code to do
this lives in platform, so we should be able to utilize it
from there

https://pulp.plan.io/issues/1467
re #1467