### PR TITLE
Restore upload checksum type property.

### DIFF
--- a/extensions_admin/pulp_rpm/extensions/admin/upload/package.py
+++ b/extensions_admin/pulp_rpm/extensions/admin/upload/package.py
@@ -54,7 +54,7 @@ class _CreatePackageCommand(UploadCommand):
         # These are extracted server-side, so nothing to do here.
         metadata = {}
         if kwargs.get(OPT_CHECKSUM_TYPE.keyword, None) is not None:
-            metadata['checksumtype'] = kwargs[OPT_CHECKSUM_TYPE.keyword]
+            metadata['checksum_type'] = kwargs[OPT_CHECKSUM_TYPE.keyword]
         return {}, metadata
 
     def create_upload_list(self, file_bundles, **kwargs):

--- a/extensions_admin/test/unit/extensions/admin/upload/test_package.py
+++ b/extensions_admin/test/unit/extensions/admin/upload/test_package.py
@@ -56,7 +56,7 @@ class CreatePackageCommandTests(PulpClientTests):
         unit_key, metadata = self.command.generate_unit_key_and_metadata(filename, **command_kwargs)
 
         self.assertEqual(unit_key, {})
-        self.assertEqual(metadata, {'checksumtype': 'sha1'})
+        self.assertEqual(metadata, {'checksum_type': 'sha1'})
 
     def test_create_upload_list_skip_existing(self):
         # Setup

--- a/plugins/pulp_rpm/plugins/importers/yum/upload.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/upload.py
@@ -359,7 +359,7 @@ def _handle_package(repo, type_id, unit_key, metadata, file_path, conduit, confi
 
     # set checksum and checksumtype
     if metadata:
-        checksumtype = metadata.pop('checksumtype', verification.TYPE_SHA256)
+        checksumtype = metadata.pop('checksum_type', verification.TYPE_SHA256)
         rpm_data['checksumtype'] = verification.sanitize_checksum_type(checksumtype)
         if 'checksum' in metadata:
             rpm_data['checksum'] = metadata.pop('checksum')


### PR DESCRIPTION
https://pulp.plan.io/issues/1802

Looks like in 2.8 the metadata `checksum_type` property passed using the RPM upload API got changed to `checksumtype`.  Best I can tell, the issue was reopened to revert this backwards incomparable change.