### PR TITLE
Removes checksum_type field from RPM unit documents in Mongo

### DIFF
--- a/plugins/pulp_rpm/plugins/migrations/0027_remove_checksum_type_field.py
+++ b/plugins/pulp_rpm/plugins/migrations/0027_remove_checksum_type_field.py
@@ -1,0 +1,21 @@
+"""
+This migration removes the `checksum_type` field of the units_rpm collection.
+"""
+from pulp.server.db import connection
+
+
+def migrate(*args, **kwargs):
+    """
+    Perform the migration as described in this module's docblock.
+
+    :param args:   unused
+    :type  args:   list
+    :param kwargs: unused
+    :type  kwargs: dict
+    """
+    db = connection.get_database()
+    collection = db['units_rpm']
+    collection.update(
+        {"checksum_type": {"$exists": True}},
+        {"$unset": {"checksum_type": True}},
+        multi=True)

--- a/plugins/test/unit/plugins/migrations/test_0027_unset_checksum_type.py
+++ b/plugins/test/unit/plugins/migrations/test_0027_unset_checksum_type.py
@@ -1,0 +1,32 @@
+import unittest
+
+import mock
+
+from pulp.server.db.migrate.models import _import_all_the_way
+
+
+PATH_TO_MODULE = 'pulp_rpm.plugins.migrations.0027_remove_checksum_type_field'
+
+migration = _import_all_the_way(PATH_TO_MODULE)
+
+
+class TestMigrate(unittest.TestCase):
+    """
+    Test migration 0027.
+    """
+
+    @mock.patch(PATH_TO_MODULE + '.connection')
+    def test_migration_fixed_expected_collections(self, mock_connection):
+        mock_units_rpm = mock.Mock()
+        mock_connection.get_database.return_value = {
+            'units_rpm': mock_units_rpm,
+        }
+
+        migration.migrate()
+        mock_connection.get_database.assert_called_once_with()
+
+        mock_units_rpm.update.assert_called_once_with(
+            {"checksum_type": {"$exists": True}},
+            {"$unset": {"checksum_type": True}},
+            multi=True
+        )


### PR DESCRIPTION
After migrating from 2.6 to 2.8, users could have database records that contain
'checksum_type' attribute that is set to null. This migration removes this field
from the documents.

https://pulp.plan.io/issues/1754
closes #1754