### PR TITLE
1626 - Fix yum repo sync cancellation.

### DIFF
--- a/docs/user-guide/release-notes/2.8.x.rst
+++ b/docs/user-guide/release-notes/2.8.x.rst
@@ -5,6 +5,13 @@ Pulp 2.8 Release Notes
 Pulp 2.8.0
 ==========
 
+New Behaviors
+-------------
+Repo sync cancellation now exists immediately. 
+If the syncronization of the repo is cancelled, the worker process exits immediately with
+sys.exit(). A new worker process is created immediately, so further tasks are normally picked up
+and executed.
+
 New Features
 ------------
 

--- a/plugins/pulp_rpm/plugins/importers/iso/importer.py
+++ b/plugins/pulp_rpm/plugins/importers/iso/importer.py
@@ -30,12 +30,6 @@ class ISOImporter(Importer):
     All methods that are missing docstrings are documented in the Importer superclass.
     """
 
-    def cancel_sync_repo(self):
-        """
-        Cancel a running repository synchronization operation.
-        """
-        self.iso_sync.cancel_sync()
-
     def import_units(self, source_repo, dest_repo, import_conduit, config, units=None):
         """
         Import content units into the given repository. This method will be

--- a/plugins/pulp_rpm/plugins/importers/iso/sync.py
+++ b/plugins/pulp_rpm/plugins/importers/iso/sync.py
@@ -79,7 +79,8 @@ class ISOSyncRun(listener.DownloadEventListener):
             'proxy_url': config.get(importer_constants.KEY_PROXY_HOST),
             'proxy_port': config.get(importer_constants.KEY_PROXY_PORT),
             'proxy_username': config.get(importer_constants.KEY_PROXY_USER),
-            'proxy_password': config.get(importer_constants.KEY_PROXY_PASS)}
+            'proxy_password': config.get(importer_constants.KEY_PROXY_PASS),
+            'working_dir': common_utils.get_working_directory()}
         downloader_config = DownloaderConfig(**downloader_config)
 
         # We will pass self as the event_listener, so that we can receive the callbacks in this
@@ -102,16 +103,6 @@ class ISOSyncRun(listener.DownloadEventListener):
             importer_constants.DOWNLOAD_POLICY,
             importer_constants.DOWNLOAD_IMMEDIATE)
         return policy != importer_constants.DOWNLOAD_IMMEDIATE
-
-    def cancel_sync(self):
-        """
-        This method will cancel a sync that is in progress.
-        """
-        # We used to support sync cancellation, but the current downloader implementation does
-        # not support it
-        # and so for now we will just pass
-        self.progress_report.state = self.progress_report.STATE_CANCELLED
-        self.downloader.cancel()
 
     def download_failed(self, report):
         """

--- a/plugins/pulp_rpm/plugins/importers/yum/importer.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/importer.py
@@ -79,12 +79,4 @@ class YumImporter(Importer):
         sync_conduit.repo = repo
         self._current_sync = sync.RepoSync(repo, sync_conduit, call_config)
         report = self._current_sync.run()
-        self._current_sync.finalize()
         return report
-
-    def cancel_sync_repo(self):
-        """
-        Cancel a currently running repository synchronization operation.
-        """
-        self._current_sync.cancel()
-        self._current_sync.finalize()

--- a/plugins/test/unit/plugins/importers/iso/test_configuration.py
+++ b/plugins/test/unit/plugins/importers/iso/test_configuration.py
@@ -52,7 +52,7 @@ class TestValidateFeedUrl(PulpRPMTests):
         self.assertTrue(status is False)
         self.assertEqual(error_message,
                          '<%(feed)s> must be a string.' % {'feed': importer_constants.KEY_FEED})
- 
+
     def test_valid(self):
         config = importer_mocks.get_basic_config(
             **{importer_constants.KEY_FEED: "http://test.com/feed"})

--- a/plugins/test/unit/plugins/importers/iso/test_importer.py
+++ b/plugins/test/unit/plugins/importers/iso/test_importer.py
@@ -12,7 +12,7 @@ from pulp_rpm.devel import importer_mocks
 from pulp_rpm.devel.rpm_support_base import PulpRPMTests
 from pulp_rpm.devel.skip import skip_broken
 from pulp_rpm.plugins.db import models
-from pulp_rpm.plugins.importers.iso import importer, sync
+from pulp_rpm.plugins.importers.iso import importer
 
 
 class TestEntryPoint(PulpRPMTests):
@@ -39,17 +39,6 @@ class TestISOImporter(PulpRPMTests):
 
     def tearDown(self):
         shutil.rmtree(self.temp_dir)
-
-    def test_cancel_sync_repo(self):
-        """
-        Make sure the cancel sync gets passed on.
-        """
-        self.iso_importer.iso_sync = mock.MagicMock(spec=sync.ISOSyncRun)
-
-        self.iso_importer.cancel_sync_repo()
-
-        # Assert that the mock cancel has been called once, with no args
-        self.iso_importer.iso_sync.cancel_sync.assert_called_once_with()
 
     def test_import_units__units_empty_list(self):
         """

--- a/plugins/test/unit/plugins/importers/iso/test_sync.py
+++ b/plugins/test/unit/plugins/importers/iso/test_sync.py
@@ -4,7 +4,6 @@ import shutil
 import tempfile
 
 from mock import MagicMock, patch
-from nectar.downloaders.threaded import HTTPThreadedDownloader
 from nectar.report import DownloadReport
 from pulp.common.plugins import importer_constants
 from pulp.plugins.model import Repository, Unit
@@ -165,23 +164,6 @@ class TestISOSyncRun(PulpRPMTests):
         # Humorously enough, the _repo_url attribute named no_trailing_slash should now have a
         # trailing slash
         self.assertEqual(iso_sync_run._repo_url, 'http://fake.com/no_trailing_slash/')
-
-    @patch('pulp_rpm.plugins.importers.iso.sync.HTTPThreadedDownloader.cancel',
-           side_effect=HTTPThreadedDownloader.cancel, autospec=HTTPThreadedDownloader.cancel)
-    def test_cancel_sync(self, cancel):
-        """
-        Test what happens if cancel_sync is called when there is no Bumper.
-        """
-        # This just passes since the downloader library does not support cancellation. This helps
-        #  us get one
-        # more line of coverage though!
-        self.iso_sync_run.cancel_sync()
-
-        # Assert that the cancel Mock was called
-        cancel.assert_called_once_with(self.iso_sync_run.downloader)
-        # The progress report's state should now be cancelled
-        self.assertEqual(self.iso_sync_run.progress_report.state,
-                         SyncProgressReport.STATE_CANCELLED)
 
     @patch('pulp_rpm.plugins.importers.iso.sync._logger')
     def test_download_failed_during_iso_download(self, _logger):


### PR DESCRIPTION
closes #1626
https://pulp.plan.io/issues/1626

1)This commit fixes the yum repo sync cancellation.
Now cancel_repo_sync() base class cancels the yum repo sync via calling sys.exit()

2)Some dead code is also removed.
3)Since DownloadConfig.finalize() is not called anymore, nectar config was changed
to use temporary space that tasks use and not use the /tmp for writing temporary files.