### PR TITLE
Adds banner warning about migration runtime

### DIFF
--- a/plugins/pulp_rpm/plugins/migrations/0028_standard_storage_path.py
+++ b/plugins/pulp_rpm/plugins/migrations/0028_standard_storage_path.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import shutil
 
@@ -7,10 +8,20 @@ from pulp.plugins.migration.standard_storage_path import Migration, Plan, Unit
 from pulp.plugins.util.misc import mkdir
 
 
+_logger = logging.getLogger(__name__)
+
+
 def migrate(*args, **kwargs):
     """
     Migrate content units to use the standard storage path introduced in pulp 2.8.
     """
+    msg = '* NOTE: This migration may take a long time depending on the size of your Pulp content *'
+    stars = '*' * len(msg)
+
+    _logger.info(stars)
+    _logger.info(msg)
+    _logger.info(stars)
+
     migration = Migration()
     migration.add(rpm_plan())
     migration.add(srpm_plan())


### PR DESCRIPTION
Migration 28 can take a long time. This outputs a banner to
the logs and the foreground of pulp-manage-db warning the user
that it could take a long time.

https://pulp.plan.io/issues/2060
re #2060