### PR TITLE
Regenerate PULP_DISTRIBUTION.xml on publish if necessary

### DIFF
--- a/plugins/pulp_rpm/plugins/importers/yum/parse/treeinfo.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/parse/treeinfo.py
@@ -162,7 +162,7 @@ class DistSync(object):
             return
 
         # Process the distribution
-        dist_files = self.process_distribution(tmp_dir)
+        dist_files, pulp_dist_xml_path = self.process_distribution(tmp_dir)
         files.extend(dist_files)
 
         self.update_unit_files(unit, files)
@@ -184,9 +184,11 @@ class DistSync(object):
         # Update deferred downloading catalog
         self.update_catalog_entries(unit, files)
 
-        # The treeinfo file is always imported into platform
+        # The treeinfo and PULP_DISTRIBTION.xml files are always imported into platform
         # # storage regardless of the download policy
         unit.safe_import_content(treeinfo_path, os.path.basename(treeinfo_path))
+        if pulp_dist_xml_path is not None:
+            unit.safe_import_content(pulp_dist_xml_path, os.path.basename(pulp_dist_xml_path))
 
         # The downloaded files are imported into platform storage.
         if downloaded:
@@ -403,8 +405,9 @@ class DistSync(object):
 
         :param tmp_dir: The absolute path to the temporary directory
         :type tmp_dir: str
-        :return: A list of file dictionaries
-        :rtype: list
+        :return: A tuple that contains the list of file dictionaries and the absolute path
+                 to the distribution file, or None if no PULP_DISTRIBUTION.xml was found.
+        :rtype: (list, basestring)
         """
         # Get the Distribution file
         result = self.get_distribution_file(tmp_dir)
@@ -440,7 +443,7 @@ class DistSync(object):
                 CHECKSUM: None,
                 CHECKSUM_TYPE: None,
             })
-        return files
+        return files, result
 
     def get_distribution_file(self, tmp_dir):
         """

--- a/plugins/test/unit/plugins/importers/yum/parse/test_treeinfo.py
+++ b/plugins/test/unit/plugins/importers/yum/parse/test_treeinfo.py
@@ -95,8 +95,9 @@ class TestProcessDistribution(unittest.TestCase):
         tmp_dir = Mock()
         parent = Mock()
         dist = DistSync(parent, '')
-        files = dist.process_distribution(tmp_dir)
+        files, dist_file = dist.process_distribution(tmp_dir)
 
+        self.assertEqual(dist_file, DISTRIBUTION_GOOD_FILE)
         self.assertEquals(3, len(files))
         self.assertEquals('foo/bar.txt', files[0]['relativepath'])
         self.assertEquals('baz/qux.txt', files[1]['relativepath'])
@@ -108,9 +109,10 @@ class TestProcessDistribution(unittest.TestCase):
         parent = Mock()
         tmp_dir = Mock()
         dist = DistSync(parent, '')
-        files = dist.process_distribution(tmp_dir)
+        files, dist_file = dist.process_distribution(tmp_dir)
 
         self.assertEquals(0, len(files))
+        self.assertEqual(dist_file, None)
 
     @patch('pulp_rpm.plugins.importers.yum.parse.treeinfo.DistSync.get_distribution_file',
            return_value=DISTRIBUTION_BAD_SYNTAX_FILE)


### PR DESCRIPTION
The PULP_DISTRIBUTION.xml file used to be saved from an upstream
repository and republished without modification. This is problematic
because files referenced by that file are filtered out during a publish.
This commit is a short-term work-around to that problematic workflow.
Without it, Pulp (or anything else using PULP_DISTRIBUTION.xml) will
attempt to download files that don't exist in the published repository.

fixes #1843