### PR TITLE
existing group and category units get associated correctly during sync

### DIFF
--- a/plugins/pulp_rpm/plugins/importers/yum/sync.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/sync.py
@@ -840,6 +840,9 @@ class RepoSync(object):
                 if additive_type:
                     model = self._concatenate_units(existing_unit, model)
                     model.save()
+                else:
+                    # make sure the associate_unit call gets the existing unit
+                    model = existing_unit
 
             repo_controller.associate_single_unit(self.repo, model)
 


### PR DESCRIPTION
Previously in 2.8 development code, when a group or category existed as an
orphan, the sync would incorrectly create the association so that the unit_id
was not unit_id of the existing unit in the DB. This caused search to break for
those units in that repo, which in turn caused copy to break.

https://pulp.plan.io/issues/1489
fixes #1489