### PR TITLE
removed DRPMListener, which was redundant

### DIFF
--- a/plugins/pulp_rpm/plugins/importers/yum/listener.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/listener.py
@@ -184,23 +184,3 @@ class RPMListener(PackageListener):
             if not added_unit.downloaded:
                 added_unit.downloaded = True
                 added_unit.save()
-
-
-class DRPMListener(PackageListener):
-    """
-    The Delta RPM package download lister.
-    """
-
-    def download_succeeded(self, report):
-        with util.deleting(report.destination):
-            unit = report.data
-            try:
-                super(DRPMListener, self).download_succeeded(report)
-            except (verification.VerificationException, verification.InvalidChecksumType):
-                # verification failed, unit not added
-                return
-            added_unit = self.sync.add_drpm_unit(self.metadata_files, unit)
-            added_unit.safe_import_content(report.destination)
-            if not added_unit.downloaded:
-                added_unit.downloaded = True
-                added_unit.save()

--- a/plugins/pulp_rpm/plugins/importers/yum/sync.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/sync.py
@@ -27,7 +27,7 @@ from pulp_rpm.common import constants, ids
 from pulp_rpm.plugins import error_codes
 from pulp_rpm.plugins.db import models
 from pulp_rpm.plugins.importers.yum import existing, purge
-from pulp_rpm.plugins.importers.yum.listener import RPMListener, DRPMListener
+from pulp_rpm.plugins.importers.yum.listener import RPMListener
 from pulp_rpm.plugins.importers.yum.parse.treeinfo import DistSync
 from pulp_rpm.plugins.importers.yum.repomd import (
     alternate, group, metadata, nectar_factory, packages, presto, primary, updateinfo)
@@ -636,9 +636,6 @@ class RepoSync(object):
         self.conduit.set_progress(self.progress_report)
         return unit
 
-    # added for clarity
-    add_drpm_unit = add_rpm_unit
-
     def download_rpms(self, metadata_files, rpms_to_download, url):
         """
         Actually download the requested RPMs. This method iterates over
@@ -709,7 +706,7 @@ class RepoSync(object):
         :param url: current URL we should sync
         :type: str
         """
-        event_listener = DRPMListener(self, metadata_files)
+        event_listener = RPMListener(self, metadata_files)
 
         for presto_file_name in presto.METADATA_FILE_NAMES:
             presto_file_handle = metadata_files.get_metadata_file_handle(presto_file_name)
@@ -730,7 +727,7 @@ class RepoSync(object):
                     if self.download_deferred:
                         for unit in units_to_download:
                             unit.downloaded = False
-                            self.add_drpm_unit(metadata_files, unit)
+                            self.add_rpm_unit(metadata_files, unit)
                         continue
 
                     download_wrapper = packages.Packages(

--- a/plugins/test/unit/plugins/importers/yum/test_listener.py
+++ b/plugins/test/unit/plugins/importers/yum/test_listener.py
@@ -57,54 +57,6 @@ class TestRPMListenerDownloadSucceeded(unittest.TestCase):
         self.assertEqual(added_unit.save.call_count, 0)
 
 
-class TestDRPMListenerDownloadSucceeded(unittest.TestCase):
-    def setUp(self):
-        self.mock_sync = mock.MagicMock()
-        # this causes validation to be skipped
-        self.mock_sync.config.get.return_value = False
-        self.mock_metadata_files = mock.MagicMock()
-        self.listener = listener.DRPMListener(self.mock_sync, self.mock_metadata_files)
-        self.report = DownloadReport('http://pulpproject.org', '/a/b/c')
-
-    @mock.patch('pulp.server.util.deleting')
-    def test_calls_deleting(self, mock_deleting):
-        unit = mock.MagicMock()
-        self.report.data = unit
-
-        self.listener.download_succeeded(self.report)
-
-        # it was called correctly
-        mock_deleting.assert_called_once_with('/a/b/c')
-        # it was used as a context manager
-        self.assertEqual(mock_deleting.return_value.__exit__.call_count, 1)
-
-    def test_change_download_flag(self):
-        unit = mock.MagicMock()
-        self.report.data = unit
-        added_unit = mock.MagicMock()
-        added_unit.downloaded = False
-        self.mock_sync.add_drpm_unit.return_value = added_unit
-
-        self.listener.download_succeeded(self.report)
-
-        # test flag changed to True and save was called
-        self.assertEqual(added_unit.downloaded, True)
-        self.assertEqual(added_unit.save.call_count, 1)
-
-    def test_save_not_called(self):
-        unit = mock.MagicMock()
-        self.report.data = unit
-        added_unit = mock.MagicMock()
-        added_unit.downloaded = True
-        self.mock_sync.add_drpm_unit.return_value = added_unit
-
-        self.listener.download_succeeded(self.report)
-
-        # test flag is still set to True but save was not called
-        self.assertEqual(added_unit.downloaded, True)
-        self.assertEqual(added_unit.save.call_count, 0)
-
-
 class TestPackageListener(unittest.TestCase):
     def setUp(self):
         self.test_rpm_path = os.path.join(os.path.dirname(__file__),


### PR DESCRIPTION
The class was identical in every way to the RPMListener, except it called
sync.add_drpm instead of sync.add_rpm. As it turns out, sync.add_drpm was
just a direct reference to sync.add_rpm, so the two classes were 100%
equivalent.