### PR TITLE
pulp-admin updated to reflect removed distribution fields

### DIFF
--- a/extensions_admin/pulp_rpm/extensions/admin/contents.py
+++ b/extensions_admin/pulp_rpm/extensions/admin/contents.py
@@ -372,16 +372,12 @@ class SearchDistributionsCommand(BaseSearchCommand):
         self.context.prompt.write(_('Files:'))
         for f in distro['files']:
             data = {
-                'filename': f['filename'],
                 'path': f['relativepath'],
-                'size': f['size'],
                 'type': f['checksumtype'],
                 'checksum': f['checksum'],
             }
 
-            self.context.prompt.write(_('  Filename:       %(filename)s') % data)
             self.context.prompt.write(_('  Relative Path:  %(path)s') % data)
-            self.context.prompt.write(_('  Size:           %(size)s') % data)
             self.context.prompt.write(_('  Checksum Type:  %(type)s') % data)
 
             checksum = self.context.prompt.wrap(_('  Checksum:       %(checksum)s') % data,


### PR DESCRIPTION
These fields were removed when pulp_rpm implemented lazy downloading,
but pulp-admin was still trying to use them.

https://pulp.plan.io/issues/1505
fixes #1505