### PR TITLE
Removes unecessary fields from RpmBase model

### DIFF
--- a/plugins/pulp_rpm/plugins/db/models.py
+++ b/plugins/pulp_rpm/plugins/db/models.py
@@ -356,10 +356,6 @@ class RpmBase(NonMetadataPackage):
     time = mongoengine.IntField()
     requires = mongoengine.ListField()
 
-    # For backward compatibility
-    _ns = mongoengine.StringField(default='units_rpm')
-    _content_type_id = mongoengine.StringField(required=True, default='rpm')
-
     unit_key_fields = ('name', 'epoch', 'version', 'release', 'arch', 'checksumtype', 'checksum')
 
     meta = {'indexes': [


### PR DESCRIPTION
The _ns and _content_type_id fields are required to be defined
on the concrete class so they make no sense to be defined on the
abstract class.