### PR TITLE
Add catalog entries when units already exist.

### DIFF
--- a/plugins/pulp_rpm/plugins/importers/iso/sync.py
+++ b/plugins/pulp_rpm/plugins/importers/iso/sync.py
@@ -217,7 +217,7 @@ class ISOSyncRun(listener.DownloadEventListener):
             self.sync_conduit.associate_existing(models.ISO._content_type_id.default, search_dicts)
 
         # Deferred downloading (Lazy) entries.
-        self.add_catalog_entries(local_missing_isos)
+        self.add_catalog_entries(local_available_isos)
 
         self.progress_report.state = self.progress_report.STATE_ISOS_IN_PROGRESS
 
@@ -229,8 +229,8 @@ class ISOSyncRun(listener.DownloadEventListener):
                     iso.save()
                 except NotUniqueError:
                     iso = iso.__class__.objects.filter(**iso.unit_key).first()
+                self.add_catalog_entries([iso])
                 repo_controller.associate_single_unit(self.sync_conduit.repo, iso)
-
         else:
             self._download_isos(local_missing_isos)
 

--- a/plugins/pulp_rpm/plugins/importers/yum/existing.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/existing.py
@@ -89,7 +89,7 @@ def get_existing_units(search_dicts, unit_class, repo):
             yield result
 
 
-def check_all_and_associate(wanted, conduit, download_deferred):
+def check_all_and_associate(wanted, conduit, download_deferred, catalog):
     """
     Given a set of unit keys as namedtuples, this function checks if a unit
     already exists in Pulp and returns the set of tuples that were not
@@ -104,6 +104,8 @@ def check_all_and_associate(wanted, conduit, download_deferred):
     :type  conduit:           pulp.plugins.conduits.repo_sync.RepoSync
     :param download_deferred: indicates downloading is deferred (or not).
     :type  download_deferred: bool
+    :param catalog:           Deferred downloading catalog.
+    :type  catalog:           pulp_rpm.plugins.importers.yum.sync.PackageCatalog
 
     :return:    set of unit keys as namedtuples, identifying which of the
                 named tuples received as input were not found on the server.
@@ -122,6 +124,7 @@ def check_all_and_associate(wanted, conduit, download_deferred):
                     ids.TYPE_ID_RPM, ids.TYPE_ID_SRPM, ids.TYPE_ID_DRPM):
                 if unit._storage_path is None or not os.path.isfile(unit._storage_path):
                     continue
+            catalog.add(unit)
             repo_controller.associate_single_unit(conduit.repo, unit)
             values.discard(unit.unit_key_as_named_tuple)
     still_wanted = set()

--- a/plugins/pulp_rpm/plugins/importers/yum/sync.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/sync.py
@@ -456,14 +456,15 @@ class RepoSync(object):
         :param url: curret URL we should sync
         :type: str
         """
-        rpms_to_download, drpms_to_download = self._decide_what_to_download(metadata_files)
+        catalog = PackageCatalog(self.conduit.importer_object_id, url)
+        rpms_to_download, drpms_to_download = self._decide_what_to_download(metadata_files, catalog)
         self.download_rpms(metadata_files, rpms_to_download, url)
         self.download_drpms(metadata_files, drpms_to_download, url)
         self.conduit.build_success_report({}, {})
         # removes unwanted units according to the config settings
         purge.purge_unwanted_units(metadata_files, self.conduit, self.config)
 
-    def _decide_what_to_download(self, metadata_files):
+    def _decide_what_to_download(self, metadata_files, catalog):
         """
         Given the metadata files, decides which RPMs and DRPMs should be
         downloaded. Also sets initial values on the progress report for total
@@ -471,15 +472,17 @@ class RepoSync(object):
 
         :param metadata_files:  instance of MetadataFiles
         :type  metadata_files:  pulp_rpm.plugins.importers.yum.repomd.metadata.MetadataFiles
+        :param catalog:         Deferred downloading catalog.
+        :type  catalog:         PackageCatalog
 
         :return:    tuple of (set(RPM.NAMEDTUPLEs), set(DRPM.NAMEDTUPLEs))
         :rtype:     tuple
         """
         _logger.info(_('Determining which units need to be downloaded.'))
         rpms_to_download, rpms_count, rpms_total_size = \
-            self._decide_rpms_to_download(metadata_files)
+            self._decide_rpms_to_download(metadata_files, catalog)
         drpms_to_download, drpms_count, drpms_total_size = \
-            self._decide_drpms_to_download(metadata_files)
+            self._decide_drpms_to_download(metadata_files, catalog)
 
         unit_counts = {
             'rpm': rpms_count,
@@ -490,13 +493,15 @@ class RepoSync(object):
         self.set_progress()
         return rpms_to_download, drpms_to_download
 
-    def _decide_rpms_to_download(self, metadata_files):
+    def _decide_rpms_to_download(self, metadata_files, catalog):
         """
         Decide which RPMs should be downloaded based on the repo metadata and on
         the importer config.
 
         :param metadata_files:  instance of MetadataFiles
         :type  metadata_files:  pulp_rpm.plugins.importers.yum.repomd.metadata.MetadataFiles
+        :param catalog:         Deferred downloading catalog.
+        :type  catalog:         PackageCatalog
 
         :return:    tuple of (set(RPM.NAMEDTUPLEs), number of RPMs, total size in bytes)
         :rtype:     tuple
@@ -513,7 +518,7 @@ class RepoSync(object):
             # check for the units that are not in the repo, but exist on the server
             # and associate them to the repo
             to_download = existing.check_all_and_associate(
-                wanted.iterkeys(), self.conduit, self.download_deferred)
+                wanted.iterkeys(), self.conduit, self.download_deferred, catalog)
             count = len(to_download)
             size = 0
             for unit in to_download:
@@ -522,13 +527,15 @@ class RepoSync(object):
         finally:
             primary_file_handle.close()
 
-    def _decide_drpms_to_download(self, metadata_files):
+    def _decide_drpms_to_download(self, metadata_files, catalog):
         """
         Decide which DRPMs should be downloaded based on the repo metadata and on
         the importer config.
 
         :param metadata_files:  instance of MetadataFiles
         :type  metadata_files:  pulp_rpm.plugins.importers.yum.repomd.metadata.MetadataFiles
+        :param catalog:         Deferred downloading catalog.
+        :type  catalog:         PackageCatalog
 
         :return:    tuple of (set(DRPM.NAMEDTUPLEs), number of DRPMs, total size in bytes)
         :rtype:     tuple
@@ -555,7 +562,7 @@ class RepoSync(object):
                     # check for the units that are not in the repo, but exist on the server
                     # and associate them to the repo
                     to_download = existing.check_all_and_associate(
-                        wanted.iterkeys(), self.conduit, self.download_deferred)
+                        wanted.iterkeys(), self.conduit, self.download_deferred, catalog)
                     count += len(to_download)
                     for unit in to_download:
                         size += wanted[unit]
@@ -563,30 +570,6 @@ class RepoSync(object):
                     presto_file_handle.close()
 
         return to_download, count, size
-
-    def catalog_generator(self, base_url, units):
-        """
-        Provides a wrapper around the *units* generator.
-        As the generator is iterated, the deferred downloading (lazy) catalog entry is added.
-
-        :param base_url: The base download URL.
-        :type base_url: str
-        :param units: A generator of (rpm|drpm) units.
-        :return: A generator of units.
-        :rtype: generator
-        """
-        for unit in units:
-            unit.set_storage_path(unit.filename)
-            entry = LazyCatalogEntry()
-            entry.path = unit.storage_path
-            entry.importer_id = str(self.conduit.importer_object_id)
-            entry.unit_id = unit.id
-            entry.unit_type_id = unit.type_id
-            entry.url = urljoin(base_url, unit.download_path)
-            entry.checksum = unit.checksum
-            entry.checksum_algorithm = unit.checksumtype
-            entry.save_revision()
-            yield unit
 
     def add_rpm_unit(self, metadata_files, unit):
         """
@@ -642,14 +625,12 @@ class RepoSync(object):
             units_to_download = self._filtered_unit_generator(package_model_generator,
                                                               rpms_to_download)
 
-            # Wrapped in a generator that adds entries to
-            # the deferred (Lazy) catalog.
-            units_to_download = self.catalog_generator(url, units_to_download)
-
             if self.download_deferred:
+                catalog = PackageCatalog(self.conduit.importer_object_id, url)
                 for unit in units_to_download:
                     unit.downloaded = False
-                    self.add_rpm_unit(metadata_files, unit)
+                    unit = self.add_rpm_unit(metadata_files, unit)
+                    catalog.add(unit)
                 return
 
             download_wrapper = alternate.Packages(
@@ -699,14 +680,12 @@ class RepoSync(object):
                     units_to_download = self._filtered_unit_generator(package_model_generator,
                                                                       drpms_to_download)
 
-                    # Wrapped in a generator that adds entries to
-                    # the deferred (Lazy) catalog.
-                    units_to_download = self.catalog_generator(url, units_to_download)
-
                     if self.download_deferred:
+                        catalog = PackageCatalog(self.conduit.importer_object_id, url)
                         for unit in units_to_download:
                             unit.downloaded = False
-                            self.add_drpm_unit(metadata_files, unit)
+                            unit = self.add_drpm_unit(metadata_files, unit)
+                            catalog.add(unit)
                         continue
 
                     download_wrapper = packages.Packages(
@@ -933,3 +912,42 @@ class RepoSync(object):
                 yield unit
             elif unit.unit_key_as_named_tuple in to_download:
                 yield unit
+
+
+class PackageCatalog(object):
+    """
+    Provides deferred catalog management for package units.
+
+    :ivar importer_id: The import DB object ID.
+    :type importer_id: bson.objectid.ObjectId
+    :ivar base_url: The base URL used to download content.
+    :type base_url: str
+    """
+
+    def __init__(self, importer_id, base_url):
+        """
+        :param importer_id: The import DB object ID.
+        :type importer_id: bson.objectid.ObjectId
+        :param base_url: The base URL used to download content.
+        :type base_url: str
+        """
+        self.importer_id = importer_id
+        self.base_url = base_url
+
+    def add(self, unit):
+        """
+        Add the specified content unit to the catalog.
+
+        :param unit: A unit being added.
+        :type unit: pulp_rpm.plugins.db.models.RpmBase
+        """
+        unit.set_storage_path(unit.filename)
+        entry = LazyCatalogEntry()
+        entry.path = unit.storage_path
+        entry.importer_id = str(self.importer_id)
+        entry.unit_id = unit.id
+        entry.unit_type_id = unit.type_id
+        entry.url = urljoin(self.base_url, unit.download_path)
+        entry.checksum = unit.checksum
+        entry.checksum_algorithm = unit.checksumtype
+        entry.save_revision()


### PR DESCRIPTION
https://pulp.plan.io/issues/1897

### _The Rant_
To start with, these changes are a hack.  The importer code is tightly coupled to downloading and a mixture of procedural and object-based (not object oriented) programming.  To fix this correctly, a significant amount of the importer would need to be rewritten (and should be anyway).  To minimize changes this late in the release cycle, I just fixed this as best I could within current design.

### _The Fix_
Instead of creating catalog entries for unit that would downloaded, I passed the initialized catalog object everywhere that did unit association.  I added fixed unit tests as best I could but most of them have been disabled.