### PR TITLE
Fixes publish of Errata with reboot_suggested == False

### DIFF
--- a/docs/user-guide/release-notes/2.8.x.rst
+++ b/docs/user-guide/release-notes/2.8.x.rst
@@ -2,6 +2,18 @@
 Pulp 2.8 Release Notes
 ======================
 
+Pulp 2.8.6
+==========
+
+See the list of :fixedbugs:`2.8.6`
+
+In particular, issue 2032 fixed an incorrect publishing and parsing of Errata. The consequence was
+that yum might think an Erratum served by pulp suggests a reboot, when it actually does not. It is
+highly recommended that you re-publish any repositories that contain Errata after upgrading, which
+will correct the information about whether a reboot is suggested. Furthermore, if you sync Errata
+from one Pulp to another, it is highly recommended that you re-sync each repository that contains
+Errata. This will fix any records that have an incorrect value for "reboot_suggested".
+
 Pulp 2.8.5
 ==========
 

--- a/plugins/pulp_rpm/plugins/db/models.py
+++ b/plugins/pulp_rpm/plugins/db/models.py
@@ -691,9 +691,10 @@ class Errata(UnitMixin, ContentUnit):
         """
         Merge two errata with the same errata_id.
 
-        There are two parts:
+        There are three parts:
         - merging of the pkglists in case of the erratum with the same id in different repositories
         - overwriting the erratum metadata based on the `updated` field
+        - overwriting the "reboot_suggested" value because of https://pulp.plan.io/issues/2032
 
         NOTE: The first part should be eliminated after we change the way erratum is stored in the
         MongoDB.
@@ -705,6 +706,11 @@ class Errata(UnitMixin, ContentUnit):
         if self.update_needed(other):
             for field_name in self.mutable_erratum_fields:
                 setattr(self, field_name, getattr(other, field_name))
+        # This is due to https://pulp.plan.io/issues/2032
+        # Syncs previously could have misinterpreted the reboot_suggested element and saved a
+        # value of True when it should have been False. The only way to correct that data in pulp
+        # is to do so here, during a subsequent sync.
+        self.reboot_suggested = other.reboot_suggested
 
     def update_needed(self, other):
         """

--- a/plugins/pulp_rpm/plugins/distributors/yum/metadata/updateinfo.py
+++ b/plugins/pulp_rpm/plugins/distributors/yum/metadata/updateinfo.py
@@ -87,10 +87,9 @@ class UpdateinfoXMLFileContext(XmlFileContext):
         issued_attributes = {'date': erratum_unit.issued}
         ElementTree.SubElement(update_element, 'issued', issued_attributes)
 
-        reboot_element = ElementTree.SubElement(update_element, 'reboot_suggested')
-        if erratum_unit.reboot_suggested is None:
-            erratum_unit.reboot_suggested = False
-        reboot_element.text = str(erratum_unit.reboot_suggested)
+        if erratum_unit.reboot_suggested:
+            reboot_element = ElementTree.SubElement(update_element, 'reboot_suggested')
+            reboot_element.text = 'True'
 
         # these elements are optional
         for key in ('title', 'release', 'rights', 'solution',
@@ -186,8 +185,9 @@ class UpdateinfoXMLFileContext(XmlFileContext):
                     sum_element = ElementTree.SubElement(package_element, 'sum', sum_attributes)
                     sum_element.text = checksum_value
 
-                reboot_element = ElementTree.SubElement(package_element, 'reboot_suggested')
-                reboot_element.text = str(package.get('reboot_suggested', False))
+                if package.get('reboot_suggested'):
+                    reboot_element = ElementTree.SubElement(package_element, 'reboot_suggested')
+                    reboot_element.text = 'True'
 
         # write the top-level XML element out to the file
         update_element_string = ElementTree.tostring(update_element, 'utf-8')

--- a/plugins/test/unit/plugins/db/test_models.py
+++ b/plugins/test/unit/plugins/db/test_models.py
@@ -413,6 +413,34 @@ class TestErrata(unittest.TestCase):
         self.assertNotEqual(existing_erratum.field1, uploaded_erratum.field1)
         self.assertNotEqual(existing_erratum.field2, uploaded_erratum.field2)
 
+    @mock.patch('pulp_rpm.plugins.db.models.Errata.merge_pkglists_and_save')
+    @mock.patch('pulp_rpm.plugins.db.models.Errata.update_needed')
+    def test_merge_fixes_reboot_needed(self, mock_update_needed, mock_merge_pkglists):
+        """
+        Test that the reboot_suggested value is overwritten by the one on the erratum being merged.
+        """
+        existing_erratum, new_erratum = models.Errata(), models.Errata()
+        mock_update_needed.return_value = False
+        existing_erratum.reboot_suggested = True
+        new_erratum.reboot_suggested = False
+        existing_erratum.merge_errata(new_erratum)
+
+        self.assertFalse(existing_erratum.reboot_suggested)
+
+    @mock.patch('pulp_rpm.plugins.db.models.Errata.merge_pkglists_and_save')
+    @mock.patch('pulp_rpm.plugins.db.models.Errata.update_needed')
+    def test_merge_preserves_reboot_needed(self, mock_update_needed, mock_merge_pkglists):
+        """
+        Test that the reboot_suggested value is preserved when both are True.
+        """
+        existing_erratum, new_erratum = models.Errata(), models.Errata()
+        mock_update_needed.return_value = False
+        existing_erratum.reboot_suggested = True
+        new_erratum.reboot_suggested = True
+        existing_erratum.merge_errata(new_erratum)
+
+        self.assertTrue(existing_erratum.reboot_suggested)
+
 
 class TestISO(unittest.TestCase):
     """

--- a/plugins/test/unit/plugins/distributors/yum/metadata/test_updateinfo.py
+++ b/plugins/test/unit/plugins/distributors/yum/metadata/test_updateinfo.py
@@ -103,6 +103,32 @@ class AddUnitMetadataTests(UpdateinfoXMLFileContextTests):
         xml = self.updateinfo_xml_file_context.metadata_file_handle.write.mock_calls[0][1][0]
         self.assertTrue(re.search('<description */>', xml) is not None)
 
+    def test_reboot_suggested(self):
+        """
+        Test that when reboot_suggested is True, the element is present in the XML
+        """
+        erratum = models.Errata(**self.unit_data)
+        erratum.reboot_suggested = True
+
+        self.updateinfo_xml_file_context.add_unit_metadata(erratum)
+
+        self.assertEqual(self.updateinfo_xml_file_context.metadata_file_handle.write.call_count, 1)
+        xml = self.updateinfo_xml_file_context.metadata_file_handle.write.mock_calls[0][1][0]
+        self.assertTrue('reboot_suggested' in xml)
+
+    def test_no_reboot_suggested(self):
+        """
+        Test that when reboot_suggested is False, the element is not present in the XML
+        """
+        erratum = models.Errata(**self.unit_data)
+        erratum.reboot_suggested = False
+
+        self.updateinfo_xml_file_context.add_unit_metadata(erratum)
+
+        self.assertEqual(self.updateinfo_xml_file_context.metadata_file_handle.write.call_count, 1)
+        xml = self.updateinfo_xml_file_context.metadata_file_handle.write.mock_calls[0][1][0]
+        self.assertTrue('reboot_suggested' not in xml)
+
     def test_no_duplicated_pkglists(self):
         """
         Test that no duplicated pkglists are generated.


### PR DESCRIPTION
Additionally, this enables sync to fix any values of reboot_suggested that are
incorrect due to having previously sync'd from a pulp that had published with
the previous behavior.

fixes #2032
https://pulp.plan.io/issues/2032