### PR TITLE
2048 american stout

### DIFF
--- a/plugins/pulp_rpm/plugins/db/models.py
+++ b/plugins/pulp_rpm/plugins/db/models.py
@@ -729,8 +729,12 @@ class Errata(UnitMixin, ContentUnit):
         err_msg = _('Fail to update the %(which)s erratum %(id)s.')
         existing_err_msg = err_msg % {'which': 'existing', 'id': self.errata_id}
         other_err_msg = err_msg % {'which': 'uploaded', 'id': self.errata_id}
-        existing_updated_dt = util.errata_format_to_datetime(self.updated, msg=existing_err_msg)
-        new_updated_dt = util.errata_format_to_datetime(other.updated, msg=other_err_msg)
+        try:
+            existing_updated_dt = util.errata_format_to_datetime(self.updated, msg=existing_err_msg)
+            new_updated_dt = util.errata_format_to_datetime(other.updated, msg=other_err_msg)
+        except ValueError as e:
+            _LOGGER.warn(str(e))
+            return False
         return new_updated_dt > existing_updated_dt
 
     def merge_pkglists_and_save(self, other):

--- a/plugins/pulp_rpm/plugins/error_codes.py
+++ b/plugins/pulp_rpm/plugins/error_codes.py
@@ -13,3 +13,5 @@ RPM1003 = Error("RPM1003", _("Error uploading an SRPM.  The specified file is a 
 RPM1004 = Error("RPM1004", _("Error retrieving metadata: %(reason)s"), ['reason'])
 RPM1005 = Error("RPM1005", _("Unable to sync a repository that has no feed."), [])
 RPM1006 = Error("RPM1006", _("Could not parse repository metadata"), [])
+RPM1007 = Error("RPM1007", _("Could not parse errata `updated` field: expected format "
+                             "'%(expected_format)s'. %(details)s"), ['expected_format', 'details'])

--- a/plugins/pulp_rpm/plugins/error_codes.py
+++ b/plugins/pulp_rpm/plugins/error_codes.py
@@ -13,5 +13,3 @@ RPM1003 = Error("RPM1003", _("Error uploading an SRPM.  The specified file is a 
 RPM1004 = Error("RPM1004", _("Error retrieving metadata: %(reason)s"), ['reason'])
 RPM1005 = Error("RPM1005", _("Unable to sync a repository that has no feed."), [])
 RPM1006 = Error("RPM1006", _("Could not parse repository metadata"), [])
-RPM1007 = Error("RPM1007", _("Could not parse errata `updated` field: expected format "
-                             "'%(expected_format)s'. %(details)s"), ['expected_format', 'details'])

--- a/plugins/pulp_rpm/yum_plugin/util.py
+++ b/plugins/pulp_rpm/yum_plugin/util.py
@@ -204,9 +204,10 @@ def errata_format_to_datetime(datetime_str, msg):
     for strptime_pattern in strptime_patterns:
         try:
             datetime_obj = datetime.datetime.strptime(datetime_str, strptime_pattern)
-            break
         except ValueError:
             continue
+        else:
+            break
     else:
         raise ValueError(msg)
     return datetime_obj

--- a/plugins/pulp_rpm/yum_plugin/util.py
+++ b/plugins/pulp_rpm/yum_plugin/util.py
@@ -9,9 +9,6 @@ import yum
 import rpmUtils
 from M2Crypto import X509
 
-from pulp.server.exceptions import PulpCodedValidationException
-from pulp_rpm.plugins import error_codes
-
 _ = gettext.gettext
 
 LOG_PREFIX_NAME = "pulp.plugins"
@@ -184,8 +181,9 @@ def errata_format_to_datetime(datetime_str, msg):
     Convert known errata date-time formats to datetime object.
 
     Expected formats are:
-     - '%Y-%m-%d %H:%M:%S'
-     - '%Y-%m-%d %H:%M:%S UTC'
+    - '%Y-%m-%d %H:%M:%S UTC'
+    - '%Y-%m-%d %H:%M:%S'
+    - '%Y-%m-%d'
 
     :param datetime_str: date and time in errata specific format
     :type  datetime_str: str
@@ -197,15 +195,18 @@ def errata_format_to_datetime(datetime_str, msg):
     :rtype: datetime.datetime
     :raises ValueError: if the date and time are in unknown format
     """
-    strptime_pattern = '%Y-%m-%d %H:%M:%S'
+    strptime_patterns = ['%Y-%m-%d %H:%M:%S',
+                         '%Y-%m-%d']
     datetime_str = datetime_str.strip()
     if datetime_str.endswith(' UTC'):
         datetime_str = datetime_str[:-4]
 
-    try:
-        datetime_obj = datetime.datetime.strptime(datetime_str, strptime_pattern)
-    except ValueError:
-        raise PulpCodedValidationException(error_code=error_codes.RPM1007, details=msg,
-                                           expected_format=strptime_pattern)
-
+    for strptime_pattern in strptime_patterns:
+        try:
+            datetime_obj = datetime.datetime.strptime(datetime_str, strptime_pattern)
+            break
+        except ValueError:
+            continue
+    else:
+        raise ValueError(msg)
     return datetime_obj


### PR DESCRIPTION
The original PR is here:  https://github.com/pulp/pulp_rpm/pull/925/files

This PR contains the [three recommended fixes](https://github.com/pulp/pulp_rpm/pull/925#issuecomment-230866214).

- Brings back RPM1007
- Causes update_needed() to return False in the case that either
  `updated` field is an empty string
- Adjust the logging to cause 1 line to be logged for all errata
  with non-empty and not recognized values for the `updated`
  field.