### PR TITLE
As a user, I can have an "signature" attribute stored for RPMs, SRPMs…

### DIFF
--- a/plugins/pulp_rpm/plugins/db/models.py
+++ b/plugins/pulp_rpm/plugins/db/models.py
@@ -117,6 +117,9 @@ class NonMetadataPackage(UnitMixin, FileContentUnit):
     :ivar checksum: The checksum of the package.
     :type checksum: mongoengine.StringField
 
+    :ivar signature: The signature of the package.
+    :type signature: mongoengine.StringField
+
     :ivar version_sort_index: ???
     :type version_sort_index: mongoengine.StringField
 
@@ -129,6 +132,7 @@ class NonMetadataPackage(UnitMixin, FileContentUnit):
     checksum = mongoengine.StringField(required=True)
     checksumtype = ChecksumTypeStringField(required=True)
     checksums = mongoengine.DictField()
+    signature = mongoengine.StringField()
 
     # We generate these two
     version_sort_index = mongoengine.StringField()

--- a/plugins/pulp_rpm/plugins/importers/yum/upload.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/upload.py
@@ -458,16 +458,7 @@ def _extract_rpm_data(type_id, rpm_filename):
     rpm_data = dict()
 
     # Read the RPM header attributes for use later
-    ts = rpm.TransactionSet()
-    ts.setVSFlags(rpm._RPMVSF_NOSIGNATURES)
-    fd = os.open(rpm_filename, os.O_RDONLY)
-    try:
-        headers = ts.hdrFromFdno(fd)
-        os.close(fd)
-    except rpm.error:
-        # Raised if the headers cannot be read
-        os.close(fd)
-        raise
+    headers = rpm_parse.package_headers(rpm_filename)
 
     for k in ['name', 'version', 'release', 'epoch']:
         rpm_data[k] = headers[k]
@@ -520,6 +511,7 @@ def _extract_rpm_data(type_id, rpm_filename):
     # rpm_parse.get_package_xml(..)
     file_stat = os.stat(rpm_filename)
     rpm_data['time'] = file_stat[stat.ST_MTIME]
+    rpm_data['signature'] = rpm_parse.package_signature(headers)
 
     return rpm_data
 

--- a/plugins/test/unit/plugins/importers/yum/parse/test_rpm.py
+++ b/plugins/test/unit/plugins/importers/yum/parse/test_rpm.py
@@ -1,9 +1,15 @@
-import unittest
+from __future__ import absolute_import
+import os
+
+import rpm as rpm_module
 
 from mock import patch, Mock
+from pulp.common.compat import unittest
 from pulp.devel.unit import util
 
 from pulp_rpm.plugins.importers.yum.parse import rpm
+
+DATA_DIR = os.path.join(os.path.dirname(__file__), '../../../../../data')
 
 
 class TesGetPackageXml(unittest.TestCase):
@@ -30,3 +36,23 @@ class TestStringToUnicode(unittest.TestCase):
         start_string.decode.side_effect = UnicodeError()
         result_string = rpm.string_to_unicode(start_string)
         self.assertEquals(None, result_string)
+
+
+class PackageHeaders(unittest.TestCase):
+    """
+    tests for package headers and signature extraction
+    """
+
+    def test_package_signature_from_header(self):
+        sample_rpm_filename = os.path.join(DATA_DIR, 'walrus-5.21-1.noarch.rpm')
+        headers = rpm.package_headers(sample_rpm_filename)
+        self.assertTrue(isinstance(headers, rpm_module.hdr))
+        signature = rpm.package_signature(headers)
+        self.assertEquals(signature, 'f78fb195')
+        self.assertEquals(len(signature), 8)
+
+    def test_invalid_package_headers(self):
+        fake_rpm_file = os.path.join(DATA_DIR, 'fake.rpm')
+        with self.assertRaises(rpm_module.error) as e:
+            rpm.package_headers(fake_rpm_file)
+        self.assertEquals(e.exception.message, 'error reading package header')


### PR DESCRIPTION
…, and DRPMs

closes #1156
https://pulp.plan.io/issues/1156