### PR TITLE
Fix package group/catagory upload.

### DIFF
--- a/plugins/pulp_rpm/plugins/importers/yum/upload.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/upload.py
@@ -271,11 +271,6 @@ def _handle_group_category_comps(repo, type_id, unit_key, metadata, file_path, c
             raise ModelInstantiationError()
 
         unit.save()
-
-        if file_path:
-            unit.set_storage_path(os.path.basename(file_path))
-            unit.safe_import_content(file_path)
-
         repo_controller.associate_single_unit(repo, unit)
 
 


### PR DESCRIPTION
https://pulp.plan.io/issues/1623

Should not be storing files for uploaded groups and categories.  This was unintentionally introduced during mongoengine conversion and Lazy work.