### PR TITLE
Fixed bug in handling errata package lists that don't include a checksum

### DIFF
--- a/plugins/pulp_rpm/plugins/db/models.py
+++ b/plugins/pulp_rpm/plugins/db/models.py
@@ -130,7 +130,7 @@ class NonMetadataPackage(UnitMixin, FileContentUnit):
     }
 
     def __init__(self, *args, **kwargs):
-        if 'checksumtype' in kwargs:
+        if kwargs.get('checksumtype') is not None:
             kwargs['checksumtype'] = verification.sanitize_checksum_type(kwargs['checksumtype'])
         super(NonMetadataPackage, self).__init__(*args, **kwargs)
 


### PR DESCRIPTION
https://pulp.plan.io/issues/1792

fixes #1792