### PR TITLE
Allow for new `incremental_export_repomd` exporter distributor config option

### DIFF
--- a/common/pulp_rpm/common/constants.py
+++ b/common/pulp_rpm/common/constants.py
@@ -136,9 +136,11 @@ SKIP_KEYWORD = 'skip'
 START_DATE_KEYWORD = 'start_date'
 GENERATE_SQLITE_KEYWORD = 'generate_sqlite'
 RELATIVE_URL_KEYWORD = 'relative_url'
+INCREMENTAL_EXPORT_REPOMD_KEYWORD = 'incremental_export_repomd'
 EXPORT_OPTIONAL_CONFIG_KEYS = (END_DATE_KEYWORD, ISO_PREFIX_KEYWORD, SKIP_KEYWORD,
                                EXPORT_DIRECTORY_KEYWORD, START_DATE_KEYWORD, ISO_SIZE_KEYWORD,
-                               GENERATE_SQLITE_KEYWORD, CREATE_PULP_MANIFEST, RELATIVE_URL_KEYWORD)
+                               GENERATE_SQLITE_KEYWORD, CREATE_PULP_MANIFEST, RELATIVE_URL_KEYWORD,
+                               INCREMENTAL_EXPORT_REPOMD_KEYWORD)
 
 EXPORT_HTTP_DIR = '/var/lib/pulp/published/http/exports/repo'
 EXPORT_HTTPS_DIR = '/var/lib/pulp/published/https/exports/repo'

--- a/extensions_admin/pulp_rpm/extensions/admin/export.py
+++ b/extensions_admin/pulp_rpm/extensions/admin/export.py
@@ -40,6 +40,8 @@ DESC_SERVE_HTTP = _('the ISO images will be served over HTTP; default to False; 
 DESC_SERVE_HTTPS = _('the ISO images will be served over HTTPS; defaults to True; if '
                      'this export is to a directory, this has no effect.')
 DESC_MANIFEST = _('if this flag is used, a PULP_MANIFEST file will be created')
+DESC_INCREMENTAL_MD = _('if this flag is used, incremental exports will use yum repodata'
+                        ' metadata instead of json.')
 
 # The iso prefix is restricted to the same character set as an id, so we use the id_validator
 OPTION_ISO_PREFIX = PulpCliOption('--iso-prefix', DESC_ISO_PREFIX, required=False,
@@ -57,6 +59,9 @@ OPTION_SERVE_HTTPS = PulpCliOption('--serve-https', DESC_SERVE_HTTPS, required=F
 OPTION_SERVE_HTTP = PulpCliOption('--serve-http', DESC_SERVE_HTTP, required=False, default='false',
                                   parse_func=parsers.parse_boolean)
 FLAG_MANIFEST = PulpCliFlag('--' + constants.CREATE_PULP_MANIFEST, DESC_MANIFEST, ['-m'])
+OPTION_INCREMENTAL_MD = PulpCliOption('--incremental-export-repomd', DESC_INCREMENTAL_MD,
+                                      required=False, default='false',
+                                      parse_func=parsers.parse_boolean)
 
 
 class RpmExportCommand(RunPublishRepositoryCommand):
@@ -73,7 +78,7 @@ class RpmExportCommand(RunPublishRepositoryCommand):
         """
         override_config_options = [OPTION_EXPORT_DIR, OPTION_ISO_PREFIX, OPTION_ISO_SIZE,
                                    OPTION_START_DATE, OPTION_END_DATE, FLAG_MANIFEST,
-                                   OPTION_RELATIVE_URL]
+                                   OPTION_RELATIVE_URL, OPTION_INCREMENTAL_MD]
 
         super(RpmExportCommand, self).__init__(context=context,
                                                renderer=renderer,
@@ -116,6 +121,7 @@ class RpmGroupExportCommand(PollingCommand):
         self.add_option(OPTION_RELATIVE_URL)
         self.add_option(OPTION_SERVE_HTTPS)
         self.add_option(OPTION_SERVE_HTTP)
+        self.add_option(OPTION_INCREMENTAL_MD)
 
         self.add_flag(FLAG_MANIFEST)
 
@@ -135,6 +141,7 @@ class RpmGroupExportCommand(PollingCommand):
         manifest = kwargs[FLAG_MANIFEST.keyword]
         serve_http = kwargs[OPTION_SERVE_HTTP.keyword]
         serve_https = kwargs[OPTION_SERVE_HTTPS.keyword]
+        incremental_md = kwargs[OPTION_INCREMENTAL_MD.keyword]
 
         # Since the export distributor is not added to a repository group on creation, add it here
         # if it is not already associated with the group id
@@ -169,6 +176,7 @@ class RpmGroupExportCommand(PollingCommand):
             constants.EXPORT_DIRECTORY_KEYWORD: export_dir,
             constants.RELATIVE_URL_KEYWORD: relative_url,
             constants.CREATE_PULP_MANIFEST: manifest,
+            constants.INCREMENTAL_EXPORT_REPOMD_KEYWORD: incremental_md,
         }
 
         # Remove keys from the config that have None value.

--- a/extensions_admin/test/unit/extensions/admin/test_export.py
+++ b/extensions_admin/test/unit/extensions/admin/test_export.py
@@ -35,6 +35,7 @@ class TestRepoExportRunCommand(PulpClientTests):
             export.OPTION_START_DATE,
             export.OPTION_ISO_PREFIX,
             export.OPTION_ISO_SIZE,
+            export.OPTION_INCREMENTAL_MD
         ]
 
         # Test
@@ -68,7 +69,8 @@ class TestRepoGroupExportRunCommand(PulpClientTests):
             export.OPTION_EXPORT_DIR.keyword: None,
             export.OPTION_RELATIVE_URL.keyword: None,
             export.OPTION_SERVE_HTTP.keyword: True,
-            export.OPTION_SERVE_HTTPS.keyword: True
+            export.OPTION_SERVE_HTTPS.keyword: True,
+            export.OPTION_INCREMENTAL_MD.keyword: False
         }
 
     def tearDown(self):
@@ -91,7 +93,8 @@ class TestRepoGroupExportRunCommand(PulpClientTests):
             export.OPTION_ISO_PREFIX,
             export.OPTION_ISO_SIZE,
             export.OPTION_SERVE_HTTPS,
-            export.OPTION_SERVE_HTTP
+            export.OPTION_SERVE_HTTP,
+            export.OPTION_INCREMENTAL_MD
         ]
 
         # Test
@@ -172,6 +175,7 @@ class TestRepoGroupExportRunCommand(PulpClientTests):
         expected_publish_config = {
             constants.PUBLISH_HTTP_KEYWORD: True,
             constants.PUBLISH_HTTPS_KEYWORD: True,
+            constants.INCREMENTAL_EXPORT_REPOMD_KEYWORD: False,
         }
 
         # Test

--- a/plugins/test/unit/plugins/distributors/yum/test_publish.py
+++ b/plugins/test/unit/plugins/distributors/yum/test_publish.py
@@ -154,8 +154,9 @@ class BaseYumRepoPublisherTests(BaseYumDistributorPublishTests):
 
         mock_publish_distribution.assert_called_once()
         mock_publish_rpms.assert_called_once()
-        mock_publish_drpms.assert_called_once()
-        mock_publish_errata.assert_called_once()
+        mock_publish_drpms.assert_called_once_with(mock_publish_distribution(),
+                                                   repo_content_unit_q=None)
+        mock_publish_errata.assert_called_once_with(repo_content_unit_q=None)
         mock_publish_metadata.assert_called_once()
         mock_build_final_report.assert_called_once()
         mock_publish_comps.assert_called_once()


### PR DESCRIPTION
Previously, incremental exports were in a custom format where each erratum and
RPM were written to disk, along with a set of JSON files with unit metadata.
This required special handling of incremental imports that was significantly
different a "regular" repo sync.

This patch adds a new `incremental_export_repomd` distributor option. When this
is set, the incremental repo export generates metadata so that the on-disk
files can be synced via the typical yum sync process. Note that you would not
want to remove old units when doing this, since it would remove any units not
in the incremental :koala:.

Fixes #1543
https://pulp.plan.io/issues/1543