### PR TITLE
Remove unused fields from units_rpm collection.

### DIFF
--- a/plugins/pulp_rpm/plugins/migrations/0029_remove_rpm_unused_fields.py
+++ b/plugins/pulp_rpm/plugins/migrations/0029_remove_rpm_unused_fields.py
@@ -1,0 +1,29 @@
+"""
+Migration to remove the `filelist` and `_erratum_references` fields from RPM units,
+that are no longer used.
+"""
+
+from pulp.server.db import connection
+
+
+def migrate(*args, **kwargs):
+    """
+    Perform the migration as described in this module's docblock.
+
+    :param args:   unused
+    :type  args:   list
+    :param kwargs: unused
+    :type  kwargs: dict
+    """
+    db = connection.get_database()
+    units_rpm_collection = db['units_rpm']
+    units_rpm_collection.update(
+        {'filelist': {'$exists': True}},
+        {'$unset': {'filelist': True}},
+        multi=True
+    )
+    units_rpm_collection.update(
+        {'_erratum_references': {'$exists': True}},
+        {'$unset': {'_erratum_references': True}},
+        multi=True
+    )

--- a/plugins/test/unit/plugins/migrations/test_0029_remove_rpm_unused_fields.py
+++ b/plugins/test/unit/plugins/migrations/test_0029_remove_rpm_unused_fields.py
@@ -1,0 +1,33 @@
+import unittest
+
+import mock
+
+from pulp.server.db.migrate.models import _import_all_the_way
+
+
+PATH_TO_MODULE = 'pulp_rpm.plugins.migrations.0029_remove_rpm_unused_fields'
+
+migration = _import_all_the_way(PATH_TO_MODULE)
+
+
+class TestMigrate(unittest.TestCase):
+    """
+    Test migration 0029.
+    """
+
+    @mock.patch(PATH_TO_MODULE + '.connection')
+    def test_migration(self, mock_connection):
+        mock_units_rpm = mock.Mock()
+        mock_connection.get_database.return_value = {
+            'units_rpm': mock_units_rpm,
+        }
+
+        migration.migrate()
+        mock_connection.get_database.assert_called_once_with()
+        self.assertEqual(mock_units_rpm.update.call_count, 2)
+        expected_calls = [
+            mock.call({'filelist': {'$exists': True}}, {'$unset': {'filelist': True}}, multi=True),
+            mock.call({'_erratum_references': {'$exists': True}},
+                      {'$unset': {'_erratum_references': True}}, multi=True)
+        ]
+        mock_units_rpm.update.assert_has_calls(expected_calls)


### PR DESCRIPTION
closes #1952
https://pulp.plan.io/issues/1952

The `filelist` and `_erratum_references` were present in earlier versions
of Pulp but are no longer used. They are not included in the mongoengine
RPM model anymore.