### PR TITLE
Updating outated docs

### DIFF
--- a/docs/tech-reference/yum-plugins.rst
+++ b/docs/tech-reference/yum-plugins.rst
@@ -483,8 +483,8 @@ configuration values are optional.
  to this option are ``True`` and ``False``; defaults to ``False``
 
 ``retain_old_count``
- Count indicating how many old rpm versions to retain; defaults to 0. This count
- only takes effect when ``remove_old`` option is set to ``True``.
+ Count indicating how many old rpm versions to retain; by default it will download
+ all versions available.
 
 ``skip``
   List of content types to be skipped during the repository synchronization.


### PR DESCRIPTION
By default if not specifying retain-old-count all versions available will be downloaded.
the remove-missing flag set to True seems like that does not affect its behaviour.
Proof : http://fpaste.org/327905/24613814/