### PR TITLE
Distribution storage path no longer dependant on hostname and PRNG.

### DIFF
--- a/plugins/pulp_rpm/plugins/importers/yum/parse/treeinfo.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/parse/treeinfo.py
@@ -271,8 +271,8 @@ class DistSync(object):
             ]
             raise DownloadFailed()
         for report in listener.succeeded_reports:
-            location = report.destination.lstrip(tmp_dir)
-            yield report.destination, location.lstrip('/')
+            location = os.path.relpath(report.destination, tmp_dir)
+            yield report.destination, location
 
     @staticmethod
     def process_successful_download_reports(unit, reports):


### PR DESCRIPTION
Use os.path.relpath instead of str.lstrip when determining the relative
path of a distribution file during content import.

The Python method `str.lstrip` takes a list of chars, but this is
treated as a set of characters to strip from the left side of the
string, *not* as a substring to remove[0]. This was problematic for many
reasons, but would (rather entertainingly) determine the relative path
for distribution files based on the hostname of the worker and the
psuedo-random number generator used by tempdir and uuid.
to '/var/cache/pulp/\<worker\>@\<host\>/\<task-uuid\>/\<temp-dir\>/'

[0] https://docs.python.org/2/library/stdtypes.html#str.lstrip

closes #1654