### PR TITLE
remove `property` decorate for `list_files` in the distribution.

### DIFF
--- a/plugins/pulp_rpm/plugins/db/models.py
+++ b/plugins/pulp_rpm/plugins/db/models.py
@@ -238,7 +238,6 @@ class Distribution(UnitMixin, FileContentUnit):
                                 self.arch))
             self.distribution_id = '-'.join(id_pieces)
 
-    @property
     def list_files(self):
         """
         List absolute paths to files associated with this unit.


### PR DESCRIPTION
The parent class implements `list_files` as a method. This made it impossible to lazy download distributions.