### PR TITLE
Removes cancel_publish_repo methods from the rsync distributors

### DIFF
--- a/plugins/pulp_rpm/plugins/distributors/iso_rsync_distributor/distributor.py
+++ b/plugins/pulp_rpm/plugins/distributors/iso_rsync_distributor/distributor.py
@@ -94,12 +94,3 @@ class ISORsyncDistributor(Distributor):
         self._publisher = publish.ISORsyncPublisher(repo, publish_conduit, config,
                                                     TYPE_ID_DISTRIBUTOR_ISO_RSYNC)
         return self._publisher.publish()
-
-    def cancel_publish_repo(self):
-        """
-        Call cancellation control hook.
-        """
-        _LOG.debug(_('Canceling publishing repo to remote server'))
-        self.canceled = True
-        if self._publisher is not None:
-            self._publisher.cancel()

--- a/plugins/pulp_rpm/plugins/distributors/rsync/distributor.py
+++ b/plugins/pulp_rpm/plugins/distributors/rsync/distributor.py
@@ -101,14 +101,3 @@ class RPMRsyncDistributor(Distributor):
         self._publisher = publish.RPMRsyncPublisher(repo, publish_conduit, config,
                                                     TYPE_ID_DISTRIBUTOR_RPM_RSYNC)
         return self._publisher.publish()
-
-    def cancel_publish_repo(self):
-        """
-        Call cancellation control hook.
-
-        """
-        _LOG.debug(_('Canceling publishing repo to remote server'))
-
-        self.canceled = True
-        if self._publisher is not None:
-            self._publisher.cancel()


### PR DESCRIPTION
The platform code performs the cancel. The methods on the distributor are not necesary.