### PR TITLE
Revert "added packages_directory option for yum_distributor"

### DIFF
--- a/extensions_admin/pulp_rpm/extensions/admin/repo_create_update.py
+++ b/extensions_admin/pulp_rpm/extensions/admin/repo_create_update.py
@@ -33,7 +33,6 @@ YUM_DISTRIBUTOR_CONFIG_KEYS = [
     ('generate_metadata', 'regenerate_metadata'),
     ('skip', 'skip'),
     ('repoview', 'repoview'),
-    ('packages_directory', 'packages_directory'),
 ]
 
 EXPORT_DISTRIBUTOR_CONFIG_KEYS = [

--- a/plugins/pulp_rpm/plugins/distributors/yum/configuration.py
+++ b/plugins/pulp_rpm/plugins/distributors/yum/configuration.py
@@ -21,8 +21,7 @@ REQUIRED_CONFIG_KEYS = ('relative_url', 'http', 'https')
 
 OPTIONAL_CONFIG_KEYS = ('gpgkey', 'auth_ca', 'auth_cert', 'https_ca', 'checksum_type',
                         'http_publish_dir', 'https_publish_dir', 'protected',
-                        'skip', 'skip_pkg_tags', 'generate_sqlite', 'force_full',
-                        'repoview', 'packages_directory')
+                        'skip', 'skip_pkg_tags', 'generate_sqlite', 'force_full', 'repoview')
 
 ROOT_PUBLISH_DIR = '/var/lib/pulp/published/yum'
 MASTER_PUBLISH_DIR = os.path.join(ROOT_PUBLISH_DIR, 'master')
@@ -112,7 +111,6 @@ def validate_config(repo, config, config_conduit):
         'skip': _validate_skip,
         'skip_pkg_tags': _validate_skip_pkg_tags,
         'generate_sqlite': _validate_generate_sqlite,
-        'packages_directory': _validate_packages_directory
     }
 
     # iterate through the options that have validation methods and validate them
@@ -442,14 +440,6 @@ def _validate_skip_pkg_tags(skip_pkg_tags, error_messages):
 def _validate_generate_sqlite(use_createrepo, error_messages):
     _validate_boolean('generate_sqlite', use_createrepo, error_messages, False)
 
-
-def _validate_packages_directory(packages_directory, error_messages):
-    if packages_directory is None:
-        return
-
-    if not isinstance(packages_directory, basestring):
-        msg = _('Configuration value for [packages_directory] must be a string, but is a %(t)s')
-        error_messages.append(msg % {'t': str(type(packages_directory))})
 
 # -- generalized validation methods --------------------------------------------
 

--- a/plugins/pulp_rpm/plugins/distributors/yum/publish.py
+++ b/plugins/pulp_rpm/plugins/distributors/yum/publish.py
@@ -930,8 +930,8 @@ class PublishDistributionStep(platform_steps.UnitModelPluginStep):
                 # a package path exists as a symlink we are going to remove it since
                 # the _create_symlink will create a real directory
                 os.unlink(package_path)
-        default_dir = self.get_config().get('packages_directory', 'Packages')
-        default_packages_symlink = os.path.join(symlink_dir, default_dir)
+
+        default_packages_symlink = os.path.join(symlink_dir, 'Packages')
         if package_path != default_packages_symlink:
             # Add the Packages directory to the content directory
             self.package_dirs.append(default_packages_symlink)


### PR DESCRIPTION
Revert "added packages_directory option for yum_distributor"

This reverts commit ac76ec18f3662dc6c95e34f70565240265b6fa2d.

This feature is being pulled so that it can be re-introduced
later when it is working.

The docs portain is being negative commited separately so there
are no 2.9.x.rst changes in this negative commit.

https://pulp.plan.io/issues/1976
re #1976
