### PR TITLE
after successfull download, incremement _added_count

### DIFF
--- a/plugins/pulp_rpm/plugins/importers/yum/listener.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/listener.py
@@ -80,6 +80,7 @@ class PackageListener(DownloadEventListener):
         unit = report.data
         self._verify_size(unit, report)
         self._verify_checksum(unit, report)
+        self.sync.conduit._added_count += 1
 
     def download_failed(self, report):
         """


### PR DESCRIPTION
https://pulp.plan.io/issues/1610

Lazy feature changed how this was done, and incrementing the sync conduit's `_added_count` was done inside of a function that saved the units: 
https://github.com/pulp/pulp_rpm/blob/2.7-dev/plugins/pulp_rpm/plugins/importers/yum/listener.py#L95