### PR TITLE
Removes all RTD references

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,13 +16,6 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #sys.path.insert(0, os.path.abspath('.'))
 
-# this var should refer to where intersphinx should pull inv files from. For
-# example, this would be set to '2.6-release' for the 2.6 branches, which would
-# pull objects.inv from http://pulp.readthedocs.org/en/2.6-release/objects.inv.
-# For master, this should point to 'latest'.
-
-rtd_builder = 'latest'
-
 # -- General configuration -----------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.

--- a/docs/user-guide/configuration.rst
+++ b/docs/user-guide/configuration.rst
@@ -11,7 +11,7 @@ The yum importer is configured by editing
 
 The importer supports the settings documented in Pulp's `importer config docs`_.
 
-.. _importer config docs: https://pulp.readthedocs.org/en/latest/user-guide/server.html#importers
+.. _importer config docs: https://docs.pulpproject.org/en/latest/user-guide/server.html#importers
 
 ISO Importer Configuration
 --------------------------
@@ -23,7 +23,7 @@ The ISO importer is configured by editing
 
 The importer supports the settings documented in Pulp's `importer config docs`_.
 
-.. _importer config docs: https://pulp.readthedocs.org/en/latest/user-guide/server.html#importers
+.. _importer config docs: https://docs.pulpproject.org/en/latest/user-guide/server.html#importers
 
 Protected Repositories
 ----------------------

--- a/docs/user-guide/release-notes/2.1.x.rst
+++ b/docs/user-guide/release-notes/2.1.x.rst
@@ -43,7 +43,7 @@ Upgrade Instructions
 Upgrade the Pulp Packages
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Please see the `Pulp Platform 2.1.1 upgrade instructions <https://pulp-user-guide.readthedocs.io/en/pulp-2.1/release-notes.html#pulp-2-1-1>`_
+Please see the `Pulp Platform 2.1.1 upgrade instructions <https://docs.pulpproject.org/en/latest/user-guide/release-notes/2.1.x.html#pulp-2-1-1>`_
 for information on how to complete the upgrade.
 
 Pulp 2.1.0
@@ -95,5 +95,5 @@ Upgrade the Pulp Packages
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Please see the
-`Pulp Platform 2.1.0 upgrade instructions <https://pulp-user-guide.readthedocs.io/en/pulp-2.1/release-notes.html#pulp-2-1-0>`_
+`Pulp Platform 2.1.0 upgrade instructions <https://docs.pulpproject.org/en/latest/user-guide/release-notes/2.1.x.html#pulp-2-1-0>`_
 for information on how to complete the upgrade.

--- a/docs/user-guide/release-notes/2.2.x.rst
+++ b/docs/user-guide/release-notes/2.2.x.rst
@@ -100,7 +100,7 @@ Upgrade Instructions
 --------------------
 
 Please see the
-`Pulp Platform upgrade instructions <https://pulp-user-guide.readthedocs.org/en/pulp-2.2/release-notes.html>`_
+`Pulp Platform upgrade instructions <https://docs.pulpproject.org/en/latest/user-guide/release-notes/2.2.x.html>`_
 for information on how to complete the upgrade.
 
 The location of the global configuration file for the yum importer has changed. Any

--- a/docs/user-guide/release-notes/2.4.x.rst
+++ b/docs/user-guide/release-notes/2.4.x.rst
@@ -17,8 +17,8 @@ The 2.4.4 release is a minor bugfix release. You can see the
 bug_ status=RELEASE_PENDING&bug_status=CLOSED&classification=Community&component=iso-support&
 component =rpm-support&list_id=2768109&product=Pulp&query_format=advanced&target_release=2.4.4>`_.
 
-Please see the `Pulp Platform upgrade instructions <https://pulp-user-guide.readthedocs.org/
-en/2.4-release/release-notes.html>`_ for information on how to perform the upgrade.
+Please see the `Pulp Platform upgrade instructions <https://docs.pulpproject.org/en/latest/
+user-guide/release-notes/2.4.x.html#pulp-2-4-4>`_ for information on how to perform the upgrade.
 
 
 Pulp RPM 2.4.3
@@ -112,8 +112,8 @@ Upgrade Instructions
 
  - pulp_rpm has added a dependency on python-lxml for xml parsing
 
-Please see the `Pulp Platform upgrade instructions <https://pulp-user-guide.readthedocs.org/
-en/2.4-release/release-notes.html>`_ for information on how to perform the upgrade.
+Please see the `Pulp Platform upgrade instructions <https://docs.pulpproject.org/en/latest/
+user-guide/release-notes/2.4.x.html#pulp-2-4-0>`_ for information on how to perform the upgrade.
 
 Known Issues
 ------------

--- a/docs/user-guide/release-notes/2.5.x.rst
+++ b/docs/user-guide/release-notes/2.5.x.rst
@@ -25,8 +25,8 @@ This release fixes `#1175818 <https://bugzilla.redhat.com/show_bug.cgi?id=117581
 `#1178920 <https://bugzilla.redhat.com/show_bug.cgi?id=1178920>`_,
 `#1171278 <https://bugzilla.redhat.com/show_bug.cgi?id=1171278>`_ and
 `#1159040 <https://bugzilla.redhat.com/show_bug.cgi?id=1159040>`_. To perform the
-upgrade, follow the Platform `upgrade instructions <http://pulp-user-guide.readthedocs.org/en/
-2.5-release/release-notes/2.5.x.html#upgrade-instructions-for-2-4-x-2-5-x>`_.
+upgrade, follow the Platform `upgrade instructions <https://docs.pulpproject.org/en/latest/
+user-guide/release-notes/2.5.x.html#upgrade-instructions-for-2-4-x-2-5-x>`_.
 
 Pulp RPM 2.5.1
 ==============


### PR DESCRIPTION
The RTD links are replaced with new links pointing to
https://docs.pulpproject.org/

https://pulp.plan.io/issues/2034
re #2034