### PR TITLE
Change ``variant`` to default to an empty string

### DIFF
--- a/plugins/pulp_rpm/plugins/db/models.py
+++ b/plugins/pulp_rpm/plugins/db/models.py
@@ -362,7 +362,7 @@ class Distribution(UnitMixin, FileContentUnit):
 
     distribution_id = mongoengine.StringField(required=True)
     family = mongoengine.StringField(required=True)
-    variant = mongoengine.StringField()
+    variant = mongoengine.StringField(default='')
     version = mongoengine.StringField(required=True)
     arch = mongoengine.StringField(required=True)
 

--- a/plugins/test/unit/plugins/db/test_models.py
+++ b/plugins/test/unit/plugins/db/test_models.py
@@ -61,7 +61,7 @@ class TestDistribution(unittest.TestCase):
         Assert __str__ works with distributions that don't have a Variant.
         """
         d = models.Distribution(family='family', variant=None, version='version', arch='arch')
-        self.assertEqual('distribution: ks-family-version-arch-family-None-version-arch',
+        self.assertEqual('distribution: ks-family--version-arch-family-None-version-arch',
                          str(d))
 
 

--- a/plugins/test/unit/plugins/importers/yum/parse/test_treeinfo.py
+++ b/plugins/test/unit/plugins/importers/yum/parse/test_treeinfo.py
@@ -43,13 +43,13 @@ class TestRealData(unittest.TestCase):
         model, files = DistSync.parse_treeinfo_file(path)
 
         self.assertTrue(isinstance(model, models.Distribution))
-        self.assertEqual(model.distribution_id, 'ks-Red Hat Enterprise Linux Server-5.9-x86_64')
+        self.assertEqual(model.distribution_id, 'ks-Red Hat Enterprise Linux Server--5.9-x86_64')
 
         self.assertEqual(len(files), 19)
         for item in files:
             self.assertTrue(item['relativepath'])
 
-        self.assertEquals(None, model.variant)
+        self.assertEquals('', model.variant)
         self.assertEquals(None, model.packagedir)
 
 


### PR DESCRIPTION
Unit keys cannot be null or missing, since MongoEngine will just leave
them off the document. In particular, this broke migration 28.

Note this is the same as https://github.com/pulp/pulp_rpm/pull/883, just reopened against 2.8-dev