### PR TITLE
iso distributor no longer fails with wrong type of Repository object

### DIFF
--- a/plugins/pulp_rpm/plugins/distributors/iso_distributor/distributor.py
+++ b/plugins/pulp_rpm/plugins/distributors/iso_distributor/distributor.py
@@ -58,8 +58,7 @@ class ISODistributor(FileDistributor):
         :return: report describing the publish operation
         :rtype: pulp.plugins.model.PublishReport
         """
-        repo = transfer_repo.repo_obj
-        return super(ISODistributor, self).publish_repo(repo, publish_conduit, config)
+        return super(ISODistributor, self).publish_repo(transfer_repo, publish_conduit, config)
 
     def unpublish_repo(self, transfer_repo, config):
         """
@@ -73,16 +72,15 @@ class ISODistributor(FileDistributor):
         :param config: plugin configuration
         :type  config: pulp.plugins.config.PluginCallConfiguration
         """
-        repo = transfer_repo.repo_obj
-        super(ISODistributor, self).unpublish_repo(repo, config)
-        publish.remove_repository_protection(repo)
+        super(ISODistributor, self).unpublish_repo(transfer_repo, config)
+        publish.remove_repository_protection(transfer_repo.repo_obj)
 
     def get_hosting_locations(self, repo, config):
         """
         Get the paths on the filesystem where the build directory should be copied
 
         :param repo: The repository that is going to be hosted
-        :type repo: pulp.server.db.model.Repository
+        :type  repo: pulp.plugins.model.Repository
 
         :param config:    plugin configuration
         :type  config:    pulp.plugins.config.PluginConfiguration
@@ -93,7 +91,7 @@ class ISODistributor(FileDistributor):
 
         hosting_locations = []
         # Publish the HTTP portion, if applicable
-        http_dest_dir = os.path.join(constants.ISO_HTTP_DIR, repo.repo_id)
+        http_dest_dir = os.path.join(constants.ISO_HTTP_DIR, repo.id)
 
         serve_http = config.get_boolean(constants.CONFIG_SERVE_HTTP)
         serve_http = serve_http if serve_http is not None else constants.CONFIG_SERVE_HTTP_DEFAULT
@@ -102,7 +100,7 @@ class ISODistributor(FileDistributor):
 
         # Publish the HTTPs portion, if applicable
         if self._is_https_supported(config):
-            https_dest_dir = os.path.join(constants.ISO_HTTPS_DIR, repo.repo_id)
+            https_dest_dir = os.path.join(constants.ISO_HTTPS_DIR, repo.id)
             hosting_locations.append(https_dest_dir)
 
         return hosting_locations
@@ -113,7 +111,7 @@ class ISODistributor(FileDistributor):
         been moved into place on the filesystem
 
         :param repo: The repository that is going to be hosted
-        :type repo: pulp.server.db.model.Repository
+        :type  repo: pulp.plugins.model.Repository
 
         :param config: the configuration for the repository
         :type  config: pulp.plugins.config.PluginCallConfiguration

--- a/plugins/test/unit/plugins/distributors/iso_distributor/test_iso_distributor_distributor.py
+++ b/plugins/test/unit/plugins/distributors/iso_distributor/test_iso_distributor_distributor.py
@@ -47,7 +47,7 @@ class TestISODistributor(unittest.TestCase):
 
     def _get_default_repo(self):
         repo = MagicMock()
-        repo.repo_id = 'awesome_repo'
+        repo.id = 'awesome_repo'
         return repo
 
     def test_metadata(self):
@@ -90,7 +90,7 @@ class TestISODistributor(unittest.TestCase):
                                      constants.CONFIG_SERVE_HTTPS: False})
         locations = self.iso_distributor.get_hosting_locations(repo, config)
         self.assertEquals(1, len(locations))
-        self.assertEquals(os.path.join(constants.ISO_HTTP_DIR, repo.repo_id), locations[0])
+        self.assertEquals(os.path.join(constants.ISO_HTTP_DIR, repo.id), locations[0])
 
     def test_get_hosting_locations_https_only(self):
         """
@@ -101,7 +101,7 @@ class TestISODistributor(unittest.TestCase):
 
         locations = self.iso_distributor.get_hosting_locations(repo, config)
         self.assertEquals(1, len(locations))
-        self.assertEquals(os.path.join(constants.ISO_HTTPS_DIR, repo.repo_id), locations[0])
+        self.assertEquals(os.path.join(constants.ISO_HTTPS_DIR, repo.id), locations[0])
 
     def test_get_hosting_locations_https_only_default(self):
         """
@@ -111,7 +111,7 @@ class TestISODistributor(unittest.TestCase):
         config = get_basic_config()
         locations = self.iso_distributor.get_hosting_locations(repo, config)
         self.assertEquals(1, len(locations))
-        self.assertEquals(os.path.join(constants.ISO_HTTPS_DIR, repo.repo_id), locations[0])
+        self.assertEquals(os.path.join(constants.ISO_HTTPS_DIR, repo.id), locations[0])
 
     def test_get_hosting_locations_http_and_https(self):
         """
@@ -122,8 +122,8 @@ class TestISODistributor(unittest.TestCase):
                                      constants.CONFIG_SERVE_HTTPS: True})
         locations = self.iso_distributor.get_hosting_locations(repo, config)
         self.assertEquals(2, len(locations))
-        self.assertEquals(os.path.join(constants.ISO_HTTP_DIR, repo.repo_id), locations[0])
-        self.assertEquals(os.path.join(constants.ISO_HTTPS_DIR, repo.repo_id), locations[1])
+        self.assertEquals(os.path.join(constants.ISO_HTTP_DIR, repo.id), locations[0])
+        self.assertEquals(os.path.join(constants.ISO_HTTPS_DIR, repo.id), locations[1])
 
     @patch(
         'pulp_rpm.plugins.distributors.iso_distributor.distributor.publish'


### PR DESCRIPTION
This is the remaining work outside platform to fix #1480. The conversion from
old to new style repository was apparently not complete. It was simplest and
safest to go back to passing around the old style object, especially since the
workflow passes back and forth between the parent and child classes, in
platform and this plugin respectively.

re #1480
https://pulp.plan.io/issues/1480