### PR TITLE
Add --force-full flag to publish command

### DIFF
--- a/docs/tech-reference/yum-plugins.rst
+++ b/docs/tech-reference/yum-plugins.rst
@@ -596,3 +596,7 @@ Optional Configuration Parameters
  List of content types to skip during the repository publish.
  If unspecified, all types will be published. Valid values are: rpm, drpm,
  distribution, errata, packagegroup.
+
+ ``force_full``
+ Boolean flag to indicate whether or not publish should be done from scratch.
+ If unspecified the incremental publish will be performed when possible.

--- a/docs/user-guide/release-notes/2.8.x.rst
+++ b/docs/user-guide/release-notes/2.8.x.rst
@@ -2,6 +2,14 @@
 Pulp 2.8 Release Notes
 ======================
 
+Pulp 2.8.3
+==========
+
+New Features
+------------
+
+* Publication of the RPMs can now be done non-incrementally using ``--force-full`` option.
+
 Pulp 2.8.2
 ==========
 

--- a/plugins/pulp_rpm/plugins/distributors/yum/configuration.py
+++ b/plugins/pulp_rpm/plugins/distributors/yum/configuration.py
@@ -21,7 +21,7 @@ REQUIRED_CONFIG_KEYS = ('relative_url', 'http', 'https')
 
 OPTIONAL_CONFIG_KEYS = ('gpgkey', 'auth_ca', 'auth_cert', 'https_ca', 'checksum_type',
                         'http_publish_dir', 'https_publish_dir', 'protected',
-                        'skip', 'skip_pkg_tags', 'generate_sqlite')
+                        'skip', 'skip_pkg_tags', 'generate_sqlite', 'force_full')
 
 ROOT_PUBLISH_DIR = '/var/lib/pulp/published/yum'
 MASTER_PUBLISH_DIR = os.path.join(ROOT_PUBLISH_DIR, 'master')

--- a/plugins/pulp_rpm/plugins/distributors/yum/publish.py
+++ b/plugins/pulp_rpm/plugins/distributors/yum/publish.py
@@ -265,9 +265,11 @@ class Publisher(BaseYumRepoPublisher):
         last_published = publish_conduit.last_publish()
         last_deleted = repo.last_unit_removed
         date_filter = None
+        force_full = config.get('force_full', False)
 
         if last_published and \
-                ((last_deleted and last_published > last_deleted) or not last_deleted):
+                ((last_deleted and last_published > last_deleted) or not last_deleted) and \
+                not force_full:
             # Add the step to copy the current published directory into place
             specific_master = None
             if config.get(constants.PUBLISH_HTTPS_KEYWORD):


### PR DESCRIPTION
If specified the full publication of the RPMs will be done even
when it is possible to make an incremental one.

closes #1158
https://pulp.plan.io/issues/1158