### PR TITLE
Fixes mistakes in 2.9 release notes.

### DIFF
--- a/docs/user-guide/release-notes/2.9.x.rst
+++ b/docs/user-guide/release-notes/2.9.x.rst
@@ -20,7 +20,6 @@ New Features
   pulp-admin command to run a group export accepts a checksum type argument.
 * Repoview support is added. The ability to generate HTML files to browse a repository can be
   enabled by using ``--repoview`` option for the yum_distributor.
-* The yum distributor now uses the configured checksum type for all repo metadata.
-* The yum distributow now supports the optional parameter
+* The yum distributor now supports the optional parameter
   ``packages_directory`` which can be used for custom destination directory
-  for packages during the publish process
+  for packages during the publish process.


### PR DESCRIPTION
The last note had a couple of typos.

The note I removed about checksum type is a duplicate of one above, and probably made its way in via a merge conflict resolution.