### PR TITLE
Fix sync and upload of the same erratum

### DIFF
--- a/docs/user-guide/recipes.rst
+++ b/docs/user-guide/recipes.rst
@@ -527,8 +527,10 @@ Now that we have these two files, we can create our new errata like so::
       --title="1: pulp-test-package bit conservation" \
       --description="1: pulp-test-package now conserves your precious bits." \
       --version=1 --release="el6" --type="bugzilla" --status="final" \
-      --updated="`date`" --issued="`date`" --reference-csv=references.csv \
-      --pkglist-csv=package_list.csv --from=pulp-list@redhat.com --repo-id=repo
+      --updated="`date -u +'%Y-%m-%d %H:%M:%S %Z'`" \
+      --issued="`date -u +'%Y-%m-%d %H:%M:%S %Z'`" \
+      --reference-csv=references.csv --pkglist-csv=package_list.csv \
+      --from=pulp-list@redhat.com --repo-id=repo
     +----------------------------------------------------------------------+
                                   Unit Upload
     +----------------------------------------------------------------------+
@@ -553,11 +555,11 @@ Now that we have these two files, we can create our new errata like so::
 
 And now we are able to see that our errata is part of the repo::
 
-    $ pulp-admin rpm repo content errata --repo-id=repo --match type=bugzilla
+    $ pulp-admin rpm repo content errata --repo-id=repo --erratum_id=DEMO_ID_1
     Description:      1: pulp-test-package now conserves your precious bits.
     From Str:         pulp-list@redhat.com
     Id:               DEMO_ID_1
-    Issued:           Wed Dec 19 12:19:18 EST 2012
+    Issued:           2012-12-19 12:19:18 UTC
     Pkglist:          
       Name:     el6
       Packages: 
@@ -592,7 +594,7 @@ And now we are able to see that our errata is part of the repo::
     Summary:          None
     Title:            1: pulp-test-package bit conservation
     Type:             bugzilla
-    Updated:          Wed Dec 19 12:19:18 EST 2012
+    Updated:          2012-12-19 12:19:18 UTC
     Version:          1
 
 Package Groups

--- a/plugins/pulp_rpm/plugins/db/models.py
+++ b/plugins/pulp_rpm/plugins/db/models.py
@@ -2,6 +2,7 @@ import csv
 import logging
 import os
 from gettext import gettext as _
+from operator import itemgetter
 from urlparse import urljoin
 
 import mongoengine
@@ -12,6 +13,7 @@ from pulp_rpm.common import version_utils
 from pulp_rpm.common import file_utils
 from pulp_rpm.plugins import serializers
 from pulp_rpm.plugins.db.fields import ChecksumTypeStringField
+from pulp_rpm.yum_plugin import util
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -453,6 +455,10 @@ class Errata(UnitMixin, ContentUnit):
 
     SERIALIZER = serializers.Errata
 
+    mutable_erratum_fields = ('status', 'updated', 'description', 'pushcount', 'references',
+                              'reboot_suggested', 'errata_from', 'severity', 'rights', 'version',
+                              'release', 'type', 'title', 'solution', 'summary')
+
     @property
     def rpm_search_dicts(self):
         ret = []
@@ -479,6 +485,113 @@ class Errata(UnitMixin, ContentUnit):
                         del unit_key[key]
                 ret.append(unit_key)
         return ret
+
+    @staticmethod
+    def _check_packages(existing_packages, new_packages):
+        """
+        Check if the new packages are the same as the existing ones.
+
+        :param existing_packages: list of packages presented in the existing erratum
+        :type  existing_packages: list of dicts
+
+        :param new_packages: list of packages presented in the new erratum
+        :type  new_packages: list of dicts
+
+        :return: True, if the lists of packages are equal
+        :rtype: bool
+        """
+        if len(existing_packages) == len(new_packages):
+            existing_packages.sort(key=itemgetter('filename'))
+            new_packages.sort(key=itemgetter('filename'))
+            return existing_packages == new_packages
+        return False
+
+    def merge_errata(self, other):
+        """
+        Merge two errata with the same errata_id.
+
+        There are two parts:
+        - merging of the pkglists in case of the erratum with the same id in different repositories
+        - overwriting the erratum metadata based on the `updated` field
+
+        NOTE: The second part should be eliminated after we change the way erratum is stored in the
+        MongoDB.
+
+        :param other: The erratum we are combining with this one
+        :type  other: pulp_rpm.plugins.db.models.Errata
+        """
+        self.merge_pkglists(other)
+        if self.update_needed(other):
+            for field_name in self.mutable_erratum_fields:
+                setattr(self, field_name, getattr(other, field_name))
+
+    def update_needed(self, other):
+        """
+        Decide based on the `updated` field if the update of the existing erratum is needed.
+
+        The `updated` field is just a string in the MongoDB, so there is no strict format for this
+        date-time field. If we are not able to parse the `updated` field either in existing
+        erratum or in the new erratum, the metadata of existing erratum won't be updated.
+
+        :param other: potentially a newer version of the erratum
+        :type  other: pulp_rpm.plugins.db.models.Errata
+
+        :return: True if the other erratum is newer than the existing one
+        :rtype:  bool
+        """
+        err_msg = _('Fail to update the %(which)s erratum %(id)s: '
+                    'Unable to parse the `updated` field')
+        existing_err_msg = err_msg % {'which': 'existing', 'id': self.errata_id}
+        other_err_msg = err_msg % {'which': 'uploaded', 'id': self.errata_id}
+        existing_updated_dt = util.errata_format_to_datetime(self.updated, msg=existing_err_msg)
+        new_updated_dt = util.errata_format_to_datetime(other.updated, msg=other_err_msg)
+        return new_updated_dt > existing_updated_dt
+
+    def merge_pkglists(self, other):
+        """
+        Merge pkglists of the two errata.
+
+         - add _pulp_repo_id to old collection if packages are the same
+         - update existing collection if the other collection is newer and from the same
+           repository
+         - otherwise add a new collection
+
+        :param other: The erratum we are combining with the existing one
+        :type  other: pulp_rpm.plugins.db.models.Errata
+
+        """
+        existing_pkglist_map = {}
+        for idx, p in enumerate(self.pkglist):
+            package_name = p['name']
+            package_repo_id = p.get('_pulp_repo_id')
+            pkglist_key = (package_name, package_repo_id)
+            existing_pkglist_map[pkglist_key] = idx
+
+        collections_to_add = []
+        for new_collection in other.pkglist:
+            coll_name = new_collection['name']
+
+            # collection with such name does not contain _pulp_repo_id
+            if (coll_name, None) in existing_pkglist_map:
+                coll_idx = existing_pkglist_map[(coll_name, None)]
+                existing_collection = self.pkglist[coll_idx]
+                if self._check_packages(existing_collection['packages'],
+                                        new_collection['packages']):
+                    existing_collection['_pulp_repo_id'] = new_collection['_pulp_repo_id']
+                else:
+                    collections_to_add.append(new_collection)
+
+            # collection with such name and _pulp_repo_id already exists
+            elif (coll_name, new_collection['_pulp_repo_id']) in existing_pkglist_map:
+                if self.update_needed(other):
+                    coll_idx = existing_pkglist_map[
+                        (coll_name, new_collection['_pulp_repo_id'])]
+                    self.pkglist[coll_idx]['packages'] = new_collection['packages']
+
+            # no collection with such name or no collection with such name and _pulp_repo_id
+            else:
+                collections_to_add.append(new_collection)
+        self.pkglist += collections_to_add
 
 
 class PackageGroup(UnitMixin, ContentUnit):

--- a/plugins/pulp_rpm/plugins/importers/yum/upload.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/upload.py
@@ -146,6 +146,13 @@ def _handle_erratum(repo, type_id, unit_key, metadata, file_path, conduit, confi
     steps are to save the metadata and optionally link the erratum to RPMs
     in the repository.
 
+    NOTE: For now errata is handled differently than other units. Uploaded erratum should not
+    overwrite the existing one if the latter exists, they should be merged. This is only because
+    of the way erratum is stored in the MongoDB and it is in `our plans`_ to re-think how to do
+    it correctly.
+
+    .. _our plans: https://pulp.plan.io/issues/1803
+
     :param repo: The repository to import the package into
     :type  repo: pulp.server.db.model.Repository
 
@@ -175,10 +182,19 @@ def _handle_erratum(repo, type_id, unit_key, metadata, file_path, conduit, confi
     unit_data.update(metadata or {})
     unit_data.update(unit_key or {})
 
-    unit = model_class(**unit_data)
+    existing_unit = model_class.objects.filter(**unit_key).first()
+    new_unit = model_class(**unit_data)
+
+    # Add repo_id to each collection of the pkglist of the new erratum
+    for collection in new_unit.pkglist:
+        collection['_pulp_repo_id'] = repo.repo_id
+
+    unit = new_unit
+    if existing_unit:
+        existing_unit.merge_errata(new_unit)
+        unit = existing_unit
 
     unit.save()
-
     if not config.get_boolean(CONFIG_SKIP_ERRATUM_LINK):
         repo_controller.associate_single_unit(repo, unit)
 

--- a/plugins/pulp_rpm/yum_plugin/util.py
+++ b/plugins/pulp_rpm/yum_plugin/util.py
@@ -1,8 +1,9 @@
+import datetime
+import gettext
+import logging
+import os
 import shutil
 import uuid
-import os
-import logging
-import gettext
 
 import yum
 import rpmUtils
@@ -173,3 +174,37 @@ def generate_listing_files(root_publish_dir, repo_publish_dir):
 
         # work up the directory structure
         working_dir = os.path.dirname(working_dir)
+
+
+def errata_format_to_datetime(datetime_str, msg):
+    """
+    Convert known errata date-time formats to datetime object.
+
+    Expected formats are:
+     - '%Y-%m-%d %H:%M:%S'
+     - '%Y-%m-%d %H:%M:%S UTC'
+
+    :param datetime_str: date and time in errata specific format
+    :type  datetime_str: str
+
+    :param msg: additional error message in case of exception
+    :type  msg: str
+
+    :return: parsed date and time
+    :rtype: datetime.datetime
+    :raises ValueError: if the date and time are in unknown format
+    """
+    strptime_pattern = '%Y-%m-%d %H:%M:%S'
+    err_msg = _('Unknown format: unable to convert "%s" to the datetime object' % datetime_str)
+
+    datetime_str = datetime_str.strip()
+    if datetime_str.endswith(' UTC'):
+        datetime_str = datetime_str[:-4]
+
+    try:
+        datetime_obj = datetime.datetime.strptime(datetime_str, strptime_pattern)
+    except ValueError as e:
+        e.args += (err_msg, msg)
+        raise
+
+    return datetime_obj

--- a/plugins/test/unit/plugins/db/test_models.py
+++ b/plugins/test/unit/plugins/db/test_models.py
@@ -1,14 +1,15 @@
 from cStringIO import StringIO
 from urlparse import urljoin
+import copy
 import hashlib
 import math
 import os
 import shutil
 import tempfile
-import unittest
 
 import mock
 
+from pulp.common.compat import unittest
 from pulp_rpm.common import ids
 from pulp_rpm.devel.skip import skip_broken
 from pulp_rpm.plugins.db import models
@@ -67,6 +68,26 @@ class TestErrata(unittest.TestCase):
     """
     This class contains tests for the Errata class.
     """
+    def setUp(self):
+        self.existing_packages = [
+            {'src': 'pulp-test-package-0.3.1-1.fc22.src.rpm',
+             'name': 'pulp-test-package',
+             'arch': 'x86_64',
+             'sums': 'sums',
+             'filename': 'pulp-test-package-0.3.1-1.fc22.x86_64.rpm',
+             'epoch': '0',
+             'version': '0.3.1',
+             'release': '1.fc22',
+             'type': 'sha256'}]
+        self.collection_wo_pulp_repo_id = {
+            'packages': self.existing_packages,
+            'name': 'test-name',
+            'short': ''}
+        self.collection_pulp_repo_id = {
+            'packages': self.existing_packages,
+            'name': 'test-name',
+            'short': '',
+            '_pulp_repo_id': 'test-repo'}
 
     def test_rpm_search_dicts_sanitizes_checksum_type_sum(self):
         """
@@ -118,6 +139,248 @@ class TestErrata(unittest.TestCase):
         self.assertEqual(ret[0]['name'], 'foo')
         # make sure this field is still not present
         self.assertTrue('checksumtype' not in ret[0])
+
+    def test_check_packages_equal(self):
+        """Assert that equal lists of packages are compared properly."""
+        erratum = models.Errata()
+        other_packages = copy.deepcopy(self.existing_packages)
+
+        ret = erratum._check_packages(self.existing_packages, other_packages)
+        self.assertTrue(ret)
+
+    def test_check_packages_not_equal(self):
+        """Assert that not equal lists of packages are compared properly."""
+        erratum = models.Errata()
+        other_packages = copy.deepcopy(self.existing_packages)
+        other_packages[0]["version"] = "0.3.2"
+
+        ret = erratum._check_packages(self.existing_packages, other_packages)
+        self.assertFalse(ret)
+
+    def test_check_packages_different_length(self):
+        """Assert that not equal lists of packages are compared properly."""
+        erratum = models.Errata()
+        other_packages = []
+
+        ret = erratum._check_packages(self.existing_packages, other_packages)
+        self.assertFalse(ret)
+
+    def test_update_needed_newer_erratum(self):
+        """
+        Assert that if the newer erratum is uploaded, then the update is needed.
+        """
+        existing_erratum, uploaded_erratum = models.Errata(), models.Errata()
+        existing_erratum.updated = '2016-01-01 00:00:00 UTC'
+        uploaded_erratum.updated = '2016-04-01 00:00:00 UTC'
+        ret = existing_erratum.update_needed(uploaded_erratum)
+        self.assertTrue(ret)
+
+    def test_update_needed_older_erratum(self):
+        """
+        Assert that if the older erratum is uploaded, then the update is not needed.
+        """
+        existing_erratum, uploaded_erratum = models.Errata(), models.Errata()
+        existing_erratum.updated = '2016-01-01 00:00:00 UTC'
+        uploaded_erratum.updated = '2015-01-01 00:00:00 UTC'
+        ret = existing_erratum.update_needed(uploaded_erratum)
+        self.assertFalse(ret)
+
+    def test_update_needed_bad_date_existing(self):
+        """
+        Assert that if the `updated` date of the existing erratum is in the unknown format, then
+        the ValueError is raised.
+        """
+        existing_erratum, uploaded_erratum = models.Errata(), models.Errata()
+        existing_erratum.updated = 'Fri Jan  1 00:00:00 UTC 2016'
+        uploaded_erratum.updated = '2016-04-01 00:00:00 UTC'
+        with self.assertRaisesRegexp(ValueError, 'existing erratum'):
+            existing_erratum.update_needed(uploaded_erratum)
+
+    def test_update_needed_bad_date_uploaded(self):
+        """
+        Assert that if the `updated` date of the uploaded erratum is in the unknown format, then
+        the ValueError is raised.
+        """
+        existing_erratum, uploaded_erratum = models.Errata(), models.Errata()
+        existing_erratum.updated = '2016-01-01 00:00:00 UTC'
+        uploaded_erratum.updated = 'Fri Apr  1 00:00:00 UTC 2016'
+        with self.assertRaisesRegexp(ValueError, 'uploaded erratum'):
+            existing_erratum.update_needed(uploaded_erratum)
+
+    def test_merge_pkglists_oldstyle_newstyle_same_collection(self):
+        """
+        Assert that _pulp_repo_id is added to the collection if it was absent and collection in the
+        uploaded erratum is the same as in the existing one.
+        """
+        existing_erratum, uploaded_erratum = models.Errata(), models.Errata()
+
+        # oldstyle erratum does not contain _pulp_repo_id, while the newstyle one does
+        collection_wo_pulp_repo_id = copy.deepcopy(self.collection_wo_pulp_repo_id)
+        existing_erratum.pkglist = [collection_wo_pulp_repo_id]
+        uploaded_erratum.pkglist = [self.collection_pulp_repo_id]
+        existing_erratum.merge_pkglists(uploaded_erratum)
+
+        # make sure no additional collections are added
+        self.assertEqual(len(existing_erratum.pkglist), 1)
+
+        # make sure _pulp_repo_id is added to the existing collection
+        self.assertEqual(existing_erratum.pkglist[0]['_pulp_repo_id'],
+                         uploaded_erratum.pkglist[0]['_pulp_repo_id'])
+
+    def test_merge_pkglists_oldstyle_newstyle_different_collection(self):
+        """
+        Assert that new collection is added to the pkglist if the collection is different from the
+        existing one where _pulp_repo_id is absent.
+        """
+        existing_erratum, uploaded_erratum = models.Errata(), models.Errata()
+
+        # oldstyle erratum does not contain _pulp_repo_id, while the newstyle one does
+        collection_wo_pulp_repo_id = copy.deepcopy(self.collection_wo_pulp_repo_id)
+        existing_erratum.pkglist = [collection_wo_pulp_repo_id]
+
+        different_collection = copy.deepcopy(self.collection_pulp_repo_id)
+        different_collection['packages'][0]['version'] = '2.0'
+        uploaded_erratum.pkglist = [different_collection]
+
+        existing_erratum.merge_pkglists(uploaded_erratum)
+
+        # make sure additional collection is added
+        self.assertEqual(len(existing_erratum.pkglist), 2)
+        self.assertEqual(existing_erratum.pkglist[1]['packages'][0]['version'],
+                         uploaded_erratum.pkglist[0]['packages'][0]['version'])
+        self.assertEqual(existing_erratum.pkglist[1]['_pulp_repo_id'],
+                         uploaded_erratum.pkglist[0]['_pulp_repo_id'])
+
+        # make sure _pulp_repo_id is not added to the existing collection
+        self.assertFalse('_pulp_repo_id' in existing_erratum.pkglist[0])
+
+    @mock.patch('pulp_rpm.plugins.db.models.Errata.update_needed')
+    def test_merge_pkglists_newstyle_same_repo_newer(self, mock_update_needed):
+        """
+        Assert that the existing collecton is overwritten, if the uploaded erratum is newer than
+        the existing one.
+        """
+        existing_erratum, uploaded_erratum = models.Errata(), models.Errata()
+
+        existing_collection = copy.deepcopy(self.collection_pulp_repo_id)
+        collection_same_repo_id_different_packages = copy.deepcopy(self.collection_pulp_repo_id)
+        collection_same_repo_id_different_packages['packages'][0]['version'] = '2.0'
+
+        existing_erratum.pkglist = [existing_collection]
+        uploaded_erratum.pkglist = [collection_same_repo_id_different_packages]
+        mock_update_needed.return_value = True
+        existing_erratum.merge_pkglists(uploaded_erratum)
+
+        # make sure no additional collections are added
+        self.assertEqual(len(existing_erratum.pkglist), 1)
+
+        # make sure the existing collection is changed
+        self.assertEqual(existing_erratum.pkglist[0]['packages'][0]['version'],
+                         uploaded_erratum.pkglist[0]['packages'][0]['version'])
+
+    @mock.patch('pulp_rpm.plugins.db.models.Errata.update_needed')
+    def test_merge_pkglists_newstyle_same_repo_older(self, mock_update_needed):
+        """
+        Assert that the existing collecton is untouched, if the uploaded erratum is older than
+        the existing one.
+        """
+        existing_erratum, uploaded_erratum = models.Errata(), models.Errata()
+
+        existing_collection = copy.deepcopy(self.collection_pulp_repo_id)
+        collection_same_repo_id_different_packages = copy.deepcopy(self.collection_pulp_repo_id)
+        collection_same_repo_id_different_packages['packages'][0]['version'] = '2.0'
+
+        existing_erratum.pkglist = [existing_collection]
+        uploaded_erratum.pkglist = [collection_same_repo_id_different_packages]
+        mock_update_needed.return_value = False
+        existing_erratum.merge_pkglists(uploaded_erratum)
+
+        # make sure no additional collections are added
+        self.assertEqual(len(existing_erratum.pkglist), 1)
+
+        # make sure the existing collection is untouched
+        self.assertEqual(existing_erratum.pkglist[0], self.collection_pulp_repo_id)
+
+    def test_merge_pkglists_newstyle_new_collection(self):
+        """
+        Assert that new collection is added to the pkglist if the collection has different name.
+        """
+        existing_erratum, uploaded_erratum = models.Errata(), models.Errata()
+
+        existing_collection = copy.deepcopy(self.collection_pulp_repo_id)
+        new_collection = copy.deepcopy(self.collection_pulp_repo_id)
+        new_collection['name'] = 'new test-name'
+
+        existing_erratum.pkglist = [existing_collection]
+        uploaded_erratum.pkglist = [new_collection]
+        existing_erratum.merge_pkglists(uploaded_erratum)
+
+        # make sure additional collection is added
+        self.assertEqual(len(existing_erratum.pkglist), 2)
+        self.assertEqual(existing_erratum.pkglist[0]['name'],
+                         self.collection_pulp_repo_id['name'])
+        self.assertEqual(existing_erratum.pkglist[1]['name'],
+                         uploaded_erratum.pkglist[0]['name'])
+
+    def test_merge_pkglists_newstyle_new_repo(self):
+        """
+        Assert that new collection is added to the pkglist if the uploaded erratum is from
+        the different repository.
+        """
+        existing_erratum, uploaded_erratum = models.Errata(), models.Errata()
+
+        existing_collection = copy.deepcopy(self.collection_pulp_repo_id)
+        new_collection = copy.deepcopy(self.collection_pulp_repo_id)
+        new_collection['_pulp_repo_id'] = 'other test-repo'
+
+        existing_erratum.pkglist = [existing_collection]
+        uploaded_erratum.pkglist = [new_collection]
+        existing_erratum.merge_pkglists(uploaded_erratum)
+
+        # make sure additional collection is added
+        self.assertEqual(len(existing_erratum.pkglist), 2)
+        self.assertEqual(existing_erratum.pkglist[0]['_pulp_repo_id'],
+                         self.collection_pulp_repo_id['_pulp_repo_id'])
+        self.assertEqual(existing_erratum.pkglist[1]['_pulp_repo_id'],
+                         uploaded_erratum.pkglist[0]['_pulp_repo_id'])
+
+    @mock.patch('pulp_rpm.plugins.db.models.Errata.merge_pkglists')
+    @mock.patch('pulp_rpm.plugins.db.models.Errata.update_needed')
+    def test_merge_errata_newer_erratum(self, mock_update_needed, mock_merge_pkglists):
+        """
+        Assert that the existing erratum is updated if the uploaded erratum is newer.
+        """
+        existing_erratum, uploaded_erratum = models.Errata(), models.Errata()
+        mock_update_needed.return_value = True
+        existing_erratum.mutable_erratum_fields = ('field1', 'field2')
+        existing_erratum.field1 = 'existing field1'
+        existing_erratum.field2 = 'existing field2'
+        uploaded_erratum.field1 = 'uploaded field1'
+        uploaded_erratum.field2 = 'uploaded field2'
+        existing_erratum.merge_errata(uploaded_erratum)
+
+        # make sure the erratum metadata is updated
+        self.assertEqual(existing_erratum.field1, uploaded_erratum.field1)
+        self.assertEqual(existing_erratum.field2, uploaded_erratum.field2)
+
+    @mock.patch('pulp_rpm.plugins.db.models.Errata.merge_pkglists')
+    @mock.patch('pulp_rpm.plugins.db.models.Errata.update_needed')
+    def test_merge_errata_older_erratum(self, mock_update_needed, mock_merge_pkglists):
+        """
+        Assert that the existing erratum is not updated if the uploaded erratum is older.
+        """
+        existing_erratum, uploaded_erratum = models.Errata(), models.Errata()
+        mock_update_needed.return_value = False
+        existing_erratum.mutable_erratum_fields = ('field1', 'field2')
+        existing_erratum.field1 = 'existing field1'
+        existing_erratum.field2 = 'existing field2'
+        uploaded_erratum.field1 = 'uploaded field1'
+        uploaded_erratum.field2 = 'uploaded field2'
+        existing_erratum.merge_errata(uploaded_erratum)
+
+        # make sure the existing erratum is not changed
+        self.assertNotEqual(existing_erratum.field1, uploaded_erratum.field1)
+        self.assertNotEqual(existing_erratum.field2, uploaded_erratum.field2)
 
 
 class TestISO(unittest.TestCase):


### PR DESCRIPTION
Handle pkglist for the same errata in different repositories.
Update errata metadata based on `updated` field.

closes #858
https://pulp.plan.io/issues/858