### PR TITLE
Adds migration 0026 which removes a field from Distribution units

### DIFF
--- a/common/pulp_rpm/common/constants.py
+++ b/common/pulp_rpm/common/constants.py
@@ -121,7 +121,6 @@ DISTRIBUTION_STORAGE_PATH = '/var/lib/pulp/content/distribution/'
 # can be '.treeinfo' or 'treeinfo' (in cdn case) we need to check which one exists
 TREE_INFO_LIST = ['.treeinfo', 'treeinfo']
 DISTRIBUTION_XML = 'PULP_DISTRIBUTION.xml'
-CONFIG_KEY_DISTRIBUTION_XML_FILE = 'pulp_distribution_xml_file'
 
 # Configuration constants for export distributors
 PUBLISH_HTTP_KEYWORD = 'http'

--- a/plugins/pulp_rpm/plugins/importers/yum/parse/treeinfo.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/parse/treeinfo.py
@@ -414,10 +414,6 @@ class DistSync(object):
                         feed=self.feed,
                         validation_exceptions=[e])])
 
-            # This is broken and best I can tell - not used.
-            # model.metadata[constants.CONFIG_KEY_DISTRIBUTION_XML_FILE] = \
-            #     constants.DISTRIBUTION_XML
-
             # parse the distribution file and add all the files to the download request
             root = tree.getroot()
             for file_element in root.findall('file'):

--- a/plugins/pulp_rpm/plugins/migrations/0026_remove_distribution_field.py
+++ b/plugins/pulp_rpm/plugins/migrations/0026_remove_distribution_field.py
@@ -1,0 +1,24 @@
+"""
+Migration to remove the pulp_distribution_xml_file field from Distribution units, which is no
+longer used.
+"""
+
+from pulp.server.db import connection
+
+
+def migrate(*args, **kwargs):
+    """
+    Perform the migration as described in this module's docblock.
+
+    :param args:   unused
+    :type  args:   list
+    :param kwargs: unused
+    :type  kwargs: dict
+    """
+    db = connection.get_database()
+    units_distribution_collection = db['units_distribution']
+    units_distribution_collection.update(
+        {'pulp_distribution_xml_file': {'$exists': True}},
+        {'$unset': {'pulp_distribution_xml_file': True}},
+        multi=True
+    )

--- a/plugins/test/unit/plugins/importers/yum/parse/test_treeinfo.py
+++ b/plugins/test/unit/plugins/importers/yum/parse/test_treeinfo.py
@@ -101,21 +101,16 @@ class TestProcessDistribution(unittest.TestCase):
         self.assertEquals('foo/bar.txt', files[0]['relativepath'])
         self.assertEquals('baz/qux.txt', files[1]['relativepath'])
         self.assertEquals(constants.DISTRIBUTION_XML, files[2]['relativepath'])
-        # TODO: This functionality is commented out in treeinfo.py
-        # self.assertEquals(model.metadata[constants.CONFIG_KEY_DISTRIBUTION_XML_FILE],
-        #                   constants.DISTRIBUTION_XML)
 
     @patch('pulp_rpm.plugins.importers.yum.parse.treeinfo.DistSync.get_distribution_file',
            return_value=None)
     def test_no_distribution(self, mock_get_dist):
         parent = Mock()
         tmp_dir = Mock()
-        model = Mock(metadata=dict())
         dist = DistSync(parent, '')
         files = dist.process_distribution(tmp_dir)
 
         self.assertEquals(0, len(files))
-        self.assertEquals(None, model.metadata.get(constants.CONFIG_KEY_DISTRIBUTION_XML_FILE))
 
     @patch('pulp_rpm.plugins.importers.yum.parse.treeinfo.DistSync.get_distribution_file',
            return_value=DISTRIBUTION_BAD_SYNTAX_FILE)

--- a/plugins/test/unit/plugins/migrations/test_0026_remove_distribution_field.py
+++ b/plugins/test/unit/plugins/migrations/test_0026_remove_distribution_field.py
@@ -1,0 +1,32 @@
+import unittest
+
+import mock
+
+from pulp.server.db.migrate.models import _import_all_the_way
+
+
+PATH_TO_MODULE = 'pulp_rpm.plugins.migrations.0026_remove_distribution_field'
+
+migration = _import_all_the_way(PATH_TO_MODULE)
+
+
+class TestMigrate(unittest.TestCase):
+    """
+    Test migration 0026.
+    """
+
+    @mock.patch(PATH_TO_MODULE + '.connection')
+    def test_migration_fixed_expected_collections(self, mock_connection):
+        mock_units_distribution = mock.Mock()
+        mock_connection.get_database.return_value = {
+            'units_distribution': mock_units_distribution,
+        }
+
+        migration.migrate()
+        mock_connection.get_database.assert_called_once_with()
+
+        mock_units_distribution.update.assert_called_once_with(
+            {'pulp_distribution_xml_file': {'$exists': True}},
+            {'$unset': {'pulp_distribution_xml_file': True}},
+            multi=True
+        )


### PR DESCRIPTION
The pulp_distribution_xml_file was present in earlier versions
of Pulp but is no longer used. It's not included in the
mongoengine Distribution model so it fails to hydrate when it is
present in the database.

closes #1742
https://pulp.plan.io/issues/1743