### PR TITLE
Fix migration #28

### DIFF
--- a/plugins/pulp_rpm/plugins/migrations/0028_standard_storage_path.py
+++ b/plugins/pulp_rpm/plugins/migrations/0028_standard_storage_path.py
@@ -11,9 +11,9 @@ def migrate(*args, **kwargs):
     migration.add(rpm_plan())
     migration.add(srpm_plan())
     migration.add(drpm_plan())
-    migration.add(distribution_plan())
     migration.add(yum_metadata_plan())
-    migration.add(iso_plan())
+    migration.add(Distribution())
+    migration.add(ISO())
     migration()
 
 
@@ -79,24 +79,6 @@ def drpm_plan():
     return Plan(collection, key_fields)
 
 
-def distribution_plan():
-    """
-    Factory to create an Distribution migration plan.
-
-    :return: A configured plan.
-    :rtype: Plan
-    """
-    key_fields = (
-        'distribution_id',
-        'family',
-        'variant',
-        'version',
-        'arch'
-    )
-    collection = connection.get_collection('units_distribution')
-    return Plan(collection, key_fields, join_leaf=False)
-
-
 def yum_metadata_plan():
     """
     Factory to create an YUM metadata migration plan.
@@ -112,17 +94,70 @@ def yum_metadata_plan():
     return Plan(collection, key_fields)
 
 
-def iso_plan():
+class Distribution(Plan):
     """
-    Factory to create an ISO migration plan.
+    The migration plan for Distribution units.
+    """
 
-    :return: A configured plan.
-    :rtype: Plan
+    def __init__(self):
+        """
+        Call super with collection and fields.
+        """
+        key_fields = (
+            'distribution_id',
+            'family',
+            'variant',
+            'version',
+            'arch'
+        )
+        collection = connection.get_collection('units_distribution')
+        super(Distribution, self).__init__(collection, key_fields, join_leaf=False)
+
+    def _new_path(self, unit):
+        """
+        The *variant* might not exist in the document for older units.
+        Default the variant part of the unit key to '' which matches the model.
+
+        :param unit: The unit being migrated.
+        :type  unit: pulp.plugins.migration.standard_storage_path.Unit
+        :return: The new path.
+        :rtype: str
+        """
+        unit.document.setdefault('variant', '')
+        return super(Distribution, self)._new_path(unit)
+
+
+class ISO(Plan):
     """
-    key_fields = (
-        'name',
-        'checksum',
-        'size'
-    )
-    collection = connection.get_collection('units_iso')
-    return Plan(collection, key_fields)
+    The migration plan for ISO units.
+    """
+
+    def __init__(self):
+        """
+        Call super with collection and fields.
+        """
+        key_fields = (
+            'name',
+            'checksum',
+            'size'
+        )
+        collection = connection.get_collection('units_iso')
+        super(ISO, self).__init__(collection, key_fields)
+
+    def _new_path(self, unit):
+        """
+        Units created by 2.8.0 don't include the ISO name.  This was a regression
+        that is being corrected by this additional logic.  If the storage path
+        does not end with the *name* stored in the unit, it is appended.
+
+        :param unit: The unit being migrated.
+        :type  unit: pulp.plugins.migration.standard_storage_path.Unit
+        :return: The new path.
+        :rtype: str
+        """
+        name = unit.document['name']
+        path = unit.document['_storage_path']
+        if not path.endswith(name):
+            unit.document['_storage_path'] = name
+        new_path = super(ISO, self)._new_path(unit)
+        return new_path


### PR DESCRIPTION
https://pulp.plan.io/issues/1945

Some of the plugins released with early 2.8 had been updated (incorrectly) to use the new platform storage model (introduced in 2.8) for unit files. This resulted in a period of time when units were created with storage paths that should have ended with the file names but did not. Apparently the ISO importer was one of these plugins but was fixed in later 2.8 releases. The ISO storage-path migration just needs to be updated to detect these units and correct the storage path.

Also handles distribution units that don't contain a `variant` in the document.  Defaults to empty string `''` which matches what the model object will do.