### PR TITLE
Include "TS_TRUEINSTALL" as a valid package state

### DIFF
--- a/handlers/pulp_rpm/handlers/rpmtools.py
+++ b/handlers/pulp_rpm/handlers/rpmtools.py
@@ -96,7 +96,8 @@ class Package:
         :return: Installed packages: {resolved=[Package,],deps=[Package,], failed=[Package,]}
         :rtype: dict
         """
-        states = (constants.TS_FAILED, constants.TS_INSTALL, constants.TS_UPDATE)
+        states = (constants.TS_FAILED, constants.TS_INSTALL,
+                  constants.TS_TRUEINSTALL, constants.TS_UPDATE)
         return Package.tx_summary(ts_info, states)
 
     @staticmethod
@@ -108,7 +109,8 @@ class Package:
         :return: Installed packages: {resolved=[Package,],deps=[Package,], failed=[Package,]}
         :rtype: dict
         """
-        states = (constants.TS_FAILED, constants.TS_INSTALL, constants.TS_UPDATE)
+        states = (constants.TS_FAILED, constants.TS_INSTALL,
+                  constants.TS_TRUEINSTALL, constants.TS_UPDATE)
         return Package.tx_summary(ts_info, states)
 
     @staticmethod

--- a/handlers/test/unit/handlers/mock_yum.py
+++ b/handlers/test/unit/handlers/mock_yum.py
@@ -1,7 +1,11 @@
 import mock
 
-from yum.Errors import InstallError, GroupsError
 from yum import constants
+from yum.Errors import InstallError, GroupsError
+
+# A list of "install-only" packages that is used in deciding transaction states in some cases.
+# It is defined in the yum python lib as `yum.config.YumConf.installonlypkgs.default`.
+INSTALLONLY_PKGS = ['kernel']
 
 
 def install():
@@ -47,6 +51,7 @@ class YumBase:
     NEED_UPDATE = [
         Pkg('openssl', '3.2'),
         Pkg('libc', '2.5'),
+        Pkg('kernel', '3.10.0'),
     ]
 
     INSTALL_DEPS = [
@@ -64,8 +69,11 @@ class YumBase:
         Pkg('dep2', '2.5'),
     ]
 
+    TRUEINSTALL_DEPS = []
+
     STATES = {
         constants.TS_INSTALL: INSTALL_DEPS,
+        constants.TS_TRUEINSTALL: TRUEINSTALL_DEPS,
         constants.TS_UPDATE: UPDATE_DEPS,
         constants.TS_ERASE: ERASE_DEPS,
     }
@@ -77,11 +85,13 @@ class YumBase:
             Pkg('zsh', '3.2'),
             Pkg('xchat', '1.3'),
             Pkg('thunderbird', '10.1.7'),
+            Pkg('kernel', '3.10.0'),
         ],
         'plain-failed': [
             Pkg('zsh', '3.2'),
             Pkg('xchat', '1.3'),
             Pkg('thunderbird', '10.1.7'),
+            Pkg('kernel', '3.10.0'),
             Pkg(FAILED_PKG, '6.3'),
         ],
         'pulp': [
@@ -117,26 +127,43 @@ class YumBase:
         self.tsInfo = []
         self.repos = mock.Mock()
 
+    def _tx_member_for_instup(self, pkg, update=False):
+        # When installing or updating a package, packages in yum's "installonlypkgs" list
+        # have a special transaction state, as these are the packages that are never updated.
+        # Instead, they have multiple versions installed (e.g. kernel packages). This encapsulates
+        # the logic for the yum test mock: If one of the installonlypkgs is being installed or
+        # updated, use the special transaction state represented by TS_TRUEINSTALL. Otherwise,
+        # return the TS_INSTALL state if installing (update kwarg is False), or TS_UPDATE if
+        # updating (update kwarg is True).
+        if pkg.name in INSTALLONLY_PKGS:
+            t = TxMember(constants.TS_TRUEINSTALL, self.REPOID, pkg)
+        else:
+            if update:
+                t = TxMember(constants.TS_UPDATE, self.REPOID, pkg)
+            else:
+                t = TxMember(constants.TS_INSTALL, self.REPOID, pkg)
+        return t
+
     def install(self, pattern):
         if YumBase.UNKNOWN_PKG in pattern:
             name = u'D' + unichr(246) + 'g'
             raise InstallError('package %s not found' % name)
         pkg = Pkg(pattern, '1.0')
-        t = TxMember(constants.TS_INSTALL, self.REPOID, pkg)
+        t = self._tx_member_for_instup(pkg)
         self.tsInfo.append(t)
 
     def update(self, pattern=None):
         # all
         if not pattern:
             for pkg in self.NEED_UPDATE:
-                t = TxMember(constants.TS_UPDATE, self.REPOID, pkg)
+                t = self._tx_member_for_instup(pkg, update=True)
                 self.tsInfo.append(t)
             return
         # specific package
         if YumBase.UNKNOWN_PKG in pattern:
             return []
         pkg = Pkg(pattern, '1.0')
-        t = TxMember(constants.TS_UPDATE, self.REPOID, pkg)
+        t = self._tx_member_for_instup(pkg, update=True)
         self.tsInfo.append(t)
 
     def remove(self, pattern):
@@ -151,7 +178,7 @@ class YumBase:
         if grp is None:
             raise GroupsError('Group not found')
         for pkg in grp:
-            t = TxMember(constants.TS_INSTALL, self.REPOID, pkg)
+            t = self._tx_member_for_instup(pkg)
             self.tsInfo.append(t)
 
     def groupRemove(self, name):

--- a/handlers/test/unit/handlers/test_rpmtools.py
+++ b/handlers/test/unit/handlers/test_rpmtools.py
@@ -52,7 +52,7 @@ class TestPackages(ToolTest):
         install = [
             mock_yum.TxMember(constants.TS_INSTALL, repo_id, mock_yum.Pkg('A', '1.0')),
             mock_yum.TxMember(constants.TS_INSTALL, repo_id, mock_yum.Pkg('B', '1.0')),
-            mock_yum.TxMember(constants.TS_INSTALL, repo_id, mock_yum.Pkg('C', '1.0')),
+            mock_yum.TxMember(constants.TS_TRUEINSTALL, repo_id, mock_yum.Pkg('C', '1.0')),
         ]
         erase = [
             mock_yum.TxMember(constants.TS_ERASE, repo_id, mock_yum.Pkg('D', '1.0')),
@@ -63,7 +63,7 @@ class TestPackages(ToolTest):
         ]
         ts_info = install + deps + erase + failed
         package = self.Package()
-        states = [constants.TS_FAILED, constants.TS_INSTALL]
+        states = [constants.TS_FAILED, constants.TS_INSTALL, constants.TS_TRUEINSTALL]
         # Test
         report = package.tx_summary(ts_info, states)
         # Verify
@@ -118,6 +118,7 @@ class TestPackages(ToolTest):
             'ksh',
             'gofer',
             'okaara',
+            'kernel',
         ]
         # Test
         package = self.Package()
@@ -198,6 +199,7 @@ class TestPackages(ToolTest):
             'ksh',
             'gofer',
             'okaara',
+            'kernel',
         ]
         # Test
         package = self.Package()


### PR DESCRIPTION
When installing or updating packages in a consumer, pulp inspects the
yum transaction report to decide how to report its actions in the task
result. pulp was excluding the "TS_TRUEINSTALL" state, which yum uses as
the state of a transaction that updated or installed one of the special
packages that can be installed multiple times, such as the kernel.

Including (or rather, not excluding) that state in pulp's transaction
reporting lets those packages be included in pulp's task results.

https://pulp.plan.io/issues/1138
fixes #1138