### PR TITLE
Ensure variant is set on distribution units.

### DIFF
--- a/plugins/pulp_rpm/plugins/migrations/0032_ensure_variant_field.py
+++ b/plugins/pulp_rpm/plugins/migrations/0032_ensure_variant_field.py
@@ -1,0 +1,26 @@
+"""
+Migration to ensure all distribution units have the variant field.
+"""
+
+from pulp.server.db import connection
+
+
+def migrate(*args, **kwargs):
+    """
+    Migration to ensure all distribution units have the variant field.
+    Defaulting to '' matches the model.
+
+    :param args: unused
+    :type  args: tuple
+    :param kwargs: unused
+    :type  kwargs: dict
+    """
+    variant = 'variant'
+    collection = connection.get_collection('units_distribution')
+    collection.update(
+        {'$or': [
+            {variant: None},
+            {variant: {'$exists': False}}
+        ]},
+        {'$set': {variant: ''}}, multi=True)
+

--- a/plugins/test/unit/plugins/migrations/test_0032_ensure_variant_field.py
+++ b/plugins/test/unit/plugins/migrations/test_0032_ensure_variant_field.py
@@ -1,0 +1,30 @@
+from unittest import TestCase
+
+from mock import patch
+
+from pulp.server.db.migrate.models import _import_all_the_way
+
+
+MODULE = 'pulp_rpm.plugins.migrations.0032_ensure_variant_field'
+
+migration = _import_all_the_way(MODULE)
+
+
+class TestMigrate(TestCase):
+    """
+    Test migration 0032.
+    """
+
+    @patch(MODULE + '.connection.get_collection')
+    def test_migration(self, get_collection):
+        # test
+        migration.migrate()
+
+        # validation
+        get_collection.assert_called_once_with('units_distribution')
+        get_collection.return_value.update.assert_called_once_with(
+            {'$or': [
+                {'variant': None},
+                {'variant': {'$exists': False}}
+            ]},
+            {'$set': {'variant': ''}}, multi=True)


### PR DESCRIPTION
https://pulp.plan.io/issues/1955

Ensure `variant` is set on distribution documents.  Intended to match the default value `''` set by the model object.

Related to: https://github.com/pulp/pulp_rpm/pull/883