### PR TITLE
"other" and "filelists" XML snippet processing fixed to not do slicing

### DIFF
--- a/plugins/pulp_rpm/plugins/db/models.py
+++ b/plugins/pulp_rpm/plugins/db/models.py
@@ -833,8 +833,8 @@ class RpmBase(NonMetadataPackage):
         self._templatize_pkgid(filelists)
 
         self.repodata['primary'] = utils.remove_fake_element(utils.element_to_text(faked_primary))
-        self.repodata['other'] = utils.remove_fake_element(utils.element_to_text(other))
-        self.repodata['filelists'] = utils.remove_fake_element(utils.element_to_text(filelists))
+        self.repodata['other'] = utils.element_to_text(other)
+        self.repodata['filelists'] = utils.element_to_text(filelists)
 
     @classmethod
     def _templatize_pkgid(cls, element):

--- a/plugins/pulp_rpm/plugins/migrations/0033_checksums_and_templates.py
+++ b/plugins/pulp_rpm/plugins/migrations/0033_checksums_and_templates.py
@@ -107,8 +107,8 @@ def _modify_xml(repodata):
 
     return {
         'primary': remove_fake_element(element_to_text(faked_primary)),
-        'other': remove_fake_element(element_to_text(other)),
-        'filelists': remove_fake_element(element_to_text(filelists)),
+        'other': element_to_text(other),
+        'filelists': element_to_text(filelists),
     }
 
 

--- a/plugins/test/unit/plugins/db/test_models.py
+++ b/plugins/test/unit/plugins/db/test_models.py
@@ -6,6 +6,7 @@ import math
 import os
 import shutil
 import tempfile
+from xml.etree import ElementTree as ET
 
 import mock
 from pulp.common.compat import unittest
@@ -151,6 +152,12 @@ class TestRpmBaseModifyXML(unittest.TestCase):
         self.unit.filename = 'fixed-filename.rpm'
         self.checksum = '951e0eacf3e6e6102b10acb2e689243b5866ec2c7720e783749dbd32f4a69ab3'
 
+    def assertParsable(self, text):
+        try:
+            ET.fromstring(text)
+        except ET.ParseError:
+            self.fail('could not parse XML')
+
     def test_update_location(self):
         self.unit.modify_xml()
 
@@ -168,11 +175,13 @@ class TestRpmBaseModifyXML(unittest.TestCase):
         self.unit.modify_xml()
         self.assertTrue('{{ pkgid }}' in self.unit.repodata['other'])
         self.assertTrue(self.checksum not in self.unit.repodata['other'])
+        self.assertParsable(self.unit.repodata['other'])
 
     def test_checksum_filelists_pkgid(self):
         self.unit.modify_xml()
         self.assertTrue('{{ pkgid }}' in self.unit.repodata['filelists'])
         self.assertTrue(self.checksum not in self.unit.repodata['filelists'])
+        self.assertParsable(self.unit.repodata['filelists'])
 
 
 class TestDistribution(unittest.TestCase):

--- a/plugins/test/unit/plugins/migrations/test_0033_checksums_and_templates.py
+++ b/plugins/test/unit/plugins/migrations/test_0033_checksums_and_templates.py
@@ -1,4 +1,5 @@
 from pulp.common.compat import unittest
+from xml.etree import ElementTree as ET
 
 import mock
 
@@ -88,17 +89,25 @@ class TestModifyXml(unittest.TestCase):
             'filelists': FILELISTS,
         }
 
+    def assertParsable(self, text):
+        try:
+            ET.fromstring(text)
+        except ET.ParseError:
+            self.fail('could not parse XML')
+
     def test_other_template(self):
         ret = migration._modify_xml(self.repodata)
 
         self.assertTrue('{{ pkgid }}' in ret['other'])
         self.assertTrue('f4200643b' not in ret['other'])
+        self.assertParsable(ret['other'])
 
     def test_filelists_template(self):
         ret = migration._modify_xml(self.repodata)
 
         self.assertTrue('{{ pkgid }}' in ret['filelists'])
         self.assertTrue('f4200643b' not in ret['filelists'])
+        self.assertParsable(ret['filelists'])
 
     def test_primary_template(self):
         ret = migration._modify_xml(self.repodata)


### PR DESCRIPTION
These snippets were mistakenly being sent through the "remove_fake_element"
function, which would slice them incorrectly and shave off a single character.
This was ok most of the time, because it would be a white space character. But
occasionally it was the final ">" of the XML.

fixes #2037
https://pulp.plan.io/issues/2037