### PR TITLE
Eliminate duplicated pkglists during XML generation.

### DIFF
--- a/plugins/pulp_rpm/plugins/distributors/yum/metadata/updateinfo.py
+++ b/plugins/pulp_rpm/plugins/distributors/yum/metadata/updateinfo.py
@@ -144,7 +144,12 @@ class UpdateinfoXMLFileContext(XmlFileContext):
         else:
             repo_unit_nevra = None
 
+        seen_pkglists = set()
         for pkglist in erratum_unit.pkglist:
+            packages = tuple(sorted(p['filename'] for p in pkglist['packages']))
+            if packages in seen_pkglists:
+                continue
+            seen_pkglists.add(packages)
 
             pkglist_element = ElementTree.SubElement(update_element, 'pkglist')
 

--- a/plugins/test/unit/plugins/distributors/yum/metadata/test_updateinfo.py
+++ b/plugins/test/unit/plugins/distributors/yum/metadata/test_updateinfo.py
@@ -1,14 +1,13 @@
 """
 Tests for the pulp_rpm.plugins.distributors.yum.metadata.updateinfo module.
 """
+import copy
 import re
 import unittest
 
-from pulp.plugins import model
 import mock
 
-from pulp_rpm.devel.skip import skip_broken
-from pulp_rpm.common import ids
+from pulp_rpm.plugins.db import models
 from pulp_rpm.plugins.distributors.yum.metadata import updateinfo
 
 
@@ -26,8 +25,36 @@ class UpdateinfoXMLFileContextTests(unittest.TestCase):
         # Let's fake the metadata_file_handle attribute so we can inspect calls to it.
         self.updateinfo_xml_file_context.metadata_file_handle = mock.MagicMock()
 
+        self.packages = [{'src': 'pulp-test-package-0.3.1-1.fc22.src.rpm',
+                          'name': 'pulp-test-package',
+                          'arch': 'x86_64',
+                          'sums': 'sums',
+                          'filename': 'pulp-test-package-0.3.1-1.fc22.x86_64.rpm',
+                          'epoch': '0',
+                          'version': '0.3.1',
+                          'release': '1.fc22',
+                          'type': 'sha256'}]
+        self.unit_data = {
+            'errata_id': 'RHSA-2014:0042',
+            'title': 'Some Title',
+            'release': '2',
+            'rights': 'You have the right to remain silent.',
+            'solution': 'Open Source is the solution to your problems.',
+            'severity': 'High',
+            'summary': 'A Summary',
+            # Note that pushcount is an int and not a string. This should be OK (no exceptions).
+            'pushcount': 1,
+            'status': 'symbol',
+            'type': 'security',
+            'version': '2.4.1',
+            'issued': '2014-05-27 00:00:00',
+            'reboot_suggested': True,
+            'references': [],
+            'updated': '2014-05-28 00:00:00',
+            'pkglist': [{'packages': self.packages, 'name': 'test-name', 'short': ''},
+                        {'packages': self.packages, 'name': 'test-name', 'short': ''}]}
 
-@skip_broken
+
 class AddUnitMetadataTests(UpdateinfoXMLFileContextTests):
     """
     Tests the UpdateinfoXMLFileContext.add_unit_metadata() method.
@@ -35,6 +62,8 @@ class AddUnitMetadataTests(UpdateinfoXMLFileContextTests):
 
     def test_handles_integer_pushcount(self):
         """
+        Test that the pushcount of type integer handled well.
+
         We had a bug[0] wherein uploaded errata couldn't be published because the pushcount would
         be represented as an int. Synchronized errata would have this field represented as a
         basestring. The descrepancy between these has been filed as a separate issue[1].
@@ -42,33 +71,11 @@ class AddUnitMetadataTests(UpdateinfoXMLFileContextTests):
         [0] https://bugzilla.redhat.com/show_bug.cgi?id=1100848
         [1] https://bugzilla.redhat.com/show_bug.cgi?id=1101728
         """
-        type_id = ids.TYPE_ID_ERRATA
-        unit_key = {'id': 'RHSA-2014:0042'}
-        metadata = {
-            'title': 'Some Title',
-            'release': '2',
-            'rights': 'You have the right to remain silent.',
-            'description': 'A Description',
-            'solution': 'Open Source is the solution to your problems.',
-            'severity': 'High',
-            'summary': 'A Summary',
-            # Note that pushcount is an int and not a string. This should be OK (no exceptions).
-            'pushcount': 1,
-            'status': 'symbol',
-            'type': 'security',
-            'version': '2.4.1',
-            'issued': '2014-05-27',
-            'reboot_suggested': 'true',
-            'references': [],
-        }
-        storage_path = '/some/path'
-        created = '2014-04-27'
-        updated = '2014-04-28'
-        erratum_unit = model.AssociatedUnit(type_id, unit_key, metadata, storage_path, created,
-                                            updated)
+        unit_data = copy.copy(self.unit_data)
+        unit_data['description'] = 'A Description'
+        erratum = models.Errata(**unit_data)
 
-        # This should not cause any Exception
-        self.updateinfo_xml_file_context.add_unit_metadata(erratum_unit)
+        self.updateinfo_xml_file_context.add_unit_metadata(erratum)
 
         self.assertEqual(self.updateinfo_xml_file_context.metadata_file_handle.write.call_count, 1)
         xml = self.updateinfo_xml_file_context.metadata_file_handle.write.mock_calls[0][1][0]
@@ -76,6 +83,9 @@ class AddUnitMetadataTests(UpdateinfoXMLFileContextTests):
 
     def test_no_description(self):
         """
+        Test that if the erratum has no description, the empty description element should be
+        generated.
+
         We had a bug[0] wherein an empty or missing description would result in
         XML that did not include a description element. The corresponding upstream
         repo (epel5) did have a description element that was merely empty, so the
@@ -83,33 +93,25 @@ class AddUnitMetadataTests(UpdateinfoXMLFileContextTests):
 
         [0] https://bugzilla.redhat.com/show_bug.cgi?id=1138475
         """
-        type_id = ids.TYPE_ID_ERRATA
-        unit_key = {'id': 'RHSA-2014:0042'}
-        metadata = {
-            'title': 'Some Title',
-            'release': '2',
-            'rights': 'You have the right to remain silent.',
-            'solution': 'Open Source is the solution to your problems.',
-            'severity': 'High',
-            'summary': 'A Summary',
-            # Note that pushcount is an int and not a string. This should be OK (no exceptions).
-            'pushcount': 1,
-            'status': 'symbol',
-            'type': 'security',
-            'version': '2.4.1',
-            'issued': '2014-05-27',
-            'reboot_suggested': 'true',
-            'references': [],
-        }
-        storage_path = '/some/path'
-        created = '2014-04-27'
-        updated = '2014-04-28'
-        erratum_unit = model.AssociatedUnit(type_id, unit_key, metadata, storage_path, created,
-                                            updated)
+        erratum = models.Errata(**self.unit_data)
 
-        # This should not cause any Exception
-        self.updateinfo_xml_file_context.add_unit_metadata(erratum_unit)
+        self.updateinfo_xml_file_context.add_unit_metadata(erratum)
 
         self.assertEqual(self.updateinfo_xml_file_context.metadata_file_handle.write.call_count, 1)
         xml = self.updateinfo_xml_file_context.metadata_file_handle.write.mock_calls[0][1][0]
         self.assertTrue(re.search('<description */>', xml) is not None)
+
+    def test_no_duplicated_pkglists(self):
+        """
+        Test that no duplicated pkglists are generated.
+        """
+        erratum = models.Errata(**self.unit_data)
+        expected_pkg_str = '<package arch="x86_64" epoch="0" name="pulp-test-package"' \
+                           ' release="1.fc22" src="pulp-test-package-0.3.1-1.fc22.src.rpm"' \
+                           ' version="0.3.1">'
+
+        self.updateinfo_xml_file_context.add_unit_metadata(erratum)
+
+        self.assertEqual(self.updateinfo_xml_file_context.metadata_file_handle.write.call_count, 1)
+        xml = self.updateinfo_xml_file_context.metadata_file_handle.write.mock_calls[0][1][0]
+        self.assertEqual(xml.count(expected_pkg_str), 1)


### PR DESCRIPTION
close #1783
https://pulp.plan.io/issues/1783