### PR TITLE
Migration for relative_url

### DIFF
--- a/plugins/pulp_rpm/plugins/migrations/0025_export_relative_url.py
+++ b/plugins/pulp_rpm/plugins/migrations/0025_export_relative_url.py
@@ -1,0 +1,76 @@
+"""
+Migration to normalize relative_url, and populate relative_url on
+export distributors
+"""
+from pulp.server.db import connection
+
+
+def _find_yum_distributor(distributors):
+    """
+    Find this repo's 'yum_distributor' to pull the relative_url from.
+
+    While technically you can have more than one yum_distributor...
+    functionality really only works for a single distributor at a time.
+    This distributor's ID is 'yum_distributor'
+
+    :param distributors: List of distributors for repo.
+    :type distributors: list
+    """
+    for distributor in distributors:
+        if distributor['distributor_id'] == 'yum_distributor':
+            if 'config' in distributor and 'relative_url' in distributor['config']:
+                return distributor
+    return None
+
+
+def _clean_distributors_relative_url(repo_distributors, distributors):
+    """
+    Cleanup the distributors relative url.  YUM Distributors were generated
+    with a leading slash in certain use cases before PR #776, which fixes
+    issue #1520
+
+    :param repo_distributors: The repo_distributor collection from mongodb
+    :type repo_distributors: pymongo.collection.Collection
+    :param distributors: The list of distributors for the repo
+    :type distributors: list
+    """
+    for distributor in distributors:
+        if 'config' in distributor and 'relative_url' in distributor['config']\
+                and distributor['config']['relative_url'].startswith('/', 0, 1):
+            relative_url = distributor['config']['relative_url'].lstrip('/ ')
+            distributor['config']['relative_url'] = relative_url
+            repo_distributors.update_one({'_id': distributor['_id']},
+                                         {'$set': {'config': distributor['config']}})
+
+
+def migrate(*args, **kwargs):
+    """
+    Perform the migration as described in this module's docblock.
+
+    :param args:   unused
+    :type  args:   list
+    :param kwargs: unused
+    :type  kwargs: dict
+    """
+    db = connection.get_database()
+    repos = db['repos']
+    repo_distributors = db['repo_distributors']
+    repo_objects = repos.find({'notes': {'_repo-type': 'rpm-repo'}})
+    for repo_object in repo_objects:
+        distributors = list(repo_distributors.find({'repo_id': repo_object['repo_id']}))
+        _clean_distributors_relative_url(repo_distributors, distributors)
+        yum_distributor = _find_yum_distributor(distributors)
+        for distributor in distributors:
+
+            if distributor['distributor_type_id'] == 'export_distributor' and \
+                    'relative_url' not in distributor['config']:
+
+                if yum_distributor is None:
+                    relative_url = repo_object['repo_id']
+                else:
+                    relative_url = yum_distributor['config']['relative_url']
+
+                distributor['config']['relative_url'] = relative_url
+
+                repo_distributors.update_one({'_id': distributor['_id']},
+                                             {'$set': {'config': distributor['config']}})

--- a/plugins/test/unit/plugins/migrations/test_0025_export_relative_url.py
+++ b/plugins/test/unit/plugins/migrations/test_0025_export_relative_url.py
@@ -1,0 +1,98 @@
+import unittest
+
+import mock
+
+from pulp.server.db.migrate.models import _import_all_the_way
+
+PATH_TO_MODULE = 'pulp_rpm.plugins.migrations.0025_export_relative_url'
+migration = _import_all_the_way(PATH_TO_MODULE)
+
+
+@mock.patch(PATH_TO_MODULE + '.connection')
+class TestMigrate(unittest.TestCase):
+    """
+    Test migration 0025
+    """
+
+    def test_migration_export_relative_url(self, connection):
+        repo_collection = self._build_repo_data()
+        repo_distributor_collection = self._build_pre_migration_data()
+        connection.get_database.return_value = {'repos': repo_collection,
+                                                'repo_distributors': repo_distributor_collection}
+        migration.migrate()
+        repo_update = {"$set": {
+            "config": {
+                "http": False,
+                "https": True,
+                "relative_url": "repos/pulp/pulp/demo_repos/zoo/"
+            }}}
+
+        expected_update_calls = [
+            mock.call({'_id': 'fake_yum_distributor'}, repo_update),
+            mock.call({'_id': 'fake_export_distributor'}, repo_update),
+        ]
+        repo_distributor_collection.update_one.assert_has_calls(expected_update_calls)
+
+    def test_migration_export_idepotency(self, connection):
+        repo_collection = self._build_repo_data()
+        repo_distributor_collection = self._build_post_migration_data()
+        connection.get_database.return_value = {'repos': repo_collection,
+                                                'repo_distributors': repo_distributor_collection}
+        migration.migrate()
+        assert not repo_distributor_collection.update_one.called
+
+    def _build_repo_data(self):
+        collection = mock.Mock()
+        collection.find.side_effect = [[{"repo_id": "zoo"}]]
+        return collection
+
+    def _build_pre_migration_data(self):
+        collection = mock.Mock()
+        collection_side_effect = [{
+            "_id": "fake_yum_distributor",
+            "repo_id": "zoo",
+            "distributor_id": "yum_distributor",
+            "distributor_type_id": "yum_distributor",
+            "config": {
+                "http": False,
+                "https": True,
+                "relative_url": "/repos/pulp/pulp/demo_repos/zoo/"
+            }
+        }, {
+            "_id": "fake_export_distributor",
+            "repo_id": "zoo",
+            "distributor_id": "export_distributor",
+            "distributor_type_id": "export_distributor",
+            "config": {
+                "http": False,
+                "https": True,
+            }
+        }]
+        collection.find.side_effect = [collection_side_effect]
+        return collection
+
+    def _build_post_migration_data(self):
+        collection = mock.Mock()
+        collection_side_effect = [{
+            "_id": "fake_yum_distributor",
+            "repo_id": "zoo",
+            "distributor_id": "yum_distributor",
+            "distributor_type_id": "yum_distributor",
+            "config": {
+                "http": False,
+                "https": True,
+                "relative_url": "repos/pulp/pulp/demo_repos/zoo/"
+            }
+        }, {
+            "_id": "fake_export_distributor",
+            "repo_id": "zoo",
+            "distributor_id": "export_distributor",
+            "distributor_type_id": "export_distributor",
+            "config": {
+                "http": False,
+                "https": True,
+                "relative_url": "repos/pulp/pulp/demo_repos/zoo/"
+            }
+        }]
+        collection.find.side_effect = [collection_side_effect]
+        return collection


### PR DESCRIPTION
This migration ensures that existing data gets updated
for PR #776

re #[1520](https://pulp.plan.io/issues/1520)
https://pulp.plan.io/issues/1520