### PR TITLE
Adds <langpacks> support in the comps file

### DIFF
--- a/common/pulp_rpm/common/ids.py
+++ b/common/pulp_rpm/common/ids.py
@@ -32,6 +32,7 @@ METADATA_ERRATA = (
 TYPE_ID_PKG_GROUP = 'package_group'
 TYPE_ID_PKG_CATEGORY = 'package_category'
 TYPE_ID_PKG_ENVIRONMENT = 'package_environment'
+TYPE_ID_PKG_LANGPACKS = 'package_langpacks'
 
 # We are adding the 'repo_id' to unit_key for each group/category
 # to ensure that each group/category is defined only for that given repo_id

--- a/docs/user-guide/recipes.rst
+++ b/docs/user-guide/recipes.rst
@@ -657,6 +657,10 @@ We can see that the package group is now part of our repo::
    Translated Name:
    User Visible:              False
 
+.. note::
+ Package groups will also be created and associated with a repository if they are specified
+ in a comps file and you `Upload a comps.xml file`_.
+
 Copying Package Groups Between Repos
 ------------------------------------
 
@@ -825,6 +829,10 @@ The package category details can be listed as well::
     Translated Description:
     Translated Name:
 
+.. note::
+ Package categories will also be created and associated with a repository if they are specified
+ in a comps file and you `Upload a comps.xml file`_.
+
 Copying Package Categories
 --------------------------
 
@@ -949,7 +957,7 @@ Package Environments
 .. _creating_package_environments:
 
 Create Your Own Package Environment
-----------------------------------
+-----------------------------------
 
 
 You can also define your own package environments with the :command:`pulp_admin`
@@ -975,6 +983,7 @@ Now let's build two package groups for our demo repo test files::
 
 And now we can create a package environment that is a collection of these
 two groups::
+
     $ pulp-admin rpm repo uploads environment --repo-id repo_1 --environment-id test-env \
     --name test-env --description test-env --group pulp_dotted_name_packages \
     --group pulp_test_packages
@@ -1010,6 +1019,7 @@ two groups::
 
 
 The package environment details can be listed as well::
+
     $ pulp-admin rpm repo content environment --repo-id repo_1 --match id=test-env
 
     Description: test-env
@@ -1018,6 +1028,9 @@ The package environment details can be listed as well::
     Name:        test-env
     Options:     
 
+.. note::
+ Package environments will also be created and associated with a repository if they are specified
+ in a comps file and you `Upload a comps.xml file`_.
 
 Copying Package Environments
 ----------------------------
@@ -1041,6 +1054,7 @@ Now let's copy ``test-env`` from ``repo_1`` to ``repo_2``::
   into the destination repo.
 
 Observe that ``repo_2`` contains newly copied package environment::
+
     $ pulp-admin repo list --repo-id repo_2
 
     +----------------------------------------------------------------------+
@@ -1054,13 +1068,107 @@ Observe that ``repo_2`` contains newly copied package environment::
       Package Environment: 1
 
 
+Package Langpacks
+=================
+
+Creating Package Langpacks
+--------------------------
+
+You can also define your own package langpacks with the :command:`pulp_admin`
+utility. Let's create and sync a repo::
+
+    $ pulp-admin rpm repo create --repo-id=repo_1
+
+Now let's build a package langpacks entry for the hyphen package::
+
+   $ pulp-admin rpm repo uploads langpacks -i hyphen -n hyphen-%s --repo-id repo_1
+   +----------------------------------------------------------------------+
+                                 Unit Upload
+   +----------------------------------------------------------------------+
+
+   Extracting necessary metadata for each request...
+   ... completed
+
+   Creating upload requests on the server...
+   [==================================================] 100%
+   Initializing upload
+   ... completed
+
+   Starting upload of selected units. If this process is stopped through ctrl+c,
+   the uploads will be paused and may be resumed later using the resume command or
+   canceled entirely using the cancel command.
+
+   Importing into the repository...
+   ... completed
+
+   Deleting the upload request...
+   ... completed
+
+We can see that the package langpacks is now part of our repo::
+
+   $ pulp-admin rpm repo content langpacks --repo-id=repo_1
+   Matches:
+     Install: hyphen
+     Name:    hyphen-%s
+
+.. note::
+ Package langpacks will also be created and associated with a repository if they are specified
+ in a comps file and you `Upload a comps.xml file`_.
+
+Copying Package Langpacks
+-------------------------
+
+Like package environments, package langpacks can be copied between repos. Assuming you've
+performed the steps from the `Creating Package Langpacks`_ section, let's begin by creating
+an empty second repo::
+
+    $ pulp-admin rpm repo create --repo-id=repo_2
+    Successfully created repository [repo_2]
+
+Now let's copy the langpacks from ``repo_1`` to ``repo_2``::
+
+    $ pulp-admin rpm repo copy langpacks --from-repo-id=repo_1 --to-repo-id=repo_2
+
+Observe that ``repo_2`` contains newly copied package langpacks::
+
+    $ pulp-admin repo list --repo-id repo_2
+
+    +----------------------------------------------------------------------+
+                                  Repositories
+    +----------------------------------------------------------------------+
+
+    Id:                   repo_2
+    Display Name:         None
+    Description:          None
+    Content Unit Counts:
+      Package Langpacks: 1
+
+Searching Package Langpacks
+---------------------------
+
+Package langpacks can be searched for within a specific repo. Assuming you've performed the
+steps from the `Copying Package Langpacks`_ section, let's search for the recently copied
+langpacks within ``repo_2``::
+
+    $ pulp-admin rpm repo content langpacks --repo-id repo_2
+
+Removing Package Langpacks
+--------------------------
+
+Package langpacks can be removed from a specific repo. Assuming you've performed the steps
+from the `Copying Package Langpacks`_ section, let's remove the recently copied langpacks
+within ``repo_2``::
+
+    $ pulp-admin rpm repo remove langpacks --repo-id repo_2 --str-eq repo_id=repo_2
+
+
 Comps
 =====
 
 .. _upload_comps_xml_file:
 
-Upload comps.xml file
----------------------
+Upload a comps.xml file
+-----------------------
 
 This is an example of creating a repo and uploading a comps.xml file into it.
 

--- a/docs/user-guide/release-notes/2.9.x.rst
+++ b/docs/user-guide/release-notes/2.9.x.rst
@@ -9,5 +9,8 @@ New Features
 ------------
 
 * Now it is possible to upload ``package_environment`` element via CLI and API.
-
 * Publication of the RPMs can now be done non-incrementally using ``--force-full`` option.
+* The <langpacks> tag in comps.xml are synced and published for repositories. These units are also
+  parsed on upload. ``pulp-admin`` also has upload, remove, and search support for 
+  package_langpacks.
+

--- a/extensions_admin/pulp_rpm/extensions/admin/contents.py
+++ b/extensions_admin/pulp_rpm/extensions/admin/contents.py
@@ -20,10 +20,12 @@ TYPE_DISTRIBUTION = 'distribution'
 TYPE_PACKAGE_GROUP = 'package_group'
 TYPE_PACKAGE_CATEGORY = 'package_category'
 TYPE_PACKAGE_ENVIRONMENT = 'package_environment'
+TYPE_PACKAGE_LANGPACKS = 'package_langpacks'
+
 
 # Intentionally does not include distributions; they should be looked up specifically
 ALL_TYPES = (TYPE_RPM, TYPE_SRPM, TYPE_DRPM, TYPE_ERRATUM, TYPE_PACKAGE_GROUP,
-             TYPE_PACKAGE_CATEGORY, TYPE_PACKAGE_ENVIRONMENT)
+             TYPE_PACKAGE_CATEGORY, TYPE_PACKAGE_ENVIRONMENT, TYPE_PACKAGE_LANGPACKS)
 
 # List of all fields that the user can elect to display for each supported type
 FIELDS_RPM = ('arch', 'buildhost', 'checksum', 'checksumtype', 'description',
@@ -35,6 +37,8 @@ FIELDS_PACKAGE_GROUP = ('id', 'name', 'description', 'mandatory_package_names',
                         'default_package_names', 'user_visible')
 FIELDS_PACKAGE_CATEGORY = ('id', 'name', 'description', 'packagegroupids')
 FIELDS_PACKAGE_ENVIRONMENT = ('id', 'name', 'description', 'group_ids', 'options')
+FIELDS_PACKAGE_LANGPACKS = ('matches', )
+
 
 # Used when generating the --fields help text so it can be customized by type
 FIELDS_BY_TYPE = {
@@ -44,7 +48,8 @@ FIELDS_BY_TYPE = {
     TYPE_ERRATUM: FIELDS_ERRATA,
     TYPE_PACKAGE_GROUP: FIELDS_PACKAGE_GROUP,
     TYPE_PACKAGE_CATEGORY: FIELDS_PACKAGE_CATEGORY,
-    TYPE_PACKAGE_ENVIRONMENT: FIELDS_PACKAGE_ENVIRONMENT
+    TYPE_PACKAGE_ENVIRONMENT: FIELDS_PACKAGE_ENVIRONMENT,
+    TYPE_PACKAGE_LANGPACKS: FIELDS_PACKAGE_LANGPACKS,
 }
 
 # Ordering of metadata fields in each type. Keep in mind these are the display
@@ -57,6 +62,7 @@ ORDER_PACKAGE_GROUP = ['id', 'name', 'description', 'default_package_names',
                        'conditional_package_names', 'user_visible']
 ORDER_PACKAGE_CATEGORY = ['id', 'name', 'description', 'packagegroupids']
 ORDER_PACKAGE_ENVIRONMENT = ['id', 'name', 'description', 'group_ids', 'options']
+ORDER_PACKAGE_LANGPACKS = ['matches']
 
 # Used to lookup the right order list based on type
 ORDER_BY_TYPE = {
@@ -67,6 +73,7 @@ ORDER_BY_TYPE = {
     TYPE_PACKAGE_GROUP: ORDER_PACKAGE_GROUP,
     TYPE_PACKAGE_CATEGORY: ORDER_PACKAGE_CATEGORY,
     TYPE_PACKAGE_ENVIRONMENT: ORDER_PACKAGE_ENVIRONMENT,
+    TYPE_PACKAGE_LANGPACKS: ORDER_PACKAGE_LANGPACKS,
 }
 
 REQUIRES_COMPARISON_TRANSLATIONS = {
@@ -119,6 +126,7 @@ DESC_GROUPS = _('search for package groups in a repository')
 DESC_CATEGORIES = _('search for package categories (groups of package groups) in a repository')
 DESC_ENVIRONMENTS = _('search for package environments (collections of package groups)'
                       'in a repository')
+DESC_LANGPACKS = _('search for package langpacks in a repository')
 DESC_DISTRIBUTIONS = _('list distributions in a repository')
 DESC_ERRATA = _('search errata in a repository')
 DESC_YUM_METADATA_FILE = _('search for Yum Metadata Files in a repository')
@@ -163,7 +171,7 @@ class BaseSearchCommand(DisplayUnitAssociationsCommand):
             units = [u[ASSOCIATION_METADATA_KEYWORD] for u in units]
 
         # Some items either override output function and are not included
-        # in the FIELDS_BY_TYPE dictionary.  Check so tha they can
+        # in the FIELDS_BY_TYPE dictionary. Check so that they can
         # override the default behavior
         if len(type_ids) == 1 and FIELDS_BY_TYPE.get(type_ids[0]):
             out_func(units, FIELDS_BY_TYPE[type_ids[0]])
@@ -315,6 +323,16 @@ class SearchPackageEnvironmentsCommand(BaseSearchCommand):
 
     def package_environment(self, **kwargs):
         self.run_search([TYPE_PACKAGE_ENVIRONMENT], **kwargs)
+
+
+class SearchPackageLangpacksCommand(BaseSearchCommand):
+    def __init__(self, context):
+        super(SearchPackageLangpacksCommand, self).__init__(self.package_langpacks, context,
+                                                            name='langpacks',
+                                                            description=DESC_LANGPACKS)
+
+    def package_langpacks(self, **kwargs):
+        self.run_search([TYPE_PACKAGE_LANGPACKS], **kwargs)
 
 
 class SearchYumMetadataFileCommand(BaseSearchCommand):

--- a/extensions_admin/pulp_rpm/extensions/admin/copy_commands.py
+++ b/extensions_admin/pulp_rpm/extensions/admin/copy_commands.py
@@ -7,9 +7,8 @@ from pulp_rpm.extensions.admin import units_display, criteria_utils
 from pulp_rpm.common.constants import DISPLAY_UNITS_THRESHOLD, CONFIG_RECURSIVE
 from pulp_rpm.common.ids import (TYPE_ID_RPM, TYPE_ID_SRPM, TYPE_ID_DRPM, TYPE_ID_ERRATA,
                                  TYPE_ID_DISTRO, TYPE_ID_PKG_GROUP, TYPE_ID_PKG_CATEGORY,
-                                 TYPE_ID_PKG_ENVIRONMENT, TYPE_ID_YUM_REPO_METADATA_FILE,
-                                 UNIT_KEY_RPM)
-
+                                 TYPE_ID_PKG_ENVIRONMENT, TYPE_ID_PKG_LANGPACKS,
+                                 TYPE_ID_YUM_REPO_METADATA_FILE, UNIT_KEY_RPM)
 
 # -- constants ----------------------------------------------------------------
 
@@ -21,6 +20,7 @@ DESC_DISTRIBUTION = _('copy distributions from one repository to another')
 DESC_PKG_GROUP = _('copy package groups from one repository to another')
 DESC_PKG_CATEGORY = _('copy package categories from one repository to another')
 DESC_PKG_ENVIRONMENT = _('copy package environment from one repository to another')
+DESC_PKG_LANGPACKS = _('copy package langpacks from one repository to another')
 DESC_METAFILE = _('copy yum repo metadata files from one repository to another')
 DESC_ALL = _('copy all content units from one repository to another')
 
@@ -137,6 +137,12 @@ class PackageEnvironmentCopyCommand(RecursiveCopyCommand):
     def __init__(self, context):
         RecursiveCopyCommand.__init__(self, context, 'environment', DESC_PKG_ENVIRONMENT,
                                       TYPE_ID_PKG_ENVIRONMENT)
+
+
+class PackageLangpacksCopyCommand(RecursiveCopyCommand):
+    def __init__(self, context):
+        RecursiveCopyCommand.__init__(self, context, 'langpacks', DESC_PKG_LANGPACKS,
+                                      TYPE_ID_PKG_LANGPACKS)
 
 
 class YumRepoMetadataFileCommand(NonRecursiveCopyCommand):

--- a/extensions_admin/pulp_rpm/extensions/admin/remove.py
+++ b/extensions_admin/pulp_rpm/extensions/admin/remove.py
@@ -7,7 +7,7 @@ from pulp_rpm.common.constants import DISPLAY_UNITS_THRESHOLD
 from pulp_rpm.common.ids import (TYPE_ID_RPM, TYPE_ID_SRPM, TYPE_ID_DRPM,
                                  TYPE_ID_ERRATA, TYPE_ID_PKG_GROUP, TYPE_ID_PKG_ENVIRONMENT,
                                  TYPE_ID_PKG_CATEGORY, TYPE_ID_DISTRO, UNIT_KEY_RPM,
-                                 TYPE_ID_YUM_REPO_METADATA_FILE)
+                                 TYPE_ID_YUM_REPO_METADATA_FILE, TYPE_ID_PKG_LANGPACKS)
 
 DESC_RPM = _('remove RPMs from a repository')
 DESC_SRPM = _('remove SRPMs from a repository')
@@ -16,6 +16,7 @@ DESC_ERRATA = _('remove errata from a repository')
 DESC_GROUP = _('remove package groups from a repository')
 DESC_CATEGORY = _('remove package categories from a repository')
 DESC_ENVIRONMENT = _('remove package environments from a repository')
+DESC_LANGPACKS = _('remove package langpacks from a repository')
 DESC_DISTRIBUTION = _('remove distributions from a repository')
 DESC_METAFILE = _('remove yum metadata files from a repository')
 
@@ -101,6 +102,13 @@ class PackageEnvironmentRemoveCommand(BaseRemoveCommand):
         super(PackageEnvironmentRemoveCommand, self).__init__(context, 'environment',
                                                               DESC_ENVIRONMENT,
                                                               TYPE_ID_PKG_ENVIRONMENT)
+
+
+class PackageLangpacksRemoveCommand(BaseRemoveCommand):
+    def __init__(self, context):
+        super(PackageLangpacksRemoveCommand, self).__init__(context, 'langpacks',
+                                                            DESC_LANGPACKS,
+                                                            TYPE_ID_PKG_LANGPACKS)
 
 
 class DistributionRemoveCommand(BaseRemoveCommand):

--- a/extensions_admin/pulp_rpm/extensions/admin/rpm_repo/pulp_cli.py
+++ b/extensions_admin/pulp_rpm/extensions/admin/rpm_repo/pulp_cli.py
@@ -11,7 +11,7 @@ from pulp_rpm.extensions.admin import structure
 from pulp_rpm.extensions.admin.upload import package
 from pulp_rpm.extensions.admin import (contents, copy_commands, export, remove, repo_create_update,
                                        repo_list, status, sync_schedules)
-from pulp_rpm.extensions.admin.upload import (category, comps, environment, errata)
+from pulp_rpm.extensions.admin.upload import (category, comps, environment, errata, langpacks)
 from pulp_rpm.extensions.admin.upload import group as package_group
 
 
@@ -37,6 +37,7 @@ def initialize(context):
     copy_section.add_command(copy_commands.PackageGroupCopyCommand(context))
     copy_section.add_command(copy_commands.PackageCategoryCopyCommand(context))
     copy_section.add_command(copy_commands.PackageEnvironmentCopyCommand(context))
+    copy_section.add_command(copy_commands.PackageLangpacksCopyCommand(context))
     copy_section.add_command(copy_commands.AllCopyCommand(context))
     copy_section.add_command(copy_commands.SrpmCopyCommand(context))
     copy_section.add_command(copy_commands.YumRepoMetadataFileCommand(context))
@@ -54,6 +55,7 @@ def initialize(context):
     remove_section.add_command(remove.PackageGroupRemoveCommand(context))
     remove_section.add_command(remove.PackageCategoryRemoveCommand(context))
     remove_section.add_command(remove.PackageEnvironmentRemoveCommand(context))
+    remove_section.add_command(remove.PackageLangpacksRemoveCommand(context))
     remove_section.add_command(remove.DistributionRemoveCommand(context))
     remove_section.add_command(remove.YumMetadataFileRemoveCommand(context))
 
@@ -64,6 +66,7 @@ def initialize(context):
     contents_section.add_command(contents.SearchPackageGroupsCommand(context))
     contents_section.add_command(contents.SearchPackageCategoriesCommand(context))
     contents_section.add_command(contents.SearchPackageEnvironmentsCommand(context))
+    contents_section.add_command(contents.SearchPackageLangpacksCommand(context))
     contents_section.add_command(contents.SearchDistributionsCommand(context))
     contents_section.add_command(contents.SearchErrataCommand(context))
     contents_section.add_command(contents.SearchYumMetadataFileCommand(context))
@@ -83,6 +86,7 @@ def initialize(context):
     uploads_section.add_command(comps.CreateCompsCommand(context, upload_manager))
     uploads_section.add_command(
         environment.CreatePackageEnvironmentCommand(context, upload_manager))
+    uploads_section.add_command(langpacks.CreatePackageLangpacksCommand(context, upload_manager))
     uploads_section.add_command(upload.ResumeCommand(context, upload_manager))
     uploads_section.add_command(upload.CancelCommand(context, upload_manager))
     uploads_section.add_command(upload.ListCommand(context, upload_manager))

--- a/extensions_admin/pulp_rpm/extensions/admin/units_display.py
+++ b/extensions_admin/pulp_rpm/extensions/admin/units_display.py
@@ -1,6 +1,7 @@
 from pulp_rpm.common.ids import (TYPE_ID_RPM, TYPE_ID_SRPM, TYPE_ID_DRPM, TYPE_ID_ERRATA,
                                  TYPE_ID_DISTRO, TYPE_ID_PKG_GROUP, TYPE_ID_PKG_CATEGORY,
-                                 TYPE_ID_PKG_ENVIRONMENT, TYPE_ID_YUM_REPO_METADATA_FILE)
+                                 TYPE_ID_PKG_ENVIRONMENT, TYPE_ID_PKG_LANGPACKS,
+                                 TYPE_ID_YUM_REPO_METADATA_FILE)
 
 
 def get_formatter_for_type(type_id):
@@ -20,6 +21,7 @@ def get_formatter_for_type(type_id):
         TYPE_ID_PKG_GROUP: lambda x: x.get('id'),
         TYPE_ID_PKG_CATEGORY: lambda x: x.get('id'),
         TYPE_ID_PKG_ENVIRONMENT: lambda x: x.get('id'),
+        TYPE_ID_PKG_LANGPACKS: lambda x: x.get('repo_id'),
         TYPE_ID_YUM_REPO_METADATA_FILE: _yum_repo_metadata_name_only,
     }
     return type_formatters[type_id]

--- a/extensions_admin/pulp_rpm/extensions/admin/upload/langpacks.py
+++ b/extensions_admin/pulp_rpm/extensions/admin/upload/langpacks.py
@@ -1,0 +1,108 @@
+from gettext import gettext as _
+
+from pulp.client.commands.options import OPTION_REPO_ID
+from pulp.client.commands.repo.upload import MetadataException, UploadCommand
+from pulp.client.extensions.extensions import PulpCliOption
+
+from pulp_rpm.common.ids import TYPE_ID_PKG_LANGPACKS
+
+
+NAME = 'langpacks'
+DESC = _('creates a new package langpacks')
+
+d = _('name field to include in the package langpacks; must be specified with the '
+      '`install` option. multiple may be indicated by specifying the argument '
+      'multiple times. Coresponds with a single `install` field sequentially in order given')
+OPT_NAME = PulpCliOption('--name', d, aliases=['-n'], allow_multiple=True, required=True)
+
+d = _('install field to include in the package langpacks; must be specified with the '
+      '`name` option. multiple may be indicated by specifying the argument '
+      'multiple times. Coresponds with a single `name` field sequentially in order given.')
+OPT_INSTALL = PulpCliOption('--install', d, aliases=['-i'], allow_multiple=True, required=True)
+
+
+class CreatePackageLangpacksCommand(UploadCommand):
+    """
+    Handles the creation of a package langpacks.
+    """
+
+    def __init__(self, context, upload_manager, name=NAME, description=DESC):
+        super(CreatePackageLangpacksCommand, self).__init__(context, upload_manager, name,
+                                                            description, upload_files=False)
+        """
+        :param context: Pulp client context
+        :type  context: pulp.client.extensions.core.ClientContext
+        :param upload_manager: created and configured upload manager instance
+        :type  upload_manager: pulp.client.upload.manager.UploadManager
+        :param name: The name of the command
+        :type  name: str
+        :param description: The description of the command
+        :type  description: str
+        :param upload_files: if false, the user will not be prompted for files
+               to upload and the create will be purely metadata based
+        :type  upload_files: bool
+        """
+
+        self.add_option(OPT_NAME)
+        self.add_option(OPT_INSTALL)
+
+    def determine_type_id(self, filename, **kwargs):
+        """
+        Returns the ID of the type of file being uploaded.
+
+        :param filename: full path to the file being uploaded
+        :type  filename: str
+        :param kwargs: arguments passed into the upload call by the user
+        :type  kwargs: dict
+
+        :return: ID of the type of file being uploaded
+        :rtype:  str
+        """
+
+        return TYPE_ID_PKG_LANGPACKS
+
+    def generate_unit_key(self, filename, **kwargs):
+        """
+        For the given file, returns the unit key that should be specified in
+        the upload request.
+
+        :param filename: full path to the file being uploaded
+        :type  filename: str, None
+        :param kwargs: arguments passed into the upload call by the user
+        :type  kwargs: dict
+
+        :return: unit key that should be uploaded for the file
+        :rtype:  dict
+        """
+
+        repo_id = kwargs[OPTION_REPO_ID.keyword]
+        return {'repo_id': repo_id}
+
+    def generate_metadata(self, filename, **kwargs):
+        """
+        For the given file, returns a list of metadata that should be included
+        as part of the upload request.
+
+        :param filename: full path to the file being uploaded
+        :type  filename: str, None
+        :param kwargs: arguments passed into the upload call by the user
+        :type  kwargs: dict
+
+        :return: metadata information that should be uploaded for the file
+        :rtype:  dict
+        """
+        names = kwargs[OPT_NAME.keyword]
+        installs = kwargs[OPT_INSTALL.keyword]
+
+        if len(names) != len(installs):
+            msg = _('Package Langpacks requires equal number `name` and `install` arguments.')
+            raise MetadataException(msg)
+
+        metadata = {
+            'matches': []
+        }
+
+        for name, install in zip(names, installs):
+            metadata['matches'].append({'name': name, 'install': install})
+
+        return metadata

--- a/plugins/pulp_rpm/plugins/db/models.py
+++ b/plugins/pulp_rpm/plugins/db/models.py
@@ -767,6 +767,24 @@ class PackageEnvironment(UnitMixin, ContentUnit):
         return [d.get('group') for d in self.options]
 
 
+class PackageLangpacks(UnitMixin, ContentUnit):
+    # TODO add docstring to this class
+    repo_id = mongoengine.StringField(required=True)
+    matches = mongoengine.ListField()
+
+    # For backward compatibility
+    _ns = mongoengine.StringField(default='units_package_langpacks')
+    _content_type_id = mongoengine.StringField(required=True, default='package_langpacks')
+
+    unit_key_fields = ('repo_id',)
+
+    meta = {
+        'collection': 'units_package_langpacks',
+        'allow_inheritance': False}
+
+    SERIALIZER = serializers.PackageLangpacks
+
+
 class YumMetadataFile(UnitMixin, FileContentUnit):
     # TODO add docstring to this class
     data_type = mongoengine.StringField(required=True)

--- a/plugins/pulp_rpm/plugins/distributors/yum/metadata/package.py
+++ b/plugins/pulp_rpm/plugins/distributors/yum/metadata/package.py
@@ -145,7 +145,7 @@ class PackageXMLFileContext(MetadataFileContext):
 
         :param unit: The environment group to publish
         :type unit: pulp_rpm.plugins.db.models.PackageEnvironment
-       """
+        """
         environment_element = ElementTree.Element('environment')
 
         ElementTree.SubElement(environment_element, 'id').text = unit.package_environment_id
@@ -175,3 +175,19 @@ class PackageXMLFileContext(MetadataFileContext):
         environment_element_string = ElementTree.tostring(environment_element, encoding='utf-8')
         _LOG.debug('Writing package_environment unit metadata:\n' + environment_element_string)
         self.metadata_file_handle.write(environment_element_string)
+
+    def add_package_langpacks_unit_metadata(self, unit):
+        """
+        Write out the XML representation of a PackageLangpacks unit
+
+        :param unit: The langpacks unit to publish
+        :type unit: pulp_rpm.plugins.db.models.PackageLangpacks
+       """
+        langpacks_element = ElementTree.Element('langpacks')
+        for match_dict in unit.matches:
+            ElementTree.SubElement(langpacks_element, 'match', match_dict)
+
+        # Write out the langpacks xml to the file
+        langpacks_element_string = ElementTree.tostring(langpacks_element, encoding='utf-8')
+        _LOG.debug('Writing package_langpacks unit metadata:\n' + langpacks_element_string)
+        self.metadata_file_handle.write(langpacks_element_string)

--- a/plugins/pulp_rpm/plugins/distributors/yum/publish.py
+++ b/plugins/pulp_rpm/plugins/distributors/yum/publish.py
@@ -668,7 +668,7 @@ class PublishCompsStep(platform_steps.UnitModelPluginStep):
     def __init__(self):
         super(PublishCompsStep, self).__init__(constants.PUBLISH_COMPS_STEP,
                                                [models.PackageGroup, models.PackageCategory,
-                                                models.PackageEnvironment])
+                                                models.PackageEnvironment, models.PackageLangpacks])
         self.comps_context = None
         self.description = _('Publishing Comps file')
 
@@ -683,6 +683,8 @@ class PublishCompsStep(platform_steps.UnitModelPluginStep):
             self.comps_context.add_package_environment_unit_metadata(item)
         elif isinstance(item, models.PackageGroup):
             self.comps_context.add_package_group_unit_metadata(item)
+        elif isinstance(item, models.PackageLangpacks):
+            self.comps_context.add_package_langpacks_unit_metadata(item)
         else:
             logger.warning(_('Unknown comps unit type: %(n)s') % {'n': item.__class__})
 

--- a/plugins/pulp_rpm/plugins/importers/yum/associate.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/associate.py
@@ -324,7 +324,13 @@ def _associate_unit(dest_repo, unit):
     :return:                copied unit
     :rtype:                 pulp.server.db.model.ContentUnit
     """
-    if isinstance(unit, (models.PackageGroup, models.PackageCategory, models.PackageEnvironment)):
+    types_to_be_copied = (
+        models.PackageGroup,
+        models.PackageCategory,
+        models.PackageEnvironment,
+        models.PackageLangpacks
+    )
+    if isinstance(unit, types_to_be_copied):
         return associate_copy_for_repo(unit, dest_repo)
     elif isinstance(unit, models.RPM):
         # copy will happen in one batch

--- a/plugins/pulp_rpm/plugins/importers/yum/importer.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/importer.py
@@ -42,7 +42,8 @@ class YumImporter(Importer):
                 models.RPM._content_type_id.default,
                 models.SRPM._content_type_id.default,
                 models.YumMetadataFile._content_type_id.default,
-                models.PackageEnvironment._content_type_id.default
+                models.PackageEnvironment._content_type_id.default,
+                models.PackageLangpacks._content_type_id.default,
             ]
         }
 

--- a/plugins/pulp_rpm/plugins/importers/yum/repomd/group.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/repomd/group.py
@@ -10,6 +10,7 @@ _LOGGER = logging.getLogger(__name__)
 GROUP_TAG = 'group'
 CATEGORY_TAG = 'category'
 ENVIRONMENT_TAG = 'environment'
+LANGPACKS_TAG = 'langpacks'
 # this according to yum.comps.lang_attr
 LANGUAGE_TAG = '{http://www.w3.org/XML/1998/namespace}lang'
 
@@ -126,6 +127,27 @@ def process_environment_element(repo_id, element):
     unit.translated_description = translated_description
     unit.translated_name = translated_name
     unit.options = options
+    return unit
+
+
+def process_langpacks_element(repo_id, element):
+    """
+    Process one XML block from comps.xml and return a models.PackageLangpacks instance
+
+    :param repo_id: unique ID for the destination repository
+    :type  repo_id  basestring
+    :param element: object representing one "PackageLangpacks" block from the XML file
+    :type  element: xml.etree.ElementTree.Element
+
+    :return:    models.PackageLangpacks instance for the XML block
+    :rtype:     pulp_rpm.plugins.db.models.PackageLangpacks
+    """
+    unit = models.PackageLangpacks()
+    unit.repo_id = repo_id
+
+    for match in element.findall('match'):
+        unit.matches.append({'install': match.get('install'), 'name': match.get('name')})
+
     return unit
 
 

--- a/plugins/pulp_rpm/plugins/importers/yum/sync.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/sync.py
@@ -239,6 +239,8 @@ class RepoSync(object):
                                                   group.CATEGORY_TAG)
                         self.get_comps_file_units(metadata_files, group.process_environment_element,
                                                   group.ENVIRONMENT_TAG)
+                        self.get_comps_file_units(metadata_files, group.process_langpacks_element,
+                                                  group.LANGPACKS_TAG)
 
                 with self.update_state(self.progress_report['purge_duplicates']) as skip:
                     if not (skip or self.skip_repomd_steps):

--- a/plugins/pulp_rpm/plugins/importers/yum/upload.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/upload.py
@@ -108,6 +108,7 @@ def upload(repo, type_id, unit_key, metadata, file_path, conduit, config):
         models.PackageGroup._content_type_id.default: _handle_group_category_comps,
         models.PackageCategory._content_type_id.default: _handle_group_category_comps,
         models.PackageEnvironment._content_type_id.default: _handle_group_category_comps,
+        models.PackageLangpacks._content_type_id.default: _handle_group_category_comps,
         models.Errata._content_type_id.default: _handle_erratum,
         models.YumMetadataFile._content_type_id.default: _handle_yum_metadata_file,
     }
@@ -267,6 +268,8 @@ def _handle_group_category_comps(repo, type_id, unit_key, metadata, file_path, c
                                  group.CATEGORY_TAG, conduit, repo)
         _get_and_save_file_units(file_path, group.process_environment_element,
                                  group.ENVIRONMENT_TAG, conduit, repo)
+        _get_and_save_file_units(file_path, group.process_langpacks_element,
+                                 group.LANGPACKS_TAG, conduit, repo)
     else:
         # uploading a package group, package category or package environment
         unit_data = {}

--- a/plugins/pulp_rpm/plugins/serializers.py
+++ b/plugins/pulp_rpm/plugins/serializers.py
@@ -58,6 +58,14 @@ class PackageEnvironment(platform_serializers.ModelSerializer):
         remapped_fields = {'package_environment_id': 'id'}
 
 
+class PackageLangpacks(platform_serializers.ModelSerializer):
+    """
+    Serializer for a PackageLangpacks models
+    """
+    class Meta:
+        remapped_fields = {}
+
+
 class YumMetadataFile(platform_serializers.ModelSerializer):
     """
     Serializer for a YumMetadataFile models

--- a/plugins/setup.py
+++ b/plugins/setup.py
@@ -43,6 +43,7 @@ setup(
             'package_group=pulp_rpm.plugins.db.models:PackageGroup',
             'package_category=pulp_rpm.plugins.db.models:PackageCategory',
             'package_environment=pulp_rpm.plugins.db.models:PackageEnvironment',
+            'package_langpacks=pulp_rpm.plugins.db.models:PackageLangpacks',
             'yum_repo_metadata_file=pulp_rpm.plugins.db.models:YumMetadataFile',
             'iso=pulp_rpm.plugins.db.models:ISO'
         ]


### PR DESCRIPTION
- PackageLangpacks model is done
- yum importer is extended to parse and save PackageLangpacks
- yum distributor is extended to write out PackageLangpacks
- adds create, copy, search, and remove capabilities for pulp-admin
- upload as part of a comps.xml upload via pulp-admin also works
- documentation for create, copy, search, and remove added to recipes
- release note added

I also fixed a few small, existing docs errors on the recipes page.

I want pulp-smash to do the actual upload/sync/publish testing, but that is blocked currently on the availability of `<langpacks>` tags in the demo repos on fedorapeople. As such, you should manually sync from a [repo that contains langpacks](https://pulp.plan.io/issues/1367#note-14) and verify that when published it is included in the published comps.xml file.

https://pulp.plan.io/issues/1367
closes #1367