### PR TITLE
use download path rather than file name

### DIFF
--- a/plugins/pulp_rpm/plugins/importers/yum/repomd/alternate.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/repomd/alternate.py
@@ -76,7 +76,7 @@ class Packages(object):
         """
         for unit in self.units:
             base_url = unit.base_url or self.base_url
-            url = self.url_modify(base_url, path_append=unit.filename)
+            url = self.url_modify(base_url, path_append=unit.download_path)
             destination = os.path.join(self.dst_dir, unit.filename)
             request = Request(
                 type_id=unit.type_id,


### PR DESCRIPTION
@bmbouter, This reverses a change done by the mongoengine conversion. I am very hesitant to merge this without review from someone who is intimately aware of the RPM conversion because it looks like this change was made deliberately to go along with many other related changes:
https://github.com/pulp/pulp_rpm/commit/944a05f7c131893a3fd46f1a67a53e4a618d95d6#diff-9a6038d8178eb03c0cbe334761cf67f4R79

This change does fix the case of https://pulp.plan.io/issues/1608 though. 
