### PR TITLE
Erratum publish reads repo nevra into memory

### DIFF
--- a/plugins/pulp_rpm/plugins/db/models.py
+++ b/plugins/pulp_rpm/plugins/db/models.py
@@ -1,3 +1,4 @@
+from collections import namedtuple
 import csv
 import logging
 import os
@@ -17,6 +18,9 @@ from pulp_rpm.yum_plugin import util
 
 
 _LOGGER = logging.getLogger(__name__)
+
+
+NEVRA = namedtuple('NEVRA', ['name', 'epoch', 'version', 'release', 'arch'])
 
 
 class UnitMixin(object):

--- a/plugins/pulp_rpm/plugins/distributors/yum/metadata/updateinfo.py
+++ b/plugins/pulp_rpm/plugins/distributors/yum/metadata/updateinfo.py
@@ -1,9 +1,7 @@
 import os
 from xml.etree import ElementTree
 
-import mongoengine
 from pulp.plugins.util.metadata_writer import XmlFileContext
-from pulp.server.db.model import RepositoryContentUnit
 
 from pulp_rpm.plugins.distributors.yum.metadata.metadata import REPO_DATA_DIR_NAME
 from pulp_rpm.plugins.db import models
@@ -16,64 +14,57 @@ UPDATE_INFO_XML_FILE_NAME = 'updateinfo.xml.gz'
 
 
 class UpdateinfoXMLFileContext(XmlFileContext):
-    def __init__(self, working_dir, checksum_type=None, conduit=None):
+
+    def __init__(self, working_dir, nevra_in_repo, checksum_type=None, conduit=None):
+        """
+        Creates and writes updateinfo XML data.
+
+        :param working_dir: The working directory for the request
+        :type working_dir:  basestring
+        :param nevra_in_repo: The nevra of all rpms in the repo.
+        :type nevra_in_repo:  set of models.NEVRA objects
+        :param checksum_type: The type of checksum to be used
+        :type checksum_type:  basestring
+        :param conduit: A conduit to use
+        :type conduit:  pulp.plugins.conduits.repo_publish.RepoPublishConduit
+        """
+        self.nevra_in_repo = nevra_in_repo
         metadata_file_path = os.path.join(working_dir, REPO_DATA_DIR_NAME,
                                           UPDATE_INFO_XML_FILE_NAME)
         self.conduit = conduit
         super(UpdateinfoXMLFileContext, self).__init__(
             metadata_file_path, 'updates', checksum_type=checksum_type)
 
-    def _repo_unit_nevra(self, erratum_unit, repo_id):
+    def _get_repo_unit_nevra(self, erratum_unit):
         """
         Return a list of NEVRA dicts for units in a single repo referenced by the given errata.
 
         Pulp errata units combine the known packages from all synced repos. Given an errata unit
         and a repo, return a list of NEVRA dicts that can be used to filter out packages not
-        linked to that repo when generating a repo's updateinfo XML file. While returning that
-        list of NEVRA dicts is the main goal, doing so quickly and without running out of memory
-        is what makes this a little bit tricky.
-
-        Build up a super-fancy query to get the unit ids for all NEVRA seen in these errata
-        check repo/unit associations for this errata to limit the packages in the published
-        updateinfo to the units in the repo being currently published.
+        linked to that repo when generating a repo's updateinfo XML file.
 
         :param erratum_unit: The erratum unit that should be written to updateinfo.xml.
         :type erratum_unit: pulp_rpm.plugins.db.models.Errata
-        :param repo_id: The repo_id of a pulp repository in which to find units
-        :type repo_id: str
+
         :return: a list of NEVRA dicts for units in a single repo referenced by the given errata
         :rtype: list
         """
-        nevra_fields = ('name', 'epoch', 'version', 'release', 'arch')
-        nevra_q = mongoengine.Q()
+        nevra_in_repo_and_pkglist = []
         for pkglist in erratum_unit.pkglist:
             for pkg in pkglist['packages']:
-                pkg_nevra = dict((field, pkg[field]) for field in nevra_fields)
-                nevra_q |= mongoengine.Q(**pkg_nevra)
-
-        # Aim the super-fancy query at mongo to get the units that this errata refers to
-        # The scaler method on the end returns a list of tuples to try to save some memory
-        # and also cut down on mongoengine model instance hydration costs.
-        nevra_units = models.RPM.objects.filter(nevra_q).scalar('id', *nevra_fields)
-
-        # Split up the nevra unit entries into a mapping of the unit id to its nevra fields
-        nevra_unit_map = dict((nevra_unit[0], nevra_unit[1:]) for nevra_unit in nevra_units)
-
-        # Get all of the unit ids from this errata that are associated with the current repo.
-        # Cast this as a set for speedier lookups when iterating of the nevra unit map.
-        repo_unit_ids = set(RepositoryContentUnit.objects.filter(
-            unit_id__in=nevra_unit_map.keys(), repo_id=repo_id).scalar('unit_id'))
-
-        # Finally(!), intersect the repo unit ids with the unit nevra ids to
-        # create a list of nevra dicts that can be easily compared to the
-        # errata package nevra and exclude unrelated packages
-        repo_unit_nevra = []
-        for nevra_unit_id, nevra_field_values in nevra_unit_map.items():
-            # based on the args to scalar when nevra_units was created:
-            if nevra_unit_id in repo_unit_ids:
-                repo_unit_nevra.append(dict(zip(nevra_fields, nevra_field_values)))
-
-        return repo_unit_nevra
+                pkg_nevra = models.NEVRA(name=pkg['name'], epoch=pkg['epoch'],
+                                         version=pkg['version'], release=pkg['release'],
+                                         arch=pkg['arch'])
+                if pkg_nevra in self.nevra_in_repo:
+                    pkg_dict = {
+                        'name': pkg_nevra.name,
+                        'epoch': pkg_nevra.epoch,
+                        'version': pkg_nevra.version,
+                        'release': pkg_nevra.release,
+                        'arch': pkg_nevra.arch,
+                    }
+                    nevra_in_repo_and_pkglist.append(pkg_dict)
+        return nevra_in_repo_and_pkglist
 
     def add_unit_metadata(self, item):
         """
@@ -140,7 +131,7 @@ class UpdateinfoXMLFileContext(XmlFileContext):
 
         # If we can pull a repo_id off the conduit, use that to generate repo-specific nevra
         if self.conduit and hasattr(self.conduit, 'repo_id'):
-            repo_unit_nevra = self._repo_unit_nevra(erratum_unit, self.conduit.repo_id)
+            repo_unit_nevra = self._get_repo_unit_nevra(erratum_unit)
         else:
             repo_unit_nevra = None
 

--- a/plugins/pulp_rpm/plugins/distributors/yum/publish.py
+++ b/plugins/pulp_rpm/plugins/distributors/yum/publish.py
@@ -1,4 +1,5 @@
 import copy
+import itertools
 import os
 import subprocess
 from gettext import gettext as _
@@ -13,6 +14,7 @@ from pulp.plugins.util import misc as plugin_misc
 from pulp.plugins.util import publish_step as platform_steps
 from pulp.server.db import model
 from pulp.server.exceptions import InvalidValue, PulpCodedException
+from pulp.server.controllers import repository as repo_controller
 
 from pulp_rpm.common import constants, ids
 from pulp_rpm.yum_plugin import util
@@ -550,6 +552,7 @@ class PublishErrataStep(platform_steps.UnitModelPluginStep):
     """
     Publish all errata
     """
+
     def __init__(self, **kwargs):
         super(PublishErrataStep, self).__init__(constants.PUBLISH_ERRATA_STEP, [models.Errata],
                                                 **kwargs)
@@ -562,10 +565,19 @@ class PublishErrataStep(platform_steps.UnitModelPluginStep):
         Initialize the UpdateInfo file and set the method used to process the unit to the
         one that is built into the UpdateinfoXMLFileContext
         """
+        repo_id = self.get_repo().id
+        nevra_fields = ('name', 'epoch', 'version', 'release', 'arch')
+        querysets = repo_controller.get_unit_model_querysets(repo_id, models.RPM)
+        nevra_scalars = itertools.chain(*[q.scalar(*nevra_fields) for q in querysets])
+        nevra_in_repo = set()
+        for scalar in nevra_scalars:
+            nevra_in_repo.add(models.NEVRA(*scalar))
+
         checksum_type = self.parent.get_checksum_type()
-        self.context = UpdateinfoXMLFileContext(self.get_working_dir(), checksum_type,
-                                                self.get_conduit())
+        self.context = UpdateinfoXMLFileContext(self.get_working_dir(), nevra_in_repo,
+                                                checksum_type, self.get_conduit())
         self.context.initialize()
+
         # set the self.process_unit method to the corresponding method on the
         # UpdateInfoXMLFileContext as there is no other processing to be done for each unit.
         self.process_main = self.context.add_unit_metadata

--- a/plugins/test/unit/plugins/distributors/yum/metadata/test_updateinfo.py
+++ b/plugins/test/unit/plugins/distributors/yum/metadata/test_updateinfo.py
@@ -21,7 +21,9 @@ class UpdateinfoXMLFileContextTests(unittest.TestCase):
         """
         Build an UpdateinfoXMLFileContext and store it on self.updateinfo_xml_file_context.
         """
-        self.updateinfo_xml_file_context = updateinfo.UpdateinfoXMLFileContext('some_working_dir')
+        nevra_in_repo = set([('pulp-test-package', '0', '0.3.1', '1.fc22', 'x86_64')])
+        self.updateinfo_xml_file_context = updateinfo.UpdateinfoXMLFileContext('some_working_dir',
+                                                                               nevra_in_repo)
         # Let's fake the metadata_file_handle attribute so we can inspect calls to it.
         self.updateinfo_xml_file_context.metadata_file_handle = mock.MagicMock()
 


### PR DESCRIPTION
The Errata publish performance became a problem recently
due to lots of db calls being made as Errata metadata is filtered
to only refer to packages in this specific repo.

This PR causes all the repo's NEVRA to be stored in memory once
and all filtering to work out of that data structure. This avoids
searching the db everytime for the NEVRA specified by the erratum
so it does much less work than before.

https://pulp.plan.io/issues/1949
fixes #1949