### PR TITLE
Removes symlink/file PULP_DISTRIBUTION.xml before writing a new file

### DIFF
--- a/plugins/pulp_rpm/plugins/distributors/yum/publish.py
+++ b/plugins/pulp_rpm/plugins/distributors/yum/publish.py
@@ -841,7 +841,14 @@ class PublishDistributionStep(platform_steps.UnitModelPluginStep):
             element.text = distro_file
 
         tree = cElementTree.ElementTree(new_xml_root)
-        tree.write(os.path.join(self.get_working_dir(), constants.DISTRIBUTION_XML))
+        distribution_xml_path = os.path.join(self.get_working_dir(), constants.DISTRIBUTION_XML)
+        try:
+            os.remove(distribution_xml_path)
+        except OSError as e:
+            if e.errno != os.errno.ENOENT:
+                raise
+
+        tree.write(distribution_xml_path)
 
     def _publish_distribution_packages_link(self, distribution_unit):
         """

--- a/plugins/test/unit/plugins/distributors/yum/test_publish.py
+++ b/plugins/test/unit/plugins/distributors/yum/test_publish.py
@@ -693,16 +693,18 @@ class TestPublishDistributionWritePulpDistributionFile(unittest.TestCase):
             if child.text == path:
                 self.fail('path in XML: %s' % path)
 
-    def test_removes_file_entries(self):
+    @mock.patch('os.path.join')
+    @mock.patch('os.remove')
+    def test_removes_file_entries(self, mock_remove, mock_path_join):
         """
         Make sure any paths in "distro_files" that are not present in the original XML get
         filtered out.
         """
+        mock_path_join.side_effect = [self.target]
         paths = list(self.included_paths)
         paths.append('remove/me')
 
-        with mock.patch('os.path.join', return_value=self.target):
-            self.step._write_pulp_distribution_file(paths, self.xml_path)
+        self.step._write_pulp_distribution_file(paths, self.xml_path)
 
         root = ET.fromstring(self.target.getvalue())
 


### PR DESCRIPTION
fixes #1869
https://pulp.plan.io/issues/1869