### PR TITLE
Fix a flake8 error.

### DIFF
--- a/plugins/test/unit/plugins/importers/iso/test_configuration.py
+++ b/plugins/test/unit/plugins/importers/iso/test_configuration.py
@@ -52,7 +52,7 @@ class TestValidateFeedUrl(PulpRPMTests):
         self.assertTrue(status is False)
         self.assertEqual(error_message,
                          '<%(feed)s> must be a string.' % {'feed': importer_constants.KEY_FEED})
- 
+
     def test_valid(self):
         config = importer_mocks.get_basic_config(
             **{importer_constants.KEY_FEED: "http://test.com/feed"})


### PR DESCRIPTION
This commit fixes this error from flake8:

./plugins/test/unit/plugins/importers/iso/test_configuration.py:55:1: W293 blank line contains whitespace