### PR TITLE
adding a unit test for _write_pulp_distribution_file

### DIFF
--- a/plugins/pulp_rpm/plugins/distributors/yum/publish.py
+++ b/plugins/pulp_rpm/plugins/distributors/yum/publish.py
@@ -829,6 +829,7 @@ class PublishDistributionStep(platform_steps.UnitModelPluginStep):
         :param old_xml_file_path: The absolute path to the old PULP_DISTRIBUTION.xml
                                   from upstream. The files referenced in here act as
                                   a filter for the new PULP_DISTRIBUTION.xml file.
+        :type  old_xml_file_path: basestring
         """
         old_xml_tree = cElementTree.parse(old_xml_file_path)
         old_xml_root = old_xml_tree.getroot()

--- a/plugins/test/data/PULP_DISTRIBUTION.xml
+++ b/plugins/test/data/PULP_DISTRIBUTION.xml
@@ -1,0 +1,5 @@
+<pulp_distribution version="1">
+<file>foo</file>
+<file>a/b</file>
+<file>a/c</file>
+</pulp_distribution>

--- a/plugins/test/unit/plugins/distributors/yum/test_publish.py
+++ b/plugins/test/unit/plugins/distributors/yum/test_publish.py
@@ -1,8 +1,10 @@
+from cStringIO import StringIO
 import datetime
 import os
 import shutil
 import tempfile
 import unittest
+from xml.etree import cElementTree as ET
 
 from pulp.common.compat import json
 from pulp.common.plugins import reporting_constants
@@ -668,6 +670,48 @@ class PublishDrpmStepTests(BaseYumDistributorPublishStepTests):
         step = publish.PublishDrpmStep(mock.Mock())
         step.parent = self.publisher
         step.finalize()
+
+
+class TestPublishDistributionWritePulpDistributionFile(unittest.TestCase):
+    xml_path = os.path.join(DATA_DIR, constants.DISTRIBUTION_XML)
+    included_paths = ('foo', 'a/b', 'a/c')
+
+    def setUp(self):
+        super(TestPublishDistributionWritePulpDistributionFile, self).setUp()
+        self.step = publish.PublishDistributionStep()
+        self.step.working_dir = '/foo/bar'
+        self.target = StringIO()
+
+    def assertPathPresent(self, root, path):
+        for child in root:
+            if child.text == path:
+                return
+        self.fail('path not found in XML: %s' % path)
+
+    def assertPathNotPresent(self, root, path):
+        for child in root:
+            if child.text == path:
+                self.fail('path in XML: %s' % path)
+
+    def test_removes_file_entries(self):
+        """
+        Make sure any paths in "distro_files" that are not present in the original XML get
+        filtered out.
+        """
+        paths = list(self.included_paths)
+        paths.append('remove/me')
+
+        with mock.patch('os.path.join', return_value=self.target):
+            self.step._write_pulp_distribution_file(paths, self.xml_path)
+
+        root = ET.fromstring(self.target.getvalue())
+
+        self.assertEqual(len(root), len(self.included_paths))
+        # make sure it removed this entry that was not in the original file
+        self.assertPathNotPresent(root, 'remove/me')
+        # make sure it kept these entries
+        for path in self.included_paths:
+            self.assertPathPresent(root, path)
 
 
 class PublishDistributionStepTests(BaseYumDistributorPublishStepTests):


### PR DESCRIPTION
https://pulp.plan.io/issues/1856

re #1856

I'm hoping to see a test failure on el6, which is already fixed by https://github.com/pulp/pulp_rpm/pull/850