### PR TITLE
Remove intersphinx and enable Strict mode

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -W -n
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,7 +30,7 @@ rtd_builder = 'latest'
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.intersphinx', 'sphinx.ext.extlinks']
+extensions = ['sphinx.ext.extlinks']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -245,9 +245,6 @@ texinfo_documents = [
 
 # How to display URL addresses: 'footnote', 'no', or 'inline'.
 #texinfo_show_urls = 'footnote'
-
-intersphinx_mapping = {'python': ('http://docs.python.org/2.7/', None),
-                       'platform': (("http://pulp.readthedocs.org/en/%s/" % rtd_builder), None)}
 
 extlinks = {'redmine': ('https://pulp.plan.io/issues/%s', '#'),
             'fixedbugs': ('https://pulp.plan.io/projects/pulp_rpm/issues?c%%5B%%5D=tracker&c%%5B'

--- a/docs/user-guide/installation.rst
+++ b/docs/user-guide/installation.rst
@@ -2,17 +2,16 @@ Installation
 ============
 
 .. note::
-  If you followed the Pulp :ref:`installation <platform:server_installation>`
-  instructions you already have RPM features installed. If not, this document
-  will walk you through the installation.
+  If you followed the Pulp installation instructions you already have RPM
+  features installed. If not, this document will walk you through the installation.
 
 Prerequisites
 -------------
 
 The only requirement is to meet the prerequisites of the Pulp Platform. Please
-see the :ref:`Pulp Installation Guide <platform:server_installation>` for
-prerequisites including repository setup. Also reference that document to learn
-more about what each of the following components are for.
+see the Pulp Installation Guide for prerequisites including repository setup.
+Also reference that document to learn more about what each of the following
+components are for.
 
 Server
 ------


### PR DESCRIPTION
Intersphinx was preventing the strict mode from being enabled
due to docs being built in a network isolated mock environment.

Intersphinx was also going to break because it is tied
to URLs from ReadTheDocs. Now intersphinx is removed, and
usage of it was dropped from the content. Strict Sphinx
mode is now enabled.

https://pulp.plan.io/issues/2034
re #2034