### PR TITLE
Re-institute purging duplicate NEVRA after an rpm repo sync

### DIFF
--- a/extensions_admin/pulp_rpm/extensions/admin/status.py
+++ b/extensions_admin/pulp_rpm/extensions/admin/status.py
@@ -29,6 +29,7 @@ class RpmStatusRenderer(StatusRenderer):
         self.distribution_sync_last_state = constants.STATE_NOT_STARTED
         self.errata_last_state = constants.STATE_NOT_STARTED
         self.comps_last_state = constants.STATE_NOT_STARTED
+        self.purge_duplicates_last_state = constants.STATE_NOT_STARTED
 
         # Publish Steps
         self.publish_steps_last_state = dict.fromkeys(constants.PUBLISH_STEPS,
@@ -46,6 +47,7 @@ class RpmStatusRenderer(StatusRenderer):
         self.distribution_sync_bar = self.prompt.create_progress_bar()
         self.errata_spinner = self.prompt.create_spinner()
         self.comps_spinner = self.prompt.create_spinner()
+        self.purge_duplicates_spinner = self.prompt.create_spinner()
 
         self.packages_bar = self.prompt.create_progress_bar()
         self.distribution_publish_bar = self.prompt.create_progress_bar()
@@ -71,6 +73,7 @@ class RpmStatusRenderer(StatusRenderer):
                 self.render_distribution_sync_step(progress_report)
                 self.render_errata_step(progress_report)
                 self.render_comps_step(progress_report)
+                self.render_purge_duplicates_step(progress_report)
 
             # Publish Steps
             if ids.YUM_DISTRIBUTOR_ID in progress_report:
@@ -330,3 +333,18 @@ class RpmStatusRenderer(StatusRenderer):
         render_general_spinner_step(self.prompt, self.comps_spinner, current_state,
                                     self.comps_last_state,
                                     _('Importing package groups/categories...'), update_func)
+
+    def render_purge_duplicates_step(self, progress_report):
+        # Example Data:
+        # "purge_duplicates": {
+        #   "state": "FINISHED"
+        # }
+
+        current_state = progress_report['yum_importer']['purge_duplicates']['state']
+
+        def update_func(new_state):
+            self.purge_duplicates_last_state = new_state
+
+        render_general_spinner_step(self.prompt, self.purge_duplicates_spinner, current_state,
+                                    self.purge_duplicates_last_state,
+                                    _('Cleaning duplicate packages...'), update_func)

--- a/plugins/pulp_rpm/plugins/importers/yum/purge.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/purge.py
@@ -61,9 +61,9 @@ def remove_old_versions(num_to_keep, conduit):
                         and remove_unit methods.
     :type  conduit:     pulp.plugins.conduits.repo_sync.RepoSyncConduit
     """
-    for model in (models.RPM, models.SRPM, models.DRPM):
+    for unit_type in (models.RPM, models.SRPM, models.DRPM):
         units = {}
-        for unit in get_existing_units(model, conduit.get_units):
+        for unit in get_existing_units(unit_type, conduit.get_units):
             model_instance = model(metadata=unit.metadata, **unit.unit_key)
             key = model_instance.key_string_without_version
             serialized_version = model_instance.complete_version_serialized
@@ -256,8 +256,8 @@ def get_remote_units(file_function, tag, process_func):
                                                                  tag,
                                                                  process_func)
 
-        for model in package_info_generator:
-            named_tuple = model.as_named_tuple
+        for unit in package_info_generator:
+            named_tuple = unit.as_named_tuple
             remote_named_tuples.add(named_tuple)
 
     finally:

--- a/plugins/pulp_rpm/plugins/importers/yum/purge.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/purge.py
@@ -1,12 +1,15 @@
-from gettext import gettext as _
 import functools
 import logging
 import operator
+from gettext import gettext as _
+from itertools import repeat
 
 from mongoengine import Q
 from pulp.common.plugins import importer_constants
+from pulp.server.db import model
 from pulp.server.db.model.criteria import UnitAssociationCriteria
 from pulp.server.controllers import repository as repo_controller
+from pymongo.errors import OperationFailure
 
 from pulp_rpm.plugins.db import models
 from pulp_rpm.plugins.importers.yum.repomd import packages, primary, presto, updateinfo, group
@@ -286,3 +289,209 @@ def remove_unit_duplicate_nevra(unit, repo):
                                                             units_q=Q_nevra_filter,
                                                             yield_content_unit=True)
     repo_controller.disassociate_units(repo, unit_iterator)
+
+
+def remove_repo_duplicate_nevra(repo_id):
+    """
+    Removes duplicate units that have same NEVRA from a repo, keeping only the most recent unit
+
+    This function is for bulk operations on an entire repo, such as after syncing a repo.
+    When operating on single units, consider using :py:func:`remove_unit_duplicate_nevra` instead.
+
+    :param repo_id: ID of the repo from which units with duplicate nevra will be unassociated
+    :type repo_id: str
+    """
+    for unit_type in (models.RPM, models.SRPM, models.DRPM):
+        for unit_ids in _duplicate_key_id_generator(unit_type):
+            # q objects don't deal with order_by, so they can't be used with repo_controller funcs
+            # disassociate_units only uses the unit_id, so limit the resultset to only that field
+            rcus = model.RepositoryContentUnit.objects.filter(
+                repo_id=repo_id, unit_id__in=unit_ids).order_by('-updated').only('unit_id')
+
+            # 0 or 1 packages from the duplicate nevra search match this repo means no duplicates
+            if rcus.count() < 2:
+                continue
+
+            repo = model.Repository.objects.get(repo_id=repo_id)
+
+            # Since the repo_units queryset is ordered by the updated field (descending), the
+            # first repo content unit is the latest. All other RCUs should be disassociated
+            duplicate_units = (unit_type(id=rcu.unit_id) for rcu in rcus[1:])
+            repo_controller.disassociate_units(repo, duplicate_units)
+
+
+def _duplicate_key_nevra_fields(unit):
+    """strip out fields not related to nevra from a nevra-supporting unit key
+
+    :param unit: unit with NEVRA fields to be filtered
+    :type unit: ContentUnit
+    """
+    # consider duplicates to be units with the same unit key when the checksum is ignored.
+    # normally that means NEVRA, but with DRPMs, for example, filename is used instead of name
+    fields = list(unit.NAMED_TUPLE._fields)
+    fields.remove('checksum')
+    fields.remove('checksumtype')
+    return fields
+
+
+def _duplicate_key_id_generator(unit):
+    """duplicate NEVRA unit ID generator
+
+    :param unit: The unit whose NEVRA should be removed
+    :type unit: ContentUnit
+
+    find all duplicate NEVRAs, regardless of repository, for a given content unit type
+
+    This is a memory-efficient pre-filter, which finds all possible duplicate NEVRAs in the
+    collection of a content unit that supports the NEVRA fields. This iterator can then be
+    cross-referenced with a repository to remove duplicate repository content unit
+    links for a given NEVRA.
+    """
+    fields = _duplicate_key_nevra_fields(unit)
+
+    try:
+        # this test aggregation is needed because the aggregation generator body
+        # won't raise OperationFailure until its first iteration, at which point it's too late to
+        # switch to the mapreduce generator. this also ensures that if OperationFailure is raised
+        # at this point, it's specifically because an unsupported aggregation feature was requested
+        unit.objects.aggregate({'$limit': 1})
+        return _duplicate_key_id_generator_aggregation(unit, fields)
+    except OperationFailure:
+        # mongodb doesn't support aggregation cursors, use the slower mapreduce method
+        _logger.info('Purging duplicate NEVRA can take significantly longer in versions of '
+                     'mongodb lower than 2.6. Consider upgrading mongodb if cleaning duplicate '
+                     'packages takes an unreasonably long time.')
+        return _duplicate_key_id_generator_mapreduce(unit, fields)
+
+
+def _duplicate_key_id_generator_aggregation(unit, fields):
+    """Superior Aggregation version of duplicate nevra unit ID generator for mongo 2.6+
+
+    In order to find potential duplicate nevras, a mongo aggregation pipeline is employed
+    to sort a unit's entire collection based on non-checksum unit key fields. Doing the sorting
+    purely as a normal QuerySet overflow's mongo's sort stage bugger, and doing it purely with
+    python uses too much memory. Running things through the aggregation pipelines results in
+    an iterable that makes it relatively simple to spit out potential duplicate unit IDs without
+    breaking either mongo or python. Because the resulting dataset can be rather large, it is
+    important to be able to use a mongo db cursor to iterate over the results, which is sadly
+    unsupported in 2.4. In that case, the mapreduce method below must be used.
+
+    :param unit: The unit whose NEVRA should be removed
+    :type unit: ContentUnit
+    :param fields: list of fields that define a given unit type's NEVRA fields
+    :type fields: list
+    """
+
+    # create the aggregation params by zipping the fields with 1
+    # It is a happy coincidence that the two dicts are the same values
+    pipeline_opts = dict(zip(fields, repeat(1)))
+
+    # for $sort, this indicates ascending sort for nevra fields
+    sort = {'$sort': pipeline_opts}
+
+    # for $project, this indicates what fields to include in the result
+    project = {'$project': pipeline_opts}
+
+    # When aggregating over hundreds of thousands of packages, mongo can overflow
+    # To prevent this, mongo needs to be allowed to temporarily use the disk for this transaction
+    aggregation = unit.objects.aggregate(sort, project, allowDiskUse=True)
+
+    # loop state tracking vars
+    previous_nevra = None
+    previous_pkg_id = None
+    yielding_ids = None
+
+    for pkg in aggregation:
+        # strip the checksums and mongo metadata so they don't get used in equality checks
+        current_nevra = tuple(pkg[field] for field in fields)
+        # current nevra matches previous: this is a duplicate nevra
+        if current_nevra == previous_nevra:
+            if yielding_ids is None:
+                # The current nevra is a duplicate but yielding_ids is None, which means
+                # this iteration is the first to detect a duplicate for this nevra.
+                # Initialize the list of ids to yield with the *previous* id,
+                # since it was the first unit seen with the current nevra
+                yielding_ids = [previous_pkg_id]
+
+            # After yielding_ids is initialized with the first unit,
+            # append the current package id for each duplicate nevra seen
+            yielding_ids.append(pkg['_id'])
+
+        # current nevra doesn't match previous: this is a new nevra
+        else:
+            # if the duplicate detection populated yielding_ids, yield it now
+            # and reset yielding ids for the next potential duplicate
+            if yielding_ids:
+                yield yielding_ids
+                yielding_ids = None
+
+        # stash the current state for comparison in the next iteration
+        previous_nevra = current_nevra
+        previous_pkg_id = pkg['_id']
+
+    # after the pkg loop, if the last pkg was a duplicate, the yielding else clause won't run
+    # in that case, do one final yield to make sure all potential duplicates are yielded
+    if yielding_ids:
+        yield yielding_ids
+
+
+def _duplicate_key_id_generator_mapreduce(unit, fields):
+    """Inferior MapReduce version of duplicate nevra unit ID generator for mongo 2.4
+
+    In order to find potential duplicate nevras, a mongo mapReduce is employed to sift units
+    with duplicate nevra in a unit's entire collection based on non-checksum unit key fields.
+    This produces the same results as the aggregation mechanism above, but is far slower. Its
+    one redeemind quality, relatively speaking, is that it works in mongo 2.4.
+
+    :param unit: The unit whose NEVRA should be removed
+    :type unit: ContentUnit
+    :param fields: list of fields that define a given unit type's NEVRA fields
+    :type fields: list
+    """
+
+    if unit is models.DRPM:
+        name_field = 'filename'
+    else:
+        name_field = 'name'
+
+    # going with % interpolation here because all the {}'s make .format no fun for JS...
+    # map all units in the collect into key value pairs, where the key is the unit
+    # key fields joined by '-', and the value is the unit id
+    map_f = """
+    function () {
+        var key_fields = [this.%s, this.epoch, this.version, this.release, this.arch]
+        emit(key_fields.join('-'), {ids: [this._id]});
+    }
+    """ % name_field
+
+    # reduce keys with multiple values down by collecting ids into a single return object
+    reduce_f = """
+    function (key, values) {
+      // collect mapped values into the first value to build the list of ids for this key/nevra
+      var collector = values[0]
+      // since collector is values[0] start this loop at index 1
+      // reduce isn't called if map only emits one result for key,
+      // so there is at least one value to collect
+      for (var i = 1; i < values.length; i++) {
+        collector.ids = collector.ids.concat(values[i].ids)
+      }
+      return collector
+    }
+    """
+
+    # to save time and memory, only return id lists with multiple values, undefing the singles
+    finalize_f = """
+    function (key, reduced) {
+        if (reduced.ids.length > 1) {
+            return reduced;
+        }
+        // if there's only one value after reduction, this key is useless
+        // undefined is implicitly returned here, which saves space
+    }
+    """
+
+    reduced_units = unit.objects.map_reduce(map_f, reduce_f, 'inline', finalize_f)
+    for reduced in reduced_units:
+        # filter out the undefined (now None) values created in the finalize step
+        if reduced.value:
+            yield reduced.value['ids']

--- a/plugins/pulp_rpm/plugins/importers/yum/sync.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/sync.py
@@ -61,6 +61,7 @@ class RepoSync(object):
             'distribution': self.distribution_report,
             'errata': {'state': 'NOT_STARTED'},
             'comps': {'state': 'NOT_STARTED'},
+            'purge_duplicates': {'state': 'NOT_STARTED'},
         }
         self.conduit = conduit
         self.set_progress()
@@ -246,6 +247,10 @@ class RepoSync(object):
                                                   group.CATEGORY_TAG)
                         self.get_comps_file_units(metadata_files, group.process_environment_element,
                                                   group.ENVIRONMENT_TAG)
+
+                with self.update_state(self.progress_report['purge_duplicates']) as skip:
+                    if not (skip or self.skip_repomd_steps):
+                        purge.remove_repo_duplicate_nevra(self.conduit.repo_id)
 
             except CancelException:
                 report = self.conduit.build_cancel_report(self._progress_summary,


### PR DESCRIPTION
https://pulp.plan.io/issues/1461
fixes #1461

See the redmine issues for a rude but effective way to generate a few dozen thousand duplicate packages to stress-test the duplicate nevra generator.