### PR TITLE
yum_distributor now uses configured checksum type for all metadata.

### DIFF
--- a/common/pulp_rpm/common/constants.py
+++ b/common/pulp_rpm/common/constants.py
@@ -182,3 +182,6 @@ REPO_AUTH_CONFIG_FILE = '/etc/pulp/repo_auth.conf'
 # used in the scratchpad
 REPOMD_REVISION_KEY = 'repomd_revision'
 PREVIOUS_SKIP_LIST = 'previous_skip_list'
+
+COMMON_NAMESPACE = 'http://linux.duke.edu/metadata/common'
+RPM_NAMESPACE = 'http://linux.duke.edu/metadata/rpm'

--- a/docs/tech-reference/yum-plugins.rst
+++ b/docs/tech-reference/yum-plugins.rst
@@ -590,7 +590,9 @@ Optional Configuration Parameters
  perform this operation.
 
 ``checksum_type``
- Checksum type to use for metadata generation
+ Checksum type to use for metadata generation. For any units where the checksum of this type is not
+ already known, it will be computed on-the-fly and saved for future use. If any such units have not
+ been downloaded, then checksum calculation is impossible, and the publish will fail gracefully.
 
 ``skip``
  List of content types to skip during the repository publish.

--- a/docs/user-guide/release-notes/2.9.x.rst
+++ b/docs/user-guide/release-notes/2.9.x.rst
@@ -13,4 +13,5 @@ New Features
 * The <langpacks> tag in comps.xml are synced and published for repositories. These units are also
   parsed on upload. ``pulp-admin`` also has upload, remove, and search support for 
   package_langpacks.
+* The yum distributor now uses the configured checksum type for all repo metadata.
 

--- a/extensions_admin/test/unit/extensions/admin/test_status.py
+++ b/extensions_admin/test/unit/extensions/admin/test_status.py
@@ -1,8 +1,8 @@
 """
 Tests for the pulp_rpm.extensions.admin.status module.
 """
-from pulp.plugins.util import verification
 import mock
+import pulp.server.util as server_util
 
 from pulp_rpm.common import constants
 from pulp_rpm.devel import client_base
@@ -31,7 +31,7 @@ class RpmStatusRendererTests(client_base.PulpClientTests):
             constants.NAME: model.unit_key['name'],
             constants.ERROR_CODE: constants.ERROR_CHECKSUM_TYPE_UNKNOWN,
             constants.CHECKSUM_TYPE: model.unit_key['checksumtype'],
-            constants.ACCEPTED_CHECKSUM_TYPES: verification.CHECKSUM_FUNCTIONS.keys()}
+            constants.ACCEPTED_CHECKSUM_TYPES: server_util.CHECKSUM_FUNCTIONS.keys()}
         content_report.failure(model, error_report)
         content_report['state'] = constants.STATE_COMPLETE
         progress_report = {'yum_importer': {'content': content_report}}

--- a/plugins/pulp_rpm/plugins/db/fields.py
+++ b/plugins/pulp_rpm/plugins/db/fields.py
@@ -1,5 +1,5 @@
 from mongoengine import StringField
-from pulp.plugins.util import verification
+from pulp.server import util
 
 
 class ChecksumTypeStringField(StringField):
@@ -14,4 +14,4 @@ class ChecksumTypeStringField(StringField):
         :return: None
         """
         super(ChecksumTypeStringField, self).validate(value)
-        verification.sanitize_checksum_type(value)
+        util.sanitize_checksum_type(value)

--- a/plugins/pulp_rpm/plugins/distributors/yum/metadata/filelists.py
+++ b/plugins/pulp_rpm/plugins/distributors/yum/metadata/filelists.py
@@ -39,7 +39,4 @@ class FilelistsXMLFileContext(FastForwardXmlFileContext):
         :param unit: unit whose metadata is to be written
         :type  unit: pulp_rpm.plugins.db.models.RpmBase
         """
-        metadata = unit.repodata['filelists']
-        if isinstance(metadata, unicode):
-            metadata = metadata.encode('utf-8')
-        self.metadata_file_handle.write(metadata)
+        self.metadata_file_handle.write(unit.render_filelists(self.checksum_type))

--- a/plugins/pulp_rpm/plugins/distributors/yum/metadata/other.py
+++ b/plugins/pulp_rpm/plugins/distributors/yum/metadata/other.py
@@ -39,7 +39,4 @@ class OtherXMLFileContext(FastForwardXmlFileContext):
         :param unit: unit whose metadata is to be written
         :type  unit: pulp_rpm.plugins.db.models.RpmBase
         """
-        metadata = unit.repodata['other']
-        if isinstance(metadata, unicode):
-            metadata = metadata.encode('utf-8')
-        self.metadata_file_handle.write(metadata)
+        self.metadata_file_handle.write(unit.render_other(self.checksum_type))

--- a/plugins/pulp_rpm/plugins/distributors/yum/metadata/prestodelta.py
+++ b/plugins/pulp_rpm/plugins/distributors/yum/metadata/prestodelta.py
@@ -47,10 +47,10 @@ class PrestodeltaXMLFileContext(XmlFileContext):
         size_element = ElementTree.SubElement(delta_element, 'size')
         size_element.text = str(delta_unit.size)
 
-        checksum_attributes = {'type': delta_unit.checksumtype}
+        checksum_attributes = {'type': self.checksum_type}
 
         checksum_element = ElementTree.SubElement(delta_element, 'checksum', checksum_attributes)
-        checksum_element.text = delta_unit.checksum
+        checksum_element.text = delta_unit.get_or_calculate_and_save_checksum(self.checksum_type)
 
         new_package_element_string = ElementTree.tostring(new_package_element, 'utf-8')
 

--- a/plugins/pulp_rpm/plugins/distributors/yum/metadata/primary.py
+++ b/plugins/pulp_rpm/plugins/distributors/yum/metadata/primary.py
@@ -2,6 +2,7 @@ import os
 
 from pulp.plugins.util.metadata_writer import FastForwardXmlFileContext
 
+from pulp_rpm.common import constants
 from pulp_rpm.plugins.distributors.yum.metadata.metadata import REPO_DATA_DIR_NAME
 from pulp_rpm.yum_plugin import util
 
@@ -9,8 +10,6 @@ from pulp_rpm.yum_plugin import util
 _LOG = util.getLogger(__name__)
 
 PRIMARY_XML_FILE_NAME = 'primary.xml.gz'
-COMMON_NAMESPACE = 'http://linux.duke.edu/metadata/common'
-RPM_NAMESPACE = 'http://linux.duke.edu/metadata/rpm'
 
 
 class PrimaryXMLFileContext(FastForwardXmlFileContext):
@@ -29,8 +28,8 @@ class PrimaryXMLFileContext(FastForwardXmlFileContext):
 
         metadata_file_path = os.path.join(working_dir, REPO_DATA_DIR_NAME, PRIMARY_XML_FILE_NAME)
         self.num_packages = num_units
-        attributes = {'xmlns': COMMON_NAMESPACE,
-                      'xmlns:rpm': RPM_NAMESPACE,
+        attributes = {'xmlns': constants.COMMON_NAMESPACE,
+                      'xmlns:rpm': constants.RPM_NAMESPACE,
                       'packages': str(self.num_packages)}
         super(PrimaryXMLFileContext, self).__init__(metadata_file_path, 'metadata',
                                                     search_tag='package',
@@ -51,7 +50,4 @@ class PrimaryXMLFileContext(FastForwardXmlFileContext):
         :param unit: unit whose metadata is to be written
         :type  unit: pulp_rpm.plugins.db.models.RpmBase
         """
-        metadata = unit.repodata['primary']
-        if isinstance(metadata, unicode):
-            metadata = metadata.encode('utf-8')
-        self.metadata_file_handle.write(metadata)
+        self.metadata_file_handle.write(unit.render_primary(self.checksum_type))

--- a/plugins/pulp_rpm/plugins/error_codes.py
+++ b/plugins/pulp_rpm/plugins/error_codes.py
@@ -15,3 +15,8 @@ RPM1005 = Error("RPM1005", _("Unable to sync a repository that has no feed."), [
 RPM1006 = Error("RPM1006", _("Could not parse repository metadata"), [])
 RPM1007 = Error("RPM1007", _("Could not parse errata `updated` field: expected format "
                              "'%(expected_format)s'. %(details)s"), ['expected_format', 'details'])
+RPM1008 = Error("RPM1008", _('Checksum type "%(checksumtype)s" is not available for all units in '
+                             'the repository. Make sure those units have been downloaded.'),
+                ['checksumtype'])
+RPM1009 = Error("RPM1009", _('Checksum type "%(checksumtype)s" is not supported.'),
+                ['checksumtype'])

--- a/plugins/pulp_rpm/plugins/importers/yum/listener.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/listener.py
@@ -79,6 +79,7 @@ class PackageListener(DownloadEventListener):
         """
         unit = report.data
         self._verify_size(unit, report)
+        self._validate_checksumtype(unit)
         self._verify_checksum(unit, report)
 
     def download_failed(self, report):
@@ -131,7 +132,7 @@ class PackageListener(DownloadEventListener):
         report and the error is re-raised.
 
         :param unit: domain model instance of the package that was downloaded
-        :type  unit: pulp_rpm.plugins.db.models.RpmBase
+        :type  unit: pulp_rpm.plugins.db.models.NonMetadataPackage
         :param report: report handed to this listener by the downloader
         :type  report: nectar.report.DownloadReport
 
@@ -141,29 +142,43 @@ class PackageListener(DownloadEventListener):
         if not self.sync.config.get(importer_constants.KEY_VALIDATE):
             return
 
-        try:
-            with open(report.destination) as fp:
-                verification.verify_checksum(fp, unit.checksumtype, unit.checksum)
+        with open(report.destination) as fp:
+            sums = util.calculate_checksums(fp, [util.TYPE_MD5, util.TYPE_SHA1, util.TYPE_SHA256])
 
-        except verification.VerificationException, e:
+        if sums[unit.checksumtype] != unit.checksum:
             error_report = {
                 constants.NAME: unit.name,
                 constants.ERROR_CODE: constants.ERROR_CHECKSUM_VERIFICATION,
                 constants.CHECKSUM_TYPE: unit.checksumtype,
                 constants.ERROR_KEY_CHECKSUM_EXPECTED: unit.checksum,
-                constants.ERROR_KEY_CHECKSUM_ACTUAL: e[0]
+                constants.ERROR_KEY_CHECKSUM_ACTUAL: sums[unit.checksumtype]
             }
             self.sync.progress_report['content'].failure(unit, error_report)
-            raise
-        except verification.InvalidChecksumType:
+            # I don't know why the argument is the calculated sum, but that's the pre-existing
+            # behavior in pulp.server.util.verify_checksum
+            raise verification.VerificationException(sums[unit.checksumtype])
+        else:
+            # The unit will be saved later in the workflow, after the file is moved into place.
+            unit.checksums.update(sums)
+
+    def _validate_checksumtype(self, unit):
+        """
+        Validate that the checksum type is one that we support.
+
+        :param unit: model instance of the package that was downloaded
+        :type  unit: pulp_rpm.plugins.db.models.NonMetadataPackage
+
+        :raises verification.VerificationException: if the checksum type is not supported
+        """
+        if unit.checksumtype not in util.CHECKSUM_FUNCTIONS:
             error_report = {
                 constants.NAME: unit.name,
                 constants.ERROR_CODE: constants.ERROR_CHECKSUM_TYPE_UNKNOWN,
                 constants.CHECKSUM_TYPE: unit.checksumtype,
-                constants.ACCEPTED_CHECKSUM_TYPES: verification.CHECKSUM_FUNCTIONS.keys()
+                constants.ACCEPTED_CHECKSUM_TYPES: util.CHECKSUM_FUNCTIONS.keys()
             }
             self.sync.progress_report['content'].failure(unit, error_report)
-            raise
+            raise util.InvalidChecksumType()
 
 
 class RPMListener(PackageListener):
@@ -176,7 +191,7 @@ class RPMListener(PackageListener):
             unit = report.data
             try:
                 super(RPMListener, self).download_succeeded(report)
-            except (verification.VerificationException, verification.InvalidChecksumType):
+            except (verification.VerificationException, util.InvalidChecksumType):
                 # verification failed, unit not added
                 return
             added_unit = self.sync.add_rpm_unit(self.metadata_files, unit)

--- a/plugins/pulp_rpm/plugins/importers/yum/parse/rpm.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/parse/rpm.py
@@ -2,14 +2,14 @@ import logging
 import os
 
 from createrepo import yumbased
+from pulp.server import util
 import rpmUtils
-from pulp.plugins.util import verification
 
 
 _LOGGER = logging.getLogger(__name__)
 
 
-def get_package_xml(pkg_path, sumtype=verification.TYPE_SHA256):
+def get_package_xml(pkg_path, sumtype=util.TYPE_SHA256):
     """
     Method to generate repo xmls - primary, filelists and other
     for a given rpm.

--- a/plugins/pulp_rpm/plugins/importers/yum/parse/treeinfo.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/parse/treeinfo.py
@@ -13,10 +13,10 @@ from mongoengine import Q
 from nectar.listener import AggregatingEventListener
 from nectar.request import DownloadRequest
 
-from pulp.plugins.util import verification
 from pulp.server.db.model import LazyCatalogEntry, RepositoryContentUnit
 from pulp.server.exceptions import PulpCodedValidationException
 from pulp.server.controllers import repository as repo_controller
+from pulp.server import util
 
 from pulp_rpm.common import constants, ids
 from pulp_rpm.plugins.db.models import Distribution
@@ -249,7 +249,7 @@ class DistSync(object):
             _list = list(unit.files)
         for _file in files:
             if _file[CHECKSUM_TYPE] is not None:
-                _file[CHECKSUM_TYPE] = verification.sanitize_checksum_type(_file[CHECKSUM_TYPE])
+                _file[CHECKSUM_TYPE] = util.sanitize_checksum_type(_file[CHECKSUM_TYPE])
             _list.append({
                 RELATIVE_PATH: _file[RELATIVE_PATH],
                 CHECKSUM: _file[CHECKSUM],
@@ -303,7 +303,7 @@ class DistSync(object):
         for report in reports:
             _file = report.data
             if _file[CHECKSUM_TYPE] is not None:
-                _file[CHECKSUM_TYPE] = verification.sanitize_checksum_type(_file[CHECKSUM_TYPE])
+                _file[CHECKSUM_TYPE] = util.sanitize_checksum_type(_file[CHECKSUM_TYPE])
             files.append({
                 RELATIVE_PATH: _file[RELATIVE_PATH],
                 CHECKSUM: _file[CHECKSUM],
@@ -534,7 +534,7 @@ class DistSync(object):
             for item in parser.items(SECTION_CHECKSUMS):
                 relativepath = item[0]
                 checksumtype, checksum = item[1].split(':')
-                checksumtype = verification.sanitize_checksum_type(checksumtype)
+                checksumtype = util.sanitize_checksum_type(checksumtype)
                 files[relativepath] = {
                     RELATIVE_PATH: relativepath,
                     CHECKSUM: checksum,

--- a/plugins/pulp_rpm/plugins/importers/yum/repomd/metadata.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/repomd/metadata.py
@@ -14,8 +14,9 @@ from xml.etree.cElementTree import iterparse
 
 from nectar.listener import AggregatingEventListener
 from nectar.request import DownloadRequest
-from pulp.plugins.util import verification
+from pulp.server import util
 
+from pulp_rpm.plugins.db import models
 from pulp_rpm.plugins.importers.yum import utils
 from pulp_rpm.plugins.importers.yum.parse.rpm import change_location_tag
 from pulp_rpm.plugins.importers.yum.repomd import filelists, nectar_factory, other
@@ -294,6 +295,7 @@ class MetadataFiles(object):
                 with contextlib.closing(gdbm.open(db_filename, 'nf')) as db_file_handle:
                     for element in generator:
                         utils.strip_ns(element)
+                        element.attrib['pkgid'] = models.RpmBase.PKGID_TEMPLATE
                         raw_xml = utils.element_to_raw_xml(element)
                         unit_key, _ = process_func(element)
                         db_key = self.generate_db_key(unit_key)
@@ -376,7 +378,7 @@ def process_repomd_data_element(data_element):
 
     checksum_element = data_element.find(CHECKSUM_TAG)
     if checksum_element is not None:
-        checksum_type = verification.sanitize_checksum_type(checksum_element.attrib['type'])
+        checksum_type = util.sanitize_checksum_type(checksum_element.attrib['type'])
         file_info['checksum']['algorithm'] = checksum_type
         file_info['checksum']['hex_digest'] = checksum_element.text
 
@@ -390,7 +392,7 @@ def process_repomd_data_element(data_element):
 
     open_checksum_element = data_element.find(OPEN_CHECKSUM_TAG)
     if open_checksum_element is not None:
-        checksum_type = verification.sanitize_checksum_type(open_checksum_element.attrib['type'])
+        checksum_type = util.sanitize_checksum_type(open_checksum_element.attrib['type'])
         file_info['open_checksum']['algorithm'] = checksum_type
         file_info['open_checksum']['hex_digest'] = open_checksum_element.text
 

--- a/plugins/pulp_rpm/plugins/importers/yum/repomd/presto.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/repomd/presto.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from pulp.plugins.util import verification
+from pulp.server import util
 
 from pulp_rpm.plugins.db import models
 
@@ -25,7 +25,7 @@ def process_package_element(element):
     sequence = delta.find('sequence')
     size = delta.find('size')
     checksum = delta.find('checksum')
-    checksum_type = verification.sanitize_checksum_type(checksum.attrib['type'])
+    checksum_type = util.sanitize_checksum_type(checksum.attrib['type'])
 
     return models.DRPM(
         new_package=element.attrib['name'],

--- a/plugins/pulp_rpm/plugins/importers/yum/sync.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/sync.py
@@ -17,11 +17,12 @@ from nectar.request import DownloadRequest
 
 from pulp.common import dateutils
 from pulp.common.plugins import importer_constants
+from pulp.plugins.util import nectar_config as nectar_utils
+from pulp.server import util
+from pulp.server.controllers import repository as repo_controller
 from pulp.server.db.model import LazyCatalogEntry
-from pulp.plugins.util import nectar_config as nectar_utils, verification
 from pulp.server.exceptions import PulpCodedException
 from pulp.server.managers.repo import _common as common_utils
-from pulp.server.controllers import repository as repo_controller
 
 from pulp_rpm.common import constants, ids
 from pulp_rpm.plugins import error_codes
@@ -430,7 +431,7 @@ class RepoSync(object):
                 checksum_type = metadata_item[1]['checksum']['algorithm']
                 break
         if checksum_type:
-            checksum_type = verification.sanitize_checksum_type(checksum_type)
+            checksum_type = util.sanitize_checksum_type(checksum_type)
             scratchpad = self.conduit.get_repo_scratchpad()
             scratchpad[constants.SCRATCHPAD_DEFAULT_METADATA_CHECKSUM] = checksum_type
             self.conduit.set_repo_scratchpad(scratchpad)
@@ -447,7 +448,7 @@ class RepoSync(object):
             if metadata_type not in metadata_files.KNOWN_TYPES:
                 file_path = file_info['local_path']
                 checksum_type = file_info['checksum']['algorithm']
-                checksum_type = verification.sanitize_checksum_type(checksum_type)
+                checksum_type = util.sanitize_checksum_type(checksum_type)
                 checksum = file_info['checksum']['hex_digest']
                 # Find an existing model
                 model = models.YumMetadataFile.objects.filter(

--- a/plugins/pulp_rpm/plugins/importers/yum/utils.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/utils.py
@@ -2,9 +2,15 @@ import re
 import sys
 from cStringIO import StringIO
 from collections import namedtuple
+import logging
 from urlparse import urljoin, urlparse, urlunparse
 
 from pulp.common.compat import check_builtin
+
+from pulp_rpm.common import constants
+
+
+_logger = logging.getLogger(__name__)
 
 
 if sys.version_info < (2, 7):
@@ -16,6 +22,12 @@ else:
 # required for converting an element to raw XML
 STRIP_NS_RE = re.compile('{.*?}')
 Namespace = namedtuple('Namespace', ['name', 'uri'])
+
+
+# this is required because some of the pre-migration XML tags use the "rpm"
+# namespace, which causes a parse error if that namespace isn't declared.
+FAKE_XML = '<?xml version="1.0" encoding="%(encoding)s"?><faketag ' \
+           'xmlns:rpm="%(namespace)s">%(xml)s</faketag>'
 
 
 def element_to_raw_xml(element, namespaces_to_register=None, default_namespace_uri=None):
@@ -50,10 +62,7 @@ def element_to_raw_xml(element, namespaces_to_register=None, default_namespace_u
     if default_namespace_uri:
         strip_ns(element, default_namespace_uri)
 
-    tree = ET.ElementTree(element)
-    io = StringIO()
-    tree.write(io, encoding='utf-8')
-    ret = io.getvalue()
+    ret = element_to_text(element)
 
     for namespace in namespaces_to_register:
         # in python 2.7, these show up only on the root element. in 2.6, these
@@ -100,6 +109,67 @@ def strip_ns(element, uri=None):
         element.tag = element.tag.replace('{%s}' % uri, '')
     for child in list(element):
         strip_ns(child, uri)
+
+
+def fake_xml_element(repodata_snippet):
+    """
+    Wrap a snippet of xml in a fake element so it can be coerced to an ElementTree Element
+
+    :param repodata_snippet: Snippet of XML to be turn into an ElementTree Element
+    :type  repodata_snippet: str
+
+    :return: Parsed ElementTree Element containing the parsed repodata snippet
+    :rtype:  xml.etree.ElementTree.Element
+    """
+    register_namespace('rpm', constants.RPM_NAMESPACE)
+    try:
+        # make a guess at the encoding
+        codec = 'UTF-8'
+        repodata_snippet.encode(codec)
+    except UnicodeEncodeError:
+        # best second guess we have, and it will never fail due to the nature
+        # of the encoding.
+        codec = 'ISO-8859-1'
+    fake_xml = FAKE_XML % {'encoding': codec, 'xml': repodata_snippet,
+                           'namespace': constants.RPM_NAMESPACE}
+    # s/fromstring/phone_home/
+    return ET.fromstring(fake_xml.encode(codec))
+
+
+def element_to_text(element):
+    """
+    Given an element, return the raw XML as a string
+
+    :param element: an element instance that should be written as XML text
+    :type  element: xml.etree.ElementTree.Element
+
+    :return:    XML text
+    :rtype:     basestring
+    """
+    out = StringIO()
+    tree = ET.ElementTree(element)
+    tree.write(out, encoding='utf-8')
+    return out.getvalue()
+
+
+def remove_fake_element(xml_text, first_expected_name='package'):
+    """
+    Given XML text that results from data that ran through the fake_xml_element() function above,
+    remove the beginning and ending "faketag" elements.
+
+    :param xml_text:    XML that starts and ends with a <faketag> element
+    :type  xml_text:    basestring
+    :param first_expected_name: the name of the first element expected after the opening faketag
+                                element. Defaults to 'package'.
+    :type  first_expected_name: basestring
+
+    :return:    new XML string
+    :rtype:     basestring
+    """
+    start_index = xml_text.find('<' + first_expected_name)
+    end_index = xml_text.rfind('</faketag')
+
+    return xml_text[start_index:end_index]
 
 
 class RepoURLModifier(object):

--- a/plugins/pulp_rpm/plugins/migrations/0017_merge_sha_sha1.py
+++ b/plugins/pulp_rpm/plugins/migrations/0017_merge_sha_sha1.py
@@ -16,8 +16,8 @@ import logging
 
 from pymongo import errors
 
-from pulp.plugins.util import verification
 from pulp.server.db import connection
+from pulp.server import util
 
 
 _logger = logging.getLogger(__name__)
@@ -52,7 +52,7 @@ def _migrate_errata():
         for collection in pkglist:
             for package in collection.get('packages', []):
                 if 'sum' in package and package['sum']:
-                    sanitized_type = verification.sanitize_checksum_type(package['sum'][0])
+                    sanitized_type = util.sanitize_checksum_type(package['sum'][0])
                     if sanitized_type != package['sum'][0]:
                         package['sum'][0] = sanitized_type
                         changed = True
@@ -75,7 +75,7 @@ def _migrate_rpmlike_units(unit_type):
 
     for unit in unit_collection.find():
         try:
-            sanitized_type = verification.sanitize_checksum_type(unit['checksumtype'])
+            sanitized_type = util.sanitize_checksum_type(unit['checksumtype'])
             if sanitized_type != unit['checksumtype']:
                 # Let's see if we can get away with changing its checksumtype to the sanitized
                 # value. If this works, we won't have to do anything else.
@@ -128,7 +128,7 @@ def _migrate_yum_metadata_files():
     """
     collection = connection.get_collection('units_yum_repo_metadata_file')
     for unit in collection.find():
-        sanitized_type = verification.sanitize_checksum_type(unit['checksum_type'])
+        sanitized_type = util.sanitize_checksum_type(unit['checksum_type'])
         if sanitized_type != unit['checksum_type']:
             collection.update({'_id': unit['_id']},
                               {'$set': {'checksum_type': sanitized_type}})

--- a/plugins/pulp_rpm/plugins/migrations/0031_checksums_and_templates.py
+++ b/plugins/pulp_rpm/plugins/migrations/0031_checksums_and_templates.py
@@ -1,0 +1,195 @@
+from cStringIO import StringIO
+import sys
+
+from pulp.server.db import connection
+
+if sys.version < (2, 7):
+    # We need the non-C implementation so we can shove a namespace into its internal data structure,
+    # since in python 2.6, the register_namespace function wasn't present.
+    import xml.etree.ElementTree as ET
+else:
+    import xml.etree.cElementTree as ET
+
+
+RPM_NAMESPACE = 'http://linux.duke.edu/metadata/rpm'
+
+# this is required because some of the pre-migration XML tags use the "rpm"
+# namespace, which causes a parse error if that namespace isn't declared.
+FAKE_XML = '<?xml version="1.0" encoding="%(encoding)s"?><faketag ' \
+           'xmlns:rpm="%(namespace)s">%(xml)s</faketag>'
+
+
+def migrate(*args, **kwargs):
+    """
+    Adds a "checksums" DictField and populates it with the known checksum type and value.
+
+    Templatizes the XML in "repodata".
+
+    :param args:   unused
+    :type  args:   list
+    :param kwargs: unused
+    :type  kwargs: dict
+    """
+    try:
+        ET.register_namespace('rpm', RPM_NAMESPACE)
+    except AttributeError:
+        # python 2.6 doesn't have the register_namespace function
+        ET._namespace_map[RPM_NAMESPACE] = 'rpm'
+
+    db = connection.get_database()
+    rpm_collection = db['units_rpm']
+    srpm_collection = db['units_srpm']
+    drpm_collection = db['units_drpm']
+
+    for rpm in rpm_collection.find({}, ['checksum', 'checksumtype', 'repodata']):
+        migrate_rpm_base(rpm_collection, rpm)
+    for srpm in srpm_collection.find({}, ['checksum', 'checksumtype', 'repodata']):
+        migrate_rpm_base(srpm_collection, srpm)
+
+    migrate_drpms(drpm_collection)
+
+
+def migrate_drpms(collection):
+    """
+    Add the "checksums" attribute in bulk.
+
+    Since this migration does not need to do any other operations on individual drpms, we'll just
+    add the empty dict. It will be auto-populated as needed during publish operations.
+
+    :param collection:  collection of DRPM units
+    :type  collection:  pymongo.collection.Collection
+    """
+    collection.update_many({}, {'$set': {'checksums': {}}})
+
+
+def migrate_rpm_base(collection, unit):
+    """
+    Templatize the repodata XML and add the "checksums" attribute to the model.
+
+    :param collection:  collection of RPM units
+    :type  collection:  pymongo.collection.Collection
+    :param unit:        the RPM unit being migrated
+    :type  unit:        dict
+    """
+    delta = {}
+    delta['checksums'] = {unit['checksumtype']: unit['checksum']}
+    delta['repodata'] = _modify_xml(unit['repodata'])
+
+    collection.update_one({'_id': unit['_id']}, {'$set': delta})
+
+
+def _modify_xml(repodata):
+    """
+    Given a unit that has repodata XML snippets, modify them in several necessary ways. These
+    include changing the location value and adding template strings to checksum elements.
+
+    This function and everything it calls was copied from pulp_rpm.plugins.db.models, with slight
+    modifications as necessary.
+
+    :param repodata:    the "repodata" attribute from a unit
+    :type  repodata:    dict
+
+    :return:    new repodata dict with templatized XML
+    :rtype:     dict
+    """
+    faked_primary = fake_xml_element(repodata['primary'])
+    primary = faked_primary.find('package')
+
+    faked_other = fake_xml_element(repodata['other'])
+    other = faked_other.find('package')
+
+    faked_filelists = fake_xml_element(repodata['filelists'])
+    filelists = faked_filelists.find('package')
+
+    _templatize_checksum(primary)
+    _templatize_pkgid(other)
+    _templatize_pkgid(filelists)
+
+    return {
+        'primary': remove_fake_element(element_to_text(faked_primary)),
+        'other': remove_fake_element(element_to_text(other)),
+        'filelists': remove_fake_element(element_to_text(filelists)),
+    }
+
+
+def _templatize_pkgid(element):
+    """
+    Modify the passed-in element so that it's "pkgid" element contains a template string
+
+    :param element: XML element that has a "pkgid" attribute
+    :type  element: xml.etree.ElementTree.Element
+    """
+    element.attrib['pkgid'] = '{{ pkgid }}'
+
+
+def _templatize_checksum(package_element):
+    """
+    Modify the checksum element to contain template strings as the text, and as the "type"
+    attribute.
+
+    :param package_element: XML element with name "package" from primary.xml
+    :type  package_element: xml.etree.ElementTree.Element
+    """
+    c_elem = package_element.find('checksum')
+    c_elem.text = '{{ checksum }}'
+    c_elem.attrib['type'] = '{{ checksumtype }}'
+
+
+def fake_xml_element(repodata_snippet):
+    """
+    Wrap a snippet of xml in a fake element so it can be coerced to an ElementTree Element
+
+    :param repodata_snippet: Snippet of XML to be turn into an ElementTree Element
+    :type  repodata_snippet: str
+
+    :return: Parsed ElementTree Element containing the parsed repodata snippet
+    :rtype:  xml.etree.ElementTree.Element
+    """
+    try:
+        # make a guess at the encoding
+        codec = 'UTF-8'
+        repodata_snippet.encode(codec)
+    except UnicodeEncodeError:
+        # best second guess we have, and it will never fail due to the nature
+        # of the encoding.
+        codec = 'ISO-8859-1'
+    fake_xml = FAKE_XML % {'encoding': codec, 'xml': repodata_snippet,
+                           'namespace': RPM_NAMESPACE}
+    # s/fromstring/phone_home/
+    return ET.fromstring(fake_xml.encode(codec))
+
+
+def remove_fake_element(xml_text, first_expected_name='package'):
+    """
+    Given XML text that results from data that ran through the fake_xml_element() function above,
+    remove the beginning and ending "faketag" elements.
+
+    :param xml_text:    XML that starts and ends with a <faketag> element
+    :type  xml_text:    basestring
+    :param first_expected_name: the name of the first element expected after the opening faketag
+                                element. Defaults to 'package'.
+    :type  first_expected_name: basestring
+
+    :return:    new XML string
+    :rtype:     basestring
+    """
+    start_index = xml_text.find('<' + first_expected_name)
+    end_index = xml_text.rfind('</faketag')
+
+    return xml_text[start_index:end_index]
+
+
+def element_to_text(element):
+    """
+    Given an element, return the raw XML as a string
+
+    :param element: an element instance that should be written as XML text
+    :type  element: xml.etree.ElementTree.Element
+
+    :return:    XML text
+    :rtype:     basestring
+    """
+    out = StringIO()
+    tree = ET.ElementTree(element)
+    tree.write(out, encoding='utf-8')
+    return out.getvalue()

--- a/plugins/test/unit/plugins/db/test_models.py
+++ b/plugins/test/unit/plugins/db/test_models.py
@@ -8,11 +8,13 @@ import shutil
 import tempfile
 
 import mock
-
 from pulp.common.compat import unittest
-from pulp.server.exceptions import PulpCodedValidationException
+import pulp.common.error_codes as platform_error_codes
+from pulp.server.exceptions import PulpCodedException, PulpCodedValidationException
+
 from pulp_rpm.common import ids
 from pulp_rpm.devel.skip import skip_broken
+from pulp_rpm.plugins import error_codes
 from pulp_rpm.plugins.db import models
 
 
@@ -25,6 +27,152 @@ class TestNonMetadataModel(unittest.TestCase):
         https://pulp.plan.io/issues/1792
         """
         models.NonMetadataPackage(version='1.0.0', release='2', checksumtype=None, checksum=None)
+
+
+class TestNonMetadataGetOrCalculateChecksum(unittest.TestCase):
+    def setUp(self):
+        super(TestNonMetadataGetOrCalculateChecksum, self).setUp()
+        self.model = models.RPM(name='foo', epoch='0', version='1.0.0', release='2', arch='noarch',
+                                checksumtype='sha1', checksum='abc123')
+        self.model.checksums = {'sha256': 'asum'}
+
+    def test_invalid_type(self):
+        self.assertRaises(ValueError, self.model.get_or_calculate_and_save_checksum, 'sha1.5')
+
+    def test_value_already_in_checksums(self):
+        ret = self.model.get_or_calculate_and_save_checksum('sha256')
+
+        self.assertEqual(ret, 'asum')
+
+    def test_value_in_unit_key(self):
+        with mock.patch.object(self.model, 'save') as mock_save:
+            ret = self.model.get_or_calculate_and_save_checksum('sha1')
+
+        self.assertEqual(ret, self.model.checksum)
+        # make sure the checksum was added to the dict and the model was saved
+        self.assertTrue('sha1' in self.model.checksums)
+        mock_save.assert_called_once_with()
+
+    @mock.patch('__builtin__.open')
+    @mock.patch('pulp.server.util.calculate_checksums')
+    def test_calculate_value(self, mock_calculate_checksums, mock_open):
+        mock_calculate_checksums.return_value = {'md5': 'md5 sum'}
+
+        with mock.patch.object(self.model, 'save') as mock_save:
+            ret = self.model.get_or_calculate_and_save_checksum('md5')
+
+        self.assertEqual(ret, 'md5 sum')
+        mock_save.assert_called_once_with()
+
+    def test_not_downloaded(self):
+        self.model.downloaded = False
+
+        with self.assertRaises(PulpCodedException) as assertion:
+            self.model.get_or_calculate_and_save_checksum('md5')
+
+        self.assertEqual(assertion.exception.error_code, error_codes.RPM1008)
+
+    def test_cannot_open_file_missing(self):
+        """
+        When the file is missing but expected, raise a PulpCodedException.
+        """
+        self.model._storage_path = '/tmp/a/b/c/d/e'
+
+        with self.assertRaises(PulpCodedException) as assertion:
+            self.model.get_or_calculate_and_save_checksum('md5')
+
+        self.assertEqual(assertion.exception.error_code, platform_error_codes.PLP0048)
+
+    @mock.patch('__builtin__.open')
+    def test_cannot_open_other_reason(self, mock_open):
+        """
+        Make sure if there is some other reason that opening the file failed, that bubbles up.
+        """
+        class MyException(Exception):
+            pass
+
+        mock_open.side_effect = MyException
+        self.model._storage_path = '/tmp/a/b/c/d/e'
+
+        self.assertRaises(MyException, self.model.get_or_calculate_and_save_checksum, 'md5')
+
+
+class TestRpmBaseModifyXML(unittest.TestCase):
+    # a snippet from repodata primary xml for a package
+    # this snippet has been truncated to only provide the tags needed to test
+    PRIMARY_EXCERPT = '''
+<package type="rpm">
+  <name>shark</name>
+  <arch>noarch</arch>
+  <version epoch="0" rel="1" ver="0.1" />
+  <checksum pkgid="YES"
+  type="sha256">951e0eacf3e6e6102b10acb2e689243b5866ec2c7720e783749dbd32f4a69ab3</checksum>
+  <summary>A dummy package of shark</summary>
+  <description>A dummy package of shark</description>
+  <packager />
+  <url>http://tstrachota.fedorapeople.org</url>
+  <time build="1331831369" file="1331832459" />
+  <size archive="296" installed="42" package="2441" />
+  <location href="fixme/shark-0.1-1.noarch.rpm" />
+  <format>
+    <rpm:license>GPLv2</rpm:license>
+    <rpm:vendor />
+    <rpm:group>Internet/Applications</rpm:group>
+    <rpm:buildhost>smqe-ws15</rpm:buildhost>
+    <rpm:sourcerpm>shark-0.1-1.src.rpm</rpm:sourcerpm>
+    <rpm:header-range end="2289" start="872" />
+    <rpm:provides>
+      <rpm:entry epoch="0" flags="EQ" name="shark" rel="1" ver="0.1" />
+    </rpm:provides>
+    <rpm:requires>
+      <rpm:entry name="shark" flags="EQ" epoch="0" ver="0.1" rel="1"/>
+      <rpm:entry name="walrus" flags="EQ" epoch="0" ver="5.21" rel="1"/>
+    </rpm:requires>
+  </format>
+</package>
+    '''
+    OTHER_EXCERPT = '''
+<package arch="noarch" name="shark"
+    pkgid="951e0eacf3e6e6102b10acb2e689243b5866ec2c7720e783749dbd32f4a69ab3">
+    <version epoch="0" rel="1" ver="0.1" />
+</package>'''
+    FILELISTS_EXCERPT = '''
+<package arch="noarch" name="shark"
+    pkgid="951e0eacf3e6e6102b10acb2e689243b5866ec2c7720e783749dbd32f4a69ab3">
+    <version epoch="0" rel="1" ver="0.1" />
+    <file>/tmp/shark.txt</file>
+</package>'''
+
+    def setUp(self):
+        self.unit = models.RPM()
+        self.unit.repodata['primary'] = self.PRIMARY_EXCERPT
+        self.unit.repodata['filelists'] = self.FILELISTS_EXCERPT
+        self.unit.repodata['other'] = self.OTHER_EXCERPT
+        self.unit.filename = 'fixed-filename.rpm'
+        self.checksum = '951e0eacf3e6e6102b10acb2e689243b5866ec2c7720e783749dbd32f4a69ab3'
+
+    def test_update_location(self):
+        self.unit.modify_xml()
+
+        self.assertTrue('fixme' not in self.unit.repodata['primary'])
+        self.assertTrue('<location href="fixed-filename.rpm"'
+                        in self.unit.repodata['primary'])
+
+    def test_checksum_template(self):
+        self.unit.modify_xml()
+        self.assertTrue('{{ checksum }}' in self.unit.repodata['primary'])
+        self.assertTrue('{{ checksumtype }}' in self.unit.repodata['primary'])
+        self.assertTrue(self.checksum not in self.unit.repodata['primary'])
+
+    def test_checksum_other_pkgid(self):
+        self.unit.modify_xml()
+        self.assertTrue('{{ pkgid }}' in self.unit.repodata['other'])
+        self.assertTrue(self.checksum not in self.unit.repodata['other'])
+
+    def test_checksum_filelists_pkgid(self):
+        self.unit.modify_xml()
+        self.assertTrue('{{ pkgid }}' in self.unit.repodata['filelists'])
+        self.assertTrue(self.checksum not in self.unit.repodata['filelists'])
 
 
 class TestDistribution(unittest.TestCase):
@@ -860,3 +1008,62 @@ class TestRPM(unittest.TestCase):
         rpm = models.RPM('name', 'epoch', 'version', 'release', 'filename', 'sha', 'checksum', {})
 
         self.assertEqual(rpm.unit_key['checksumtype'], 'sha1')
+
+
+class TestRpmBaseRender(unittest.TestCase):
+    def setUp(self):
+        super(TestRpmBaseRender, self).setUp()
+        self.unit = models.RPM(name='cat', epoch='0', version='1.0', release='1', arch='noarch')
+        self.unit.checksum = 'abc123'
+        self.unit.checksumtype = 'sha1'
+        self.unit.checksums = {'sha1': 'abc123'}
+        self.unit.repodata['filelists'] = '''
+<package arch="noarch" name="cat" pkgid="{{ pkgid }}">
+    <version epoch="0" rel="1" ver="1.0" />
+    <file>/tmp/cat.txt</file>
+</package>'''
+        self.unit.repodata['other'] = '''
+<package arch="noarch" name="cat" pkgid="{{ pkgid }}">
+    <version epoch="0" rel="1" ver="1.0" />
+</package>'''
+        self.unit.repodata['primary'] = '''
+<package type="rpm">
+  <name>cat</name>
+  <arch>noarch</arch>
+  <version epoch="0" rel="1" ver="1.0" />
+  <checksum pkgid="YES" type="{{ checksumtype }}">{{ checksum }}</checksum>
+  <summary>A dummy package of cat</summary>
+  <description>A dummy package of cat</description>
+  <packager />
+  <url>http://tstrachota.fedorapeople.org</url>
+  <time build="1331831362" file="1331832453" />
+  <size archive="292" installed="42" package="2420" />
+<location href="cat-1.0-1.noarch.rpm"/>
+  <format>
+    <rpm:license>GPLv2</rpm:license>
+    <rpm:vendor />
+    <rpm:group>Internet/Applications</rpm:group>
+    <rpm:buildhost>smqe-ws15</rpm:buildhost>
+    <rpm:sourcerpm>cat-1.0-1.src.rpm</rpm:sourcerpm>
+    <rpm:header-range end="2273" start="872" />
+    <rpm:provides>
+      <rpm:entry epoch="0" flags="EQ" name="cat" rel="1" ver="1.0" />
+    </rpm:provides>
+  </format>
+</package>'''
+
+    def test_render_filelists(self):
+        ret = self.unit.render_filelists('sha1')
+
+        self.assertTrue('abc123' in ret)
+
+    def test_render_other(self):
+        ret = self.unit.render_other('sha1')
+
+        self.assertTrue('abc123' in ret)
+
+    def test_render_primary(self):
+        ret = self.unit.render_primary('sha1')
+
+        self.assertTrue('abc123' in ret)
+        self.assertTrue('sha1' in ret)

--- a/plugins/test/unit/plugins/distributors/yum/metadata/test_other.py
+++ b/plugins/test/unit/plugins/distributors/yum/metadata/test_other.py
@@ -10,7 +10,9 @@ from pulp_rpm.plugins.distributors.yum.metadata.other import OtherXMLFileContext
 class OtherXMLFileContextTests(unittest.TestCase):
     def setUp(self):
         self.working_dir = tempfile.mkdtemp()
-        self.context = OtherXMLFileContext(self.working_dir, 3)
+        self.context = OtherXMLFileContext(self.working_dir, 3, 'sha256')
+        self.unit = mock.Mock()
+        self.unit.render_other.return_value = 'somexml'
 
     def tearDown(self):
         shutil.rmtree(self.working_dir)
@@ -21,15 +23,17 @@ class OtherXMLFileContextTests(unittest.TestCase):
 
     def test_add_unit_metadata(self):
         self.context.metadata_file_handle = mock.Mock()
-        self.context.add_unit_metadata(mock.Mock(repodata={'other': 'bar'}))
-        self.context.metadata_file_handle.write.assert_called_once_with('bar')
+        self.context.add_unit_metadata(self.unit)
+        self.context.metadata_file_handle.write.assert_called_once_with('somexml')
+        self.unit.render_other.assert_called_once_with('sha256')
 
     def test_add_unit_metadata_unicode(self):
         """
         Test that the other repodata is passed as a str even if it's a unicode object.
         """
         self.context.metadata_file_handle = mock.Mock()
-        expected_call = 'some unicode'
-        repodata = {'other': unicode(expected_call)}
-        self.context.add_unit_metadata(mock.Mock(repodata=repodata))
+        expected_call = u'some unicode'
+        self.unit.render_other.return_value = expected_call
+        self.context.add_unit_metadata(self.unit)
         self.context.metadata_file_handle.write.assert_called_once_with(expected_call)
+        self.unit.render_other.assert_called_once_with('sha256')

--- a/plugins/test/unit/plugins/importers/yum/repomd/test_primary.py
+++ b/plugins/test/unit/plugins/importers/yum/repomd/test_primary.py
@@ -16,7 +16,7 @@ class TestProcessPackageElement(unittest.TestCase):
 
     @mock.patch('pulp_rpm.plugins.db.models.version_utils.encode')
     @mock.patch('pulp_rpm.plugins.importers.yum.repomd.primary.utils.element_to_raw_xml')
-    def test_process_package_element_sanitizes_checksum_type(self, element_to_raw_xml, encode):
+    def test_sanitizes_checksum_type(self, element_to_raw_xml, encode):
         """
         Assert that the function correctly sanitizes checksum types.
         """
@@ -33,6 +33,20 @@ class TestProcessPackageElement(unittest.TestCase):
         model = primary.process_package_element(element)
 
         self.assertEqual(model.checksumtype, 'sha1')
+
+    def test_adds_templates(self):
+        """
+        Assert that the function correctly adds templates.
+        """
+        rpms = packages.package_list_generator(StringIO(F18_XML),
+                                               primary.PACKAGE_TAG,
+                                               primary.process_package_element)
+        rpms = list(rpms)
+        self.assertEqual(len(rpms), 1)
+        model = rpms[0]
+
+        self.assertTrue(model.CHECKSUM_TEMPLATE in model.raw_xml)
+        self.assertTrue(model.CHECKSUMTYPE_TEMPLATE in model.raw_xml)
 
 
 class TestProcessSRPMElement(unittest.TestCase):

--- a/plugins/test/unit/plugins/migrations/test_0031_checksums_and_templates.py
+++ b/plugins/test/unit/plugins/migrations/test_0031_checksums_and_templates.py
@@ -1,0 +1,154 @@
+from pulp.common.compat import unittest
+
+import mock
+
+from pulp.server.db.migrate.models import _import_all_the_way
+
+
+PATH_TO_MODULE = 'pulp_rpm.plugins.migrations.0031_checksums_and_templates'
+migration = _import_all_the_way(PATH_TO_MODULE)
+
+
+@mock.patch('pulp.server.db.connection.get_database')
+@mock.patch.object(migration, 'migrate_rpm_base')
+@mock.patch.object(migration, 'migrate_drpms')
+class TestMigrate(unittest.TestCase):
+    def test_calls_migrate_rpm_base(self, mock_migrate_drpms, mock_migrate_rpm_base, mock_get_db):
+        mock_db = mock_get_db.return_value
+        mock_unit = mock.MagicMock()
+        mock_rpm_collection = mock_db['units_rpm']
+        mock_rpm_collection.find.return_value = [mock_unit]
+        mock_srpm_collection = mock_db['units_srpm']
+        mock_srpm_collection.find.return_value = [mock_unit]
+
+        migration.migrate()
+
+        self.assertEqual(mock_migrate_rpm_base.call_count, 2)
+        mock_migrate_rpm_base.assert_called_with(mock_rpm_collection, mock_unit)
+        mock_migrate_rpm_base.assert_called_with(mock_srpm_collection, mock_unit)
+
+    def test_calls_migrate_drpms(self, mock_migrate_drpms, mock_migrate_rpm_base, mock_get_db):
+        mock_db = mock_get_db.return_value
+        mock_drpm_collection = mock_db['units_drpm']
+
+        migration.migrate()
+
+        mock_migrate_drpms.assert_called_once_with(mock_drpm_collection)
+
+
+class TestMigrateDRPMs(unittest.TestCase):
+    def test_calls_update(self):
+        mock_collection = mock.MagicMock()
+
+        migration.migrate_drpms(mock_collection)
+
+        # re-typing the call args here would have little value, so we just make sure the call
+        # happened
+        self.assertEqual(mock_collection.update_many.call_count, 1)
+
+
+class TestMigrateRPMBase(unittest.TestCase):
+    def setUp(self):
+        super(TestMigrateRPMBase, self).setUp()
+        self.rpm = {
+            '_id': '1234',
+            'checksum': 'abc123',
+            'checksumtype': 'sha1',
+            'repodata': {'primary': 'stuff'},
+        }
+
+    @mock.patch.object(migration, '_modify_xml')
+    def test_calls_modify_xml(self, mock_modify_xml):
+        mock_collection = mock.MagicMock()
+
+        migration.migrate_rpm_base(mock_collection, self.rpm)
+
+        mock_modify_xml.assert_called_once_with(self.rpm['repodata'])
+
+    @mock.patch.object(migration, '_modify_xml')
+    def test_calls_update(self, mock_modify_xml):
+        mock_collection = mock.MagicMock()
+
+        migration.migrate_rpm_base(mock_collection, self.rpm)
+
+        expected_delta = {
+            'repodata': mock_modify_xml.return_value,
+            'checksums': {'sha1': 'abc123'},
+        }
+        mock_collection.update_one.assert_called_once_with({'_id': '1234'},
+                                                           {'$set': expected_delta})
+
+
+class TestModifyXml(unittest.TestCase):
+    def setUp(self):
+        super(TestModifyXml, self).setUp()
+        self.repodata = {
+            'primary': PRIMARY,
+            'other': OTHER,
+            'filelists': FILELISTS,
+        }
+
+    def test_other_template(self):
+        ret = migration._modify_xml(self.repodata)
+
+        self.assertTrue('{{ pkgid }}' in ret['other'])
+        self.assertTrue('f4200643b' not in ret['other'])
+
+    def test_filelists_template(self):
+        ret = migration._modify_xml(self.repodata)
+
+        self.assertTrue('{{ pkgid }}' in ret['filelists'])
+        self.assertTrue('f4200643b' not in ret['filelists'])
+
+    def test_primary_template(self):
+        ret = migration._modify_xml(self.repodata)
+
+        self.assertTrue('{{ checksum }}' in ret['primary'])
+        self.assertTrue('{{ checksumtype }}' in ret['primary'])
+        self.assertTrue('f4200643b' not in ret['primary'])
+        self.assertTrue('sha256' not in ret['primary'])
+
+
+PRIMARY = '''
+<package type="rpm">
+  <name>mouse</name>
+  <arch>noarch</arch>
+  <version epoch="0" rel="1" ver="0.1.12" />
+  <checksum pkgid="YES"
+    type="sha256">f4200643b0845fdc55ee002c92c0404a9f3a2a49f596c78b40ab56749de226ce</checksum>
+  <summary>A dummy package of mouse</summary>
+  <description>A dummy package of mouse</description>
+  <packager />
+  <url>http://tstrachota.fedorapeople.org</url>
+  <time build="1331831376" file="1463813415" />
+  <size archive="296" installed="42" package="2476" />
+  <location href="mouse-0.1.12-1.noarch.rpm"/>
+  <format>
+    <rpm:license>GPLv2</rpm:license>
+    <rpm:vendor />
+    <rpm:group>Internet/Applications</rpm:group>
+    <rpm:buildhost>smqe-ws15</rpm:buildhost>
+    <rpm:sourcerpm>mouse-0.1.12-1.src.rpm</rpm:sourcerpm>
+    <rpm:header-range end="2325" start="872" />
+    <rpm:provides>
+      <rpm:entry epoch="0" flags="EQ" name="mouse" rel="1" ver="0.1.12" />
+    </rpm:provides>
+    <rpm:requires>
+      <rpm:entry name="dolphin" />
+      <rpm:entry name="zebra" />
+    </rpm:requires>
+  </format>
+</package>'''
+
+OTHER = '''
+<package arch="noarch" name="mouse"
+  pkgid="f4200643b0845fdc55ee002c92c0404a9f3a2a49f596c78b40ab56749de226ce">
+  <version epoch="0" rel="1" ver="0.1.12" />
+</package>'''
+
+FILELISTS = '''
+<package arch="noarch" name="mouse"
+  pkgid="f4200643b0845fdc55ee002c92c0404a9f3a2a49f596c78b40ab56749de226ce">
+  <version epoch="0" rel="1" ver="0.1.12" />
+  <file>/tmp/mouse.txt</file>
+</package>'''

--- a/plugins/test/unit/yum_plugin/test_yumplugin_upload.py
+++ b/plugins/test/unit/yum_plugin/test_yumplugin_upload.py
@@ -1,7 +1,7 @@
 import os
 import unittest
 
-from pulp.plugins.util import verification
+from pulp.server import util
 
 from pulp_rpm.devel.skip import skip_broken
 from pulp_rpm.plugins.importers.yum import upload
@@ -38,7 +38,7 @@ class TestUploadGenerateRpmData(unittest.TestCase):
         type is used.
         """
         unit_key, metadata = upload._generate_rpm_data(models.RPM.TYPE, RPM_USUAL_NAME, {})
-        self.assertEquals(verification.TYPE_SHA256, unit_key['checksumtype'])
+        self.assertEquals(util.TYPE_SHA256, unit_key['checksumtype'])
 
     def test_user_metadata_present_with_checksum_type(self):
         """
@@ -46,5 +46,5 @@ class TestUploadGenerateRpmData(unittest.TestCase):
         """
         unit_key, metadata = upload._generate_rpm_data(models.RPM.TYPE,
                                                        RPM_USUAL_NAME,
-                                                       {'checksum_type': verification.TYPE_MD5})
-        self.assertEquals(verification.TYPE_MD5, unit_key['checksumtype'])
+                                                       {'checksum_type': util.TYPE_MD5})
+        self.assertEquals(util.TYPE_MD5, unit_key['checksumtype'])


### PR DESCRIPTION
A lot of model-related code was moved into models.py from other places. In
addition to being more object-oriented, it made that code accessible from
multiple places instead of being isolated somewhere, such as in the upload
code. Being able to use the code from multiple places was the primary reason
for moving the code in this PR.

I tested with pulp-smash and by kick-starting a rhel7 VM from a published repo.

This requires both of the following platform PRs:
https://github.com/pulp/pulp/pull/2577
https://github.com/pulp/pulp/pull/2578

re #1618
https://pulp.plan.io/issues/1618