### PR TITLE
Add new export distributor config option to allow repo exports with yum metadata

### DIFF
--- a/common/pulp_rpm/common/constants.py
+++ b/common/pulp_rpm/common/constants.py
@@ -136,9 +136,11 @@ SKIP_KEYWORD = 'skip'
 START_DATE_KEYWORD = 'start_date'
 GENERATE_SQLITE_KEYWORD = 'generate_sqlite'
 RELATIVE_URL_KEYWORD = 'relative_url'
+INCREMENTAL_EXPORT_REPOMD_KEYWORD = 'incremental_export_repomd'
 EXPORT_OPTIONAL_CONFIG_KEYS = (END_DATE_KEYWORD, ISO_PREFIX_KEYWORD, SKIP_KEYWORD,
                                EXPORT_DIRECTORY_KEYWORD, START_DATE_KEYWORD, ISO_SIZE_KEYWORD,
-                               GENERATE_SQLITE_KEYWORD, CREATE_PULP_MANIFEST, RELATIVE_URL_KEYWORD)
+                               GENERATE_SQLITE_KEYWORD, CREATE_PULP_MANIFEST, RELATIVE_URL_KEYWORD,
+                               INCREMENTAL_EXPORT_REPOMD_KEYWORD)
 
 EXPORT_HTTP_DIR = '/var/lib/pulp/published/http/exports/repo'
 EXPORT_HTTPS_DIR = '/var/lib/pulp/published/https/exports/repo'

--- a/docs/tech-reference/yum-plugins.rst
+++ b/docs/tech-reference/yum-plugins.rst
@@ -596,3 +596,7 @@ Optional Configuration Parameters
  List of content types to skip during the repository publish.
  If unspecified, all types will be published. Valid values are: rpm, drpm,
  distribution, errata, packagegroup.
+
+``force_full``
+Boolean flag to indicate whether or not publish should be done from scratch.
+If unspecified the incremental publish will be performed when possible.

--- a/docs/user-guide/release-notes/index.rst
+++ b/docs/user-guide/release-notes/index.rst
@@ -6,6 +6,7 @@ Contents:
 .. toctree::
    :maxdepth: 2
 
+   2.9.x
    2.8.x
    2.7.x
    2.6.x

--- a/extensions_admin/pulp_rpm/extensions/admin/export.py
+++ b/extensions_admin/pulp_rpm/extensions/admin/export.py
@@ -40,6 +40,8 @@ DESC_SERVE_HTTP = _('the ISO images will be served over HTTP; default to False; 
 DESC_SERVE_HTTPS = _('the ISO images will be served over HTTPS; defaults to True; if '
                      'this export is to a directory, this has no effect.')
 DESC_MANIFEST = _('if this flag is used, a PULP_MANIFEST file will be created')
+DESC_INCREMENTAL_MD = _('if this flag is used, incremental exports will use yum repodata'
+                        ' metadata instead of json.')
 
 # The iso prefix is restricted to the same character set as an id, so we use the id_validator
 OPTION_ISO_PREFIX = PulpCliOption('--iso-prefix', DESC_ISO_PREFIX, required=False,
@@ -57,6 +59,9 @@ OPTION_SERVE_HTTPS = PulpCliOption('--serve-https', DESC_SERVE_HTTPS, required=F
 OPTION_SERVE_HTTP = PulpCliOption('--serve-http', DESC_SERVE_HTTP, required=False, default='false',
                                   parse_func=parsers.parse_boolean)
 FLAG_MANIFEST = PulpCliFlag('--' + constants.CREATE_PULP_MANIFEST, DESC_MANIFEST, ['-m'])
+OPTION_INCREMENTAL_MD = PulpCliOption('--incremental-export-repomd', DESC_INCREMENTAL_MD,
+                                      required=False, default='false',
+                                      parse_func=parsers.parse_boolean)
 
 
 class RpmExportCommand(RunPublishRepositoryCommand):
@@ -73,7 +78,7 @@ class RpmExportCommand(RunPublishRepositoryCommand):
         """
         override_config_options = [OPTION_EXPORT_DIR, OPTION_ISO_PREFIX, OPTION_ISO_SIZE,
                                    OPTION_START_DATE, OPTION_END_DATE, FLAG_MANIFEST,
-                                   OPTION_RELATIVE_URL]
+                                   OPTION_RELATIVE_URL, OPTION_INCREMENTAL_MD]
 
         super(RpmExportCommand, self).__init__(context=context,
                                                renderer=renderer,
@@ -116,6 +121,7 @@ class RpmGroupExportCommand(PollingCommand):
         self.add_option(OPTION_RELATIVE_URL)
         self.add_option(OPTION_SERVE_HTTPS)
         self.add_option(OPTION_SERVE_HTTP)
+        self.add_option(OPTION_INCREMENTAL_MD)
 
         self.add_flag(FLAG_MANIFEST)
 
@@ -135,6 +141,7 @@ class RpmGroupExportCommand(PollingCommand):
         manifest = kwargs[FLAG_MANIFEST.keyword]
         serve_http = kwargs[OPTION_SERVE_HTTP.keyword]
         serve_https = kwargs[OPTION_SERVE_HTTPS.keyword]
+        incremental_md = kwargs[OPTION_INCREMENTAL_MD.keyword]
 
         # Since the export distributor is not added to a repository group on creation, add it here
         # if it is not already associated with the group id
@@ -169,6 +176,7 @@ class RpmGroupExportCommand(PollingCommand):
             constants.EXPORT_DIRECTORY_KEYWORD: export_dir,
             constants.RELATIVE_URL_KEYWORD: relative_url,
             constants.CREATE_PULP_MANIFEST: manifest,
+            constants.INCREMENTAL_EXPORT_REPOMD_KEYWORD: incremental_md,
         }
 
         # Remove keys from the config that have None value.

--- a/extensions_admin/test/unit/extensions/admin/test_export.py
+++ b/extensions_admin/test/unit/extensions/admin/test_export.py
@@ -35,6 +35,7 @@ class TestRepoExportRunCommand(PulpClientTests):
             export.OPTION_START_DATE,
             export.OPTION_ISO_PREFIX,
             export.OPTION_ISO_SIZE,
+            export.OPTION_INCREMENTAL_MD
         ]
 
         # Test
@@ -68,7 +69,8 @@ class TestRepoGroupExportRunCommand(PulpClientTests):
             export.OPTION_EXPORT_DIR.keyword: None,
             export.OPTION_RELATIVE_URL.keyword: None,
             export.OPTION_SERVE_HTTP.keyword: True,
-            export.OPTION_SERVE_HTTPS.keyword: True
+            export.OPTION_SERVE_HTTPS.keyword: True,
+            export.OPTION_INCREMENTAL_MD.keyword: False
         }
 
     def tearDown(self):
@@ -91,7 +93,8 @@ class TestRepoGroupExportRunCommand(PulpClientTests):
             export.OPTION_ISO_PREFIX,
             export.OPTION_ISO_SIZE,
             export.OPTION_SERVE_HTTPS,
-            export.OPTION_SERVE_HTTP
+            export.OPTION_SERVE_HTTP,
+            export.OPTION_INCREMENTAL_MD
         ]
 
         # Test
@@ -172,6 +175,7 @@ class TestRepoGroupExportRunCommand(PulpClientTests):
         expected_publish_config = {
             constants.PUBLISH_HTTP_KEYWORD: True,
             constants.PUBLISH_HTTPS_KEYWORD: True,
+            constants.INCREMENTAL_EXPORT_REPOMD_KEYWORD: False,
         }
 
         # Test

--- a/plugins/pulp_rpm/plugins/distributors/yum/configuration.py
+++ b/plugins/pulp_rpm/plugins/distributors/yum/configuration.py
@@ -21,7 +21,7 @@ REQUIRED_CONFIG_KEYS = ('relative_url', 'http', 'https')
 
 OPTIONAL_CONFIG_KEYS = ('gpgkey', 'auth_ca', 'auth_cert', 'https_ca', 'checksum_type',
                         'http_publish_dir', 'https_publish_dir', 'protected',
-                        'skip', 'skip_pkg_tags', 'generate_sqlite')
+                        'skip', 'skip_pkg_tags', 'generate_sqlite', 'force_full')
 
 ROOT_PUBLISH_DIR = '/var/lib/pulp/published/yum'
 MASTER_PUBLISH_DIR = os.path.join(ROOT_PUBLISH_DIR, 'master')

--- a/plugins/pulp_rpm/plugins/distributors/yum/publish.py
+++ b/plugins/pulp_rpm/plugins/distributors/yum/publish.py
@@ -104,17 +104,23 @@ class ExportRepoPublisher(BaseYumRepoPublisher):
         :param distributor_type: The type of the distributor that is being published
         :type distributor_type: str
         """
-        super(ExportRepoPublisher, self).__init__(repo, publish_conduit, config, distributor_type,
-                                                  **kwargs)
 
         date_q = export_utils.create_date_range_filter(config)
-        if date_q:
-            # Since this is a partial export we don't generate metadata
-            # we have to clear out the previously added steps
-            # we only need special version s of the rpm, drpm, and errata steps
-            self.clear_children()
-            self.add_child(PublishRpmAndDrpmStepIncremental(repo_content_unit_q=date_q))
-            self.add_child(PublishErrataStepIncremental(repo_content_unit_q=date_q))
+
+        if config.get_boolean(constants.INCREMENTAL_EXPORT_REPOMD_KEYWORD):
+            super(ExportRepoPublisher, self).__init__(repo, publish_conduit, config,
+                                                      distributor_type, association_filters=date_q,
+                                                      **kwargs)
+        else:
+            super(ExportRepoPublisher, self).__init__(repo, publish_conduit, config,
+                                                      distributor_type, **kwargs)
+            if date_q:
+                # Since this is a partial export we don't generate metadata
+                # we have to clear out the previously added steps
+                # we only need special version s of the rpm, drpm, and errata steps
+                self.clear_children()
+                self.add_child(PublishRpmAndDrpmStepIncremental(repo_content_unit_q=date_q))
+                self.add_child(PublishErrataStepIncremental(repo_content_unit_q=date_q))
 
         working_directory = self.get_working_dir()
         export_dir = config.get(constants.EXPORT_DIRECTORY_KEYWORD)
@@ -248,13 +254,17 @@ class Publisher(BaseYumRepoPublisher):
     of a yum repository over HTTP and/or HTTPS.
     """
 
-    def __init__(self, transfer_repo, publish_conduit, config, distributor_type, **kwargs):
+    def __init__(self, transfer_repo, publish_conduit, config, distributor_type,
+                 association_filters=None, **kwargs):
         """
         :param transfer_repo: repository being published
         :type  transfer_repo: pulp.plugins.db.model.Repository
         :param publish_conduit: Conduit providing access to relative Pulp functionality
         :type  publish_conduit: pulp.plugins.conduits.repo_publish.RepoPublishConduit
         :param config: Pulp configuration for the distributor
+        :type  config: pulp.plugins.config.PluginCallConfiguration
+        :param association_filters: Any filters to be applied to the list of RPMs being published
+        :type association_filters: mongoengine.Q
         :type  config: pulp.plugins.config.PluginCallConfiguration
         :param distributor_type: The type of the distributor that is being published
         :type distributor_type: str
@@ -265,8 +275,15 @@ class Publisher(BaseYumRepoPublisher):
 
         last_published = publish_conduit.last_publish()
         last_deleted = repo.last_unit_removed
-        force_full = config.get('force_full', False)
-        date_filter = None
+
+        # if a filter is passed in, assume force_full and use the filter as the
+        # date filter
+        if association_filters:
+            force_full = True
+            date_filter = association_filters
+        else:
+            force_full = config.get('force_full', False)
+            date_filter = None
 
         if last_published and \
                 (last_deleted is None or last_published > last_deleted) and \

--- a/plugins/pulp_rpm/plugins/distributors/yum/publish.py
+++ b/plugins/pulp_rpm/plugins/distributors/yum/publish.py
@@ -265,10 +265,12 @@ class Publisher(BaseYumRepoPublisher):
 
         last_published = publish_conduit.last_publish()
         last_deleted = repo.last_unit_removed
+        force_full = config.get('force_full', False)
         date_filter = None
 
         if last_published and \
-                ((last_deleted and last_published > last_deleted) or not last_deleted):
+                (last_deleted is None or last_published > last_deleted) and \
+                not force_full:
             # Add the step to copy the current published directory into place
             specific_master = None
             if config.get(constants.PUBLISH_HTTPS_KEYWORD):


### PR DESCRIPTION
This PR has a patch to allow for optionally exporting incremental yum repos with yum metadata.

Additionally, it backports a commit from master for the `force-full` option. b9455af uses `force-full` in order to keep the passed-in association filter and not override with a date-based filter.