### PR TITLE
Ensure file objects are cleaned up on error

### DIFF
--- a/plugins/pulp_rpm/plugins/importers/iso/importer.py
+++ b/plugins/pulp_rpm/plugins/importers/iso/importer.py
@@ -146,8 +146,7 @@ class ISOImporter(Importer):
         except ValueError, e:
             return {'success_flag': False, 'summary': e.message, 'details': None}
 
-        iso.save()
-        iso.import_content(file_path)
+        iso.save_and_import_content(file_path)
 
         repo_controller.associate_single_unit(transfer_repo.repo_obj, iso)
 

--- a/plugins/pulp_rpm/plugins/importers/iso/sync.py
+++ b/plugins/pulp_rpm/plugins/importers/iso/sync.py
@@ -163,8 +163,7 @@ class ISOSyncRun(listener.DownloadEventListener):
             try:
                 if self._validate_downloads:
                     iso.validate_iso(report.destination)
-                iso.save()
-                iso.import_content(report.destination)
+                iso.save_and_import_content(report.destination)
                 repo_controller.associate_single_unit(self.sync_conduit.repo, iso)
 
                 # We can drop this ISO from the url --> ISO map

--- a/plugins/pulp_rpm/plugins/importers/yum/associate.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/associate.py
@@ -366,7 +366,7 @@ def associate_copy_for_repo(unit, dest_repo, set_content=False):
 
     if set_content:
         new_unit.set_storage_path(os.path.basename(unit._storage_path))
-        new_unit.import_content(unit._storage_path)
+        new_unit.safe_import_content(unit._storage_path)
 
     repo_controller.associate_single_unit(repository=dest_repo, unit=new_unit)
     return new_unit

--- a/plugins/pulp_rpm/plugins/importers/yum/listener.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/listener.py
@@ -179,7 +179,7 @@ class RPMListener(PackageListener):
             # verification failed, unit not added
             return
         self.sync.add_rpm_unit(self.metadata_files, unit)
-        unit.import_content(report.destination)
+        unit.safe_import_content(report.destination)
 
 
 class DRPMListener(PackageListener):
@@ -195,4 +195,4 @@ class DRPMListener(PackageListener):
             # verification failed, unit not added
             return
         self.sync.add_drpm_unit(self.metadata_files, unit)
-        unit.import_content(report.destination)
+        unit.safe_import_content(report.destination)

--- a/plugins/pulp_rpm/plugins/importers/yum/parse/treeinfo.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/parse/treeinfo.py
@@ -183,11 +183,11 @@ class DistSync(object):
 
         # The treeinfo file is always imported into platform
         # # storage regardless of the download policy
-        unit.import_content(treeinfo_path, os.path.basename(treeinfo_path))
+        unit.safe_import_content(treeinfo_path, os.path.basename(treeinfo_path))
 
         # The downloaded files are imported into platform storage.
         for destination, location in downloaded:
-            unit.import_content(destination, location)
+            unit.safe_import_content(destination, location)
 
         # Associate the unit.
         repo_controller.associate_single_unit(self.repo, unit)

--- a/plugins/pulp_rpm/plugins/importers/yum/sync.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/sync.py
@@ -441,8 +441,7 @@ class RepoSync(object):
                         checksum_type=checksum_type)
 
                 model.set_storage_path(os.path.basename(file_path))
-                model.save()
-                model.import_content(file_path)
+                model.save_and_import_content(file_path)
 
                 # associate/re-associate model to the repo
                 repo_controller.associate_single_unit(self.repo, model)

--- a/plugins/pulp_rpm/plugins/importers/yum/upload.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/upload.py
@@ -214,8 +214,7 @@ def _handle_yum_metadata_file(repo, type_id, unit_key, metadata, file_path, cond
 
     model = models.YumMetadataFile(**unit_data)
     model.set_storage_path(os.path.basename(file_path))
-    model.save()
-    model.import_content(file_path)
+    model.save_and_import_content(file_path)
 
     repo_controller.associate_single_unit(conduit.repo, model)
 
@@ -275,7 +274,7 @@ def _handle_group_category_comps(repo, type_id, unit_key, metadata, file_path, c
 
         if file_path:
             unit.set_storage_path(os.path.basename(file_path))
-            unit.import_content(file_path)
+            unit.safe_import_content(file_path)
 
         repo_controller.associate_single_unit(repo, unit)
 
@@ -384,8 +383,7 @@ def _handle_package(repo, type_id, unit_key, metadata, file_path, conduit, confi
     purge.remove_unit_duplicate_nevra(unit, repo)
 
     unit.set_storage_path(os.path.basename(file_path))
-    unit.save()
-    unit.import_content(file_path)
+    unit.save_and_import_content(file_path)
 
     repo_controller.associate_single_unit(repo, unit)
 


### PR DESCRIPTION
Call save_and_import_content().

Utilize cleanup pattern instead where usage doesn't
fit.

re #[1457](https://pulp.plan.io/issues/1457)
https://pulp.plan.io/issues/1457