### PR TITLE
Make sample JSON code valid & pretty

### DIFF
--- a/docs/tech-reference/iso-rsync-distributor.rst
+++ b/docs/tech-reference/iso-rsync-distributor.rst
@@ -14,17 +14,17 @@ Here is an example iso_rsync_distributor configuration:
 .. code-block:: json
 
     {
-     "distributor_id": "my_iso_rsync_distributor",
-     "distributor_type_id": "iso_rsync_distributor",
-     "distributor_config": {
-        "remote": {
-            "auth_type": "publickey",
-            "ssh_user": "foo",
-            "ssh_identity_file": "/home/user/.ssh/id_rsa",
-            "host": "192.168.121.1",
-            "root": "/home/foo/pulp_root_dir"
-        },
-        "predistributor_id": "my_iso_distributor",
+        "distributor_id": "my_iso_rsync_distributor",
+        "distributor_type_id": "iso_rsync_distributor",
+        "distributor_config": {
+            "remote": {
+                "auth_type": "publickey",
+                "ssh_user": "foo",
+                "ssh_identity_file": "/home/user/.ssh/id_rsa",
+                "host": "192.168.121.1",
+                "root": "/home/foo/pulp_root_dir"
+            },
+            "predistributor_id": "my_iso_distributor"
         }
     }
 

--- a/docs/tech-reference/rsync-distributor.rst
+++ b/docs/tech-reference/rsync-distributor.rst
@@ -14,17 +14,17 @@ Here's an example of rpm_rsync_distributor configuration:
 .. code-block:: json
 
     {
-     "distributor_id": "my_rpm_rsync_distributor",
-     "distributor_type_id": "rpm_rsync_distributor",
-     "distributor_config": {
-        "remote": {
-            "auth_type": "publickey",
-            "ssh_user": "foo",
-            "ssh_identity_file": "/home/user/.ssh/id_rsa",
-            "host": "192.168.121.1",
-            "root": "/home/foo/pulp_root_dir"
-        },
-        "predistributor_id": "yum_distributor",
+        "distributor_id": "my_rpm_rsync_distributor",
+        "distributor_type_id": "rpm_rsync_distributor",
+        "distributor_config": {
+            "remote": {
+                "auth_type": "publickey",
+                "ssh_user": "foo",
+                "ssh_identity_file": "/home/user/.ssh/id_rsa",
+                "host": "192.168.121.1",
+                "root": "/home/foo/pulp_root_dir"
+            },
+            "predistributor_id": "yum_distributor"
         }
     }
 


### PR DESCRIPTION
According to the JSON specification, objects and arrays must not have
trailing commas. The following are invalid:

    {"foo": "bar",}
    [1, 2, 3,]

Make the sample JSON code in the rsync distributor documentation pages
valid. Also, reformat the JSON code samples with `json_reformat`, so
that indentation is consistent, instead of using a mixture of one, three
and four spaces.