### PR TITLE
Overwriting a metadata unit during copy disassociates first

### DIFF
--- a/plugins/pulp_rpm/plugins/importers/yum/associate.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/associate.py
@@ -364,7 +364,9 @@ def associate_copy_for_repo(unit, dest_repo, set_content=False):
         # It is possible that a previous copy exists as an orphan, in which case it can safely
         # be deleted and replaced with this new version.
         _LOGGER.debug(_('replacing pre-existing copy of %(u)s' % {'u': new_unit}))
-        new_unit.__class__.objects.filter(**new_unit.unit_key).delete()
+        existing_unit_qs = new_unit.__class__.objects.filter(**new_unit.unit_key)
+        repo_controller.disassociate_units(dest_repo, existing_unit_qs)
+        existing_unit_qs.delete()
         new_unit.save()
 
     if set_content:

--- a/plugins/pulp_rpm/plugins/migrations/0031_regenerate_repo_unit_counts.py
+++ b/plugins/pulp_rpm/plugins/migrations/0031_regenerate_repo_unit_counts.py
@@ -1,0 +1,50 @@
+"""
+Migration to regenerate the repo unit counts after a issue 1979 is fixed which caused some of them
+to be too high.
+
+https://pulp.plan.io/issues/1979
+
+"""
+
+from pulp.server.db import connection
+
+
+def rebuild_content_unit_counts(db, repo_id):
+    """
+    Update the content_unit_counts field on a Repository.
+
+    :param db: The database reference to use
+    :type db: pymongo.database.Database
+    :param repo_id: The repository id to update
+    :type repo_id: basestring
+    """
+    repos_collection = db['repos']
+
+    pipeline = [
+        {'$match': {'repo_id': repo_id}},
+        {'$group': {'_id': '$unit_type_id', 'sum': {'$sum': 1}}}]
+    q = db.command('aggregate', 'repo_content_units', pipeline=pipeline)
+
+    # Flip this into the form that we need
+    counts = {}
+    for result in q['result']:
+        counts[result['_id']] = result['sum']
+
+    if counts:
+        repos_collection.update_one({'repo_id': repo_id}, {'$set': {'content_unit_counts': counts}})
+
+
+def migrate(*args, **kwargs):
+    """
+    Perform the migration as described in this module's docblock.
+
+    :param args:   unused
+    :type  args:   list
+    :param kwargs: unused
+    :type  kwargs: dict
+    """
+    db = connection.get_database()
+    repos_collection = db['repos']
+    for repo in repos_collection.find():
+        repo_id = repo['repo_id']
+        rebuild_content_unit_counts(db, repo_id)

--- a/plugins/test/unit/plugins/migrations/test_0031_regenerate_repo_unit_counts.py
+++ b/plugins/test/unit/plugins/migrations/test_0031_regenerate_repo_unit_counts.py
@@ -1,0 +1,61 @@
+import unittest
+
+import mock
+
+from pulp.server.db.migrate.models import _import_all_the_way
+
+
+PATH_TO_MODULE = 'pulp_rpm.plugins.migrations.0031_regenerate_repo_unit_counts'
+
+migration = _import_all_the_way(PATH_TO_MODULE)
+
+
+class TestMigrate(unittest.TestCase):
+    """
+    Test migration 0031.
+    """
+
+    @mock.patch(PATH_TO_MODULE + '.rebuild_content_unit_counts')
+    @mock.patch(PATH_TO_MODULE + '.connection')
+    def test_migration(self, mock_connection, mock_rebuild_content_unit_counts):
+        mock_repos = mock.Mock()
+        mock_db = {'repos': mock_repos}
+        mock_connection.get_database.return_value = mock_db
+        mock_repo_id = mock.Mock()
+        mock_repo = {'repo_id': mock_repo_id}
+        mock_repos.find.return_value = [mock_repo]
+
+        migration.migrate()
+
+        mock_rebuild_content_unit_counts.assert_called_once_with(mock_db, mock_repo_id)
+
+    def test_rebuild_content_unit_counts(self):
+        faketype = 'faketype'
+        count = 100
+        mock_q = {
+            'result': [{
+                '_id': faketype,
+                'sum': count,
+            }]
+        }
+
+        class MockDatabase(dict):
+            command = mock.Mock(return_value=mock_q)
+        mock_repos = mock.Mock()
+        mock_db = MockDatabase()
+        mock_db['repos'] = mock_repos
+        mock_repo_id = mock.Mock()
+
+        migration.rebuild_content_unit_counts(mock_db, mock_repo_id)
+
+        mock_db.command.assert_called_once_with(
+            'aggregate', 'repo_content_units',
+            pipeline=[
+                {'$match': {'repo_id': mock_repo_id}},
+                {'$group': {'sum': {'$sum': 1}, '_id': '$unit_type_id'}}
+            ]
+        )
+        mock_repos.update_one.assert_called_once_with(
+            {'repo_id': mock_repo_id},
+            {'$set': {'content_unit_counts': {faketype: count}}}
+        )


### PR DESCRIPTION
The metadata units have an overwrite functionaity whereby newer
units overwrite older units if they have the same unit key. The
unit being overwritten is deleted and the new one is added. The
unit being deleted did not have disassociate called so the
unit count would be wrong for these unit types after multiple
copies.

HEAD of pulp-smash passes and all unit tests pass

https://pulp.plan.io/issues/1979
fixes #1979