### PR TITLE
checksum_type setting for repo and group export distributor

### DIFF
--- a/common/pulp_rpm/common/constants.py
+++ b/common/pulp_rpm/common/constants.py
@@ -142,7 +142,8 @@ FORCE_FULL_KEYWORD = 'force_full'
 EXPORT_OPTIONAL_CONFIG_KEYS = (END_DATE_KEYWORD, ISO_PREFIX_KEYWORD, SKIP_KEYWORD,
                                EXPORT_DIRECTORY_KEYWORD, START_DATE_KEYWORD, ISO_SIZE_KEYWORD,
                                GENERATE_SQLITE_KEYWORD, CREATE_PULP_MANIFEST, RELATIVE_URL_KEYWORD,
-                               INCREMENTAL_EXPORT_REPOMD_KEYWORD, FORCE_FULL_KEYWORD)
+                               INCREMENTAL_EXPORT_REPOMD_KEYWORD, FORCE_FULL_KEYWORD,
+                               CONFIG_KEY_CHECKSUM_TYPE)
 
 EXPORT_HTTP_DIR = '/var/lib/pulp/published/http/exports/repo'
 EXPORT_HTTPS_DIR = '/var/lib/pulp/published/https/exports/repo'

--- a/docs/tech-reference/export-distributor.rst
+++ b/docs/tech-reference/export-distributor.rst
@@ -71,3 +71,8 @@ Optional Configuration Parameters
 ``manifest``
  If this boolean is True, a PULP_MANIFEST file will be created in the directory where ISOs are
  created. This allows the ISO importer to directly import what was published. Defaults to False.
+
+``checksum_type``
+ Checksum type to use for metadata generation. For any units where the checksum of this type is not
+ already known, it will be computed on-the-fly and saved for future use. If any such units have not
+ been downloaded, then checksum calculation is impossible, and the publish will fail gracefully.

--- a/docs/user-guide/release-notes/2.9.x.rst
+++ b/docs/user-guide/release-notes/2.9.x.rst
@@ -13,6 +13,8 @@ New Features
 * The <langpacks> tag in comps.xml are synced and published for repositories. These units are also
   parsed on upload. ``pulp-admin`` also has upload, remove, and search support for 
   package_langpacks.
-* The yum distributor now uses the configured checksum type for all repo metadata.
+* The yum distributor and export distributor now use the configured checksum type for all repo
+  metadata. The pulp-admin repo "create" and "update" commands now save the specified checksum type
+  on both distributors.
 * Repoview support is added. The ability to generate HTML files to browse a repository can be
   enabled by using ``--repoview`` option for the yum_distributor.

--- a/docs/user-guide/release-notes/2.9.x.rst
+++ b/docs/user-guide/release-notes/2.9.x.rst
@@ -16,5 +16,7 @@ New Features
 * The yum distributor and export distributor now use the configured checksum type for all repo
   metadata. The pulp-admin repo "create" and "update" commands now save the specified checksum type
   on both distributors.
+* The group export distributor now uses the configured checksum type for all repo metadata. The
+  pulp-admin command to run a group export accepts a checksum type argument.
 * Repoview support is added. The ability to generate HTML files to browse a repository can be
   enabled by using ``--repoview`` option for the yum_distributor.

--- a/extensions_admin/pulp_rpm/extensions/admin/export.py
+++ b/extensions_admin/pulp_rpm/extensions/admin/export.py
@@ -10,6 +10,7 @@ from pulp.client.extensions.extensions import PulpCliOption, PulpCliFlag
 from pulp.common import tags as tag_utils
 
 from pulp_rpm.common import ids, constants
+from pulp_rpm.extensions.admin import repo_options
 
 
 DESC_EXPORT_RUN = _('triggers an immediate export of a repository')
@@ -78,7 +79,8 @@ class RpmExportCommand(RunPublishRepositoryCommand):
         """
         override_config_options = [OPTION_EXPORT_DIR, OPTION_ISO_PREFIX, OPTION_ISO_SIZE,
                                    OPTION_START_DATE, OPTION_END_DATE, FLAG_MANIFEST,
-                                   OPTION_RELATIVE_URL, OPTION_INCREMENTAL_MD]
+                                   OPTION_RELATIVE_URL, OPTION_INCREMENTAL_MD,
+                                   repo_options.OPT_CHECKSUM_TYPE]
 
         super(RpmExportCommand, self).__init__(context=context,
                                                renderer=renderer,

--- a/extensions_admin/pulp_rpm/extensions/admin/export.py
+++ b/extensions_admin/pulp_rpm/extensions/admin/export.py
@@ -124,6 +124,7 @@ class RpmGroupExportCommand(PollingCommand):
         self.add_option(OPTION_SERVE_HTTPS)
         self.add_option(OPTION_SERVE_HTTP)
         self.add_option(OPTION_INCREMENTAL_MD)
+        self.add_option(repo_options.OPT_CHECKSUM_TYPE)
 
         self.add_flag(FLAG_MANIFEST)
 
@@ -144,6 +145,7 @@ class RpmGroupExportCommand(PollingCommand):
         serve_http = kwargs[OPTION_SERVE_HTTP.keyword]
         serve_https = kwargs[OPTION_SERVE_HTTPS.keyword]
         incremental_md = kwargs[OPTION_INCREMENTAL_MD.keyword]
+        checksum_type = kwargs[repo_options.OPT_CHECKSUM_TYPE.keyword]
 
         # Since the export distributor is not added to a repository group on creation, add it here
         # if it is not already associated with the group id
@@ -179,6 +181,7 @@ class RpmGroupExportCommand(PollingCommand):
             constants.RELATIVE_URL_KEYWORD: relative_url,
             constants.CREATE_PULP_MANIFEST: manifest,
             constants.INCREMENTAL_EXPORT_REPOMD_KEYWORD: incremental_md,
+            constants.CHECKSUM_TYPE: checksum_type,
         }
 
         # Remove keys from the config that have None value.

--- a/extensions_admin/pulp_rpm/extensions/admin/repo_create_update.py
+++ b/extensions_admin/pulp_rpm/extensions/admin/repo_create_update.py
@@ -41,6 +41,7 @@ EXPORT_DISTRIBUTOR_CONFIG_KEYS = [
     ('relative_url', 'relative_url'),
     ('generate_sqlite', 'generate_sqlite'),
     ('skip', 'skip'),
+    ('checksum_type', 'checksum_type'),
 ]
 
 

--- a/extensions_admin/test/unit/extensions/admin/test_export.py
+++ b/extensions_admin/test/unit/extensions/admin/test_export.py
@@ -71,7 +71,8 @@ class TestRepoGroupExportRunCommand(PulpClientTests):
             export.OPTION_RELATIVE_URL.keyword: None,
             export.OPTION_SERVE_HTTP.keyword: True,
             export.OPTION_SERVE_HTTPS.keyword: True,
-            export.OPTION_INCREMENTAL_MD.keyword: False
+            export.OPTION_INCREMENTAL_MD.keyword: False,
+            repo_options.OPT_CHECKSUM_TYPE.keyword: None,
         }
 
     def tearDown(self):
@@ -95,7 +96,8 @@ class TestRepoGroupExportRunCommand(PulpClientTests):
             export.OPTION_ISO_SIZE,
             export.OPTION_SERVE_HTTPS,
             export.OPTION_SERVE_HTTP,
-            export.OPTION_INCREMENTAL_MD
+            export.OPTION_INCREMENTAL_MD,
+            repo_options.OPT_CHECKSUM_TYPE,
         ]
 
         # Test

--- a/extensions_admin/test/unit/extensions/admin/test_export.py
+++ b/extensions_admin/test/unit/extensions/admin/test_export.py
@@ -9,7 +9,7 @@ from pulp.devel.unit.util import compare_dict
 from pulp_rpm.extensions.admin import export
 from pulp_rpm.common import constants, ids
 from pulp_rpm.devel.client_base import PulpClientTests
-from pulp_rpm.extensions.admin import status
+from pulp_rpm.extensions.admin import repo_options, status
 
 
 class TestRepoExportRunCommand(PulpClientTests):
@@ -35,7 +35,8 @@ class TestRepoExportRunCommand(PulpClientTests):
             export.OPTION_START_DATE,
             export.OPTION_ISO_PREFIX,
             export.OPTION_ISO_SIZE,
-            export.OPTION_INCREMENTAL_MD
+            export.OPTION_INCREMENTAL_MD,
+            repo_options.OPT_CHECKSUM_TYPE,
         ]
 
         # Test

--- a/extensions_admin/test/unit/extensions/admin/test_repo_create_update.py
+++ b/extensions_admin/test/unit/extensions/admin/test_repo_create_update.py
@@ -144,6 +144,7 @@ class RpmRepoCreateCommandTests(PulpClientTests):
         self.assertEqual(iso_config['https'], True)
         self.assertEqual(iso_config['relative_url'], '/repo')
         self.assertEqual(iso_config['skip'], [ids.TYPE_ID_RPM])
+        self.assertEqual(iso_config['checksum_type'], 'sha256')
 
         self.assertEqual([TAG_SUCCESS], self.prompt.get_write_tags())
 
@@ -312,6 +313,7 @@ class RpmRepoUpdateCommandTests(PulpClientTests):
             repo_options.OPT_SERVE_HTTP.keyword: True,
             repo_options.OPT_SERVE_HTTPS.keyword: True,
             repo_options.OPT_SKIP.keyword: [ids.TYPE_ID_RPM],
+            repo_options.OPT_CHECKSUM_TYPE.keyword: 'sha1',
         }
 
         self.server_mock.request.return_value = 200, {}
@@ -339,11 +341,13 @@ class RpmRepoUpdateCommandTests(PulpClientTests):
         self.assertEqual(yum_dist_config['http'], True)
         self.assertEqual(yum_dist_config['https'], True)
         self.assertEqual(yum_dist_config['skip'], [ids.TYPE_ID_RPM])
+        self.assertEqual(yum_dist_config['checksum_type'], 'sha1')
 
         iso_dist_config = body['distributor_configs'][ids.EXPORT_DISTRIBUTOR_ID]
         self.assertEqual(iso_dist_config['http'], True)
         self.assertEqual(iso_dist_config['https'], True)
         self.assertEqual(iso_dist_config['skip'], [ids.TYPE_ID_RPM])
+        self.assertEqual(iso_dist_config['checksum_type'], 'sha1')
 
     def test_run_through_cli(self):
         """


### PR DESCRIPTION
This adds two behaviors that are closely related. 1619 actually depended on doing part of 1969 first. I think it makes sense to review them together, hence the two commits in one PR.

https://pulp.plan.io/issues/1969
https://pulp.plan.io/issues/1619