### PR TITLE
Remove unused fields from units_erratum collection

### DIFF
--- a/plugins/pulp_rpm/plugins/migrations/0030_remove_errata_unused_fields.py
+++ b/plugins/pulp_rpm/plugins/migrations/0030_remove_errata_unused_fields.py
@@ -1,0 +1,24 @@
+"""
+Migration to remove the `_rpm_references` field from Errata units, which is no
+longer used.
+"""
+
+from pulp.server.db import connection
+
+
+def migrate(*args, **kwargs):
+    """
+    Perform the migration as described in this module's docblock.
+
+    :param args:   unused
+    :type  args:   list
+    :param kwargs: unused
+    :type  kwargs: dict
+    """
+    db = connection.get_database()
+    units_erratum_collection = db['units_erratum']
+    units_erratum_collection.update(
+        {'_rpm_references': {'$exists': True}},
+        {'$unset': {'_rpm_references': True}},
+        multi=True
+    )

--- a/plugins/test/unit/plugins/migrations/test_0030_remove_errata_unused_fields.py
+++ b/plugins/test/unit/plugins/migrations/test_0030_remove_errata_unused_fields.py
@@ -1,0 +1,32 @@
+import unittest
+
+import mock
+
+from pulp.server.db.migrate.models import _import_all_the_way
+
+
+PATH_TO_MODULE = 'pulp_rpm.plugins.migrations.0030_remove_errata_unused_fields'
+
+migration = _import_all_the_way(PATH_TO_MODULE)
+
+
+class TestMigrate(unittest.TestCase):
+    """
+    Test migration 0030.
+    """
+
+    @mock.patch(PATH_TO_MODULE + '.connection')
+    def test_migration(self, mock_connection):
+        mock_units_erratum = mock.Mock()
+        mock_connection.get_database.return_value = {
+            'units_erratum': mock_units_erratum,
+        }
+
+        migration.migrate()
+        mock_connection.get_database.assert_called_once_with()
+
+        mock_units_erratum.update.assert_called_once_with(
+            {'_rpm_references': {'$exists': True}},
+            {'$unset': {'_rpm_references': True}},
+            multi=True
+        )


### PR DESCRIPTION
closes #1931
https://pulp.plan.io/issues/1931

The `_rpm_references` field was present in earlier versions of Pulp
but is no longer used. It is not included in the mongoengine
Errata model anymore.