### PR TITLE
Do not index the errata id twice.

### DIFF
--- a/plugins/pulp_rpm/plugins/db/models.py
+++ b/plugins/pulp_rpm/plugins/db/models.py
@@ -448,7 +448,7 @@ class Errata(UnitMixin, ContentUnit):
     unit_key_fields = ('errata_id',)
 
     meta = {'indexes': [
-        "errata_id", "version", "release", "type", "status", "updated",
+        "version", "release", "type", "status", "updated",
         "issued", "severity", "references",
         {
             'fields': unit_key_fields,


### PR DESCRIPTION
It is an error in pymongo >= 3 to create two indices with different
parameters and the same id. This commit eliminates a redundant
index in the Errata unit.

https://pulp.plan.io/issues/1528

re #1528