### PR TITLE
Reclassify signature verification as signature and key ID filtering

### DIFF
--- a/common/pulp_rpm/common/constants.py
+++ b/common/pulp_rpm/common/constants.py
@@ -16,7 +16,7 @@ ERROR_SIZE_VERIFICATION = 'size_mismatch'
 ERROR_CHECKSUM_VERIFICATION = 'checksum_mismatch'
 ERROR_CHECKSUM_TYPE_UNKNOWN = 'checksum_type_unknown'
 ERROR_INVALID_PACKAGE_SIG = 'invalid_package_signature'
-ERROR_SIGNATURE_VERIFICATION = 'signature_verification_failure'
+ERROR_KEY_ID_FILTER = 'gpg_key_id_filter_failure'
 
 # Standard keywords for progress reports to include
 PROGRESS_STATE_KEY = 'state'

--- a/docs/tech-reference/yum-plugins.rst
+++ b/docs/tech-reference/yum-plugins.rst
@@ -532,10 +532,15 @@ configuration values are optional.
 
 ``require_signature``
 Requires that imported packages like RPM/DRPM/SRPM should be signed. Defaults to False.
+This does not trigger package signature verification, it only guarantees that the package
+is signed.
 
 ``allowed_keys``
-Comma-separated list of allowed signature keys that imported packages can be signed with.
-The key should be lowercase 8 character abbreviated fingerprint (so called short key ID).
+Comma-separated list of allowed signature key IDs that imported packages can be signed with.
+The key should be lowercase 8 character abbreviated fingerprint (the so-called short key ID).
+Since short key IDs are `easy to impersonate <https://evil32.com/>`_, this feature is intended to
+make it easy to filter packages based on their signing key and does not use these key IDs for
+package signature verification.
 
 
 Yum Distributor

--- a/docs/user-guide/features.rst
+++ b/docs/user-guide/features.rst
@@ -54,25 +54,22 @@ For each Pulp-hosted repository that is protected, a consumer certificate can be
 supplied that will be distributed to consumers when they bind. That certificate
 will allow them to access the protected repository.
 
-Package signature verification
-------------------------------
+Package Signatures and GPG Key ID Filtering
+-------------------------------------------
 
-RPM repositories can have signature verification policy enabled.
-With this policy it can be restricted if only RPM/SRPM/DRPM packages, that are
-signed, will be imported and accepted into the repo. There is also a possibility
-to specify the list of allowed signature keys. These are the keys that are usually
-used to sign packages. It is enough to provide in the list short key ID that is
-8 characters long. So during the import phase, packages will be checked with which
-key they were signed and if this key is among allowed, the import of the package
-into the repo will be granted. Requirement of the package signature and list of
-allowed signature keys can be changed at anytime.
+RPM repositories have limited support for acting on package GPG signatures,
+including requiring packages to have GPG signatures, and whitelisting signing
+key IDs to only sync packages with matching signing key IDs. The signing key
+ID filtering feature uses the 8-character "short" key ID, which does not uniquely
+identify a GPG signing key. This feature does not verify package signatures.
 
-This signature validation is granted within the current importer settings and current
-import of the content, without taking into consideration already present content in
+This signature filtering is granted within the current importer settings and current
+import of the content, without taking into consideration content already present in
 the repository.
-In order to parse package signature it is needed to download the content first. That's
-why signature verification cannot be enabled with on_demand or background download policy,
-only the immediate download policy is compatible with signature verification.
+
+These features cannot be enable with on_demand or background download policies, since
+access to the package files is required to get the GPG signature information.
+Only the immediate download policy is compatible with signature filtering.
 
 Export
 ------

--- a/docs/user-guide/recipes.rst
+++ b/docs/user-guide/recipes.rst
@@ -200,13 +200,13 @@ The ``--basicauth-user`` and ``--basicauth-pass`` options are used for this
 during repo creation or update.
 
 
-Sync a repo with signature verification
-=======================================
+Sync a repo with GPG Key ID Filtering
+=====================================
 
-Syncing a repo with signature verification is done by specifying ``--require-signature``
-and ``--allowed-keys``. With these options enabled, just signed packages will be synced
-and in addition just those packages that were signed with specific keys that were provided
-in the allow keys list.
+Syncing a repo with key ID filtering is done by specifying ``--require-signature``
+and ``--allowed-keys``. With these options enabled, only signed packages will be synced.
+In addition, only packages that were signed with specific keys that were provided
+in the allowed keys list will be synced.
 
 Let's try to sync from a remote feed where packages are unsigned.
 
@@ -240,7 +240,7 @@ Let's try to sync from a remote feed where packages are unsigned.
 
     Individual package errors encountered during sync:
 
-    3 packages failed signature check and were not imported.
+    3 packages failed signature filter and were not imported.
 
 
 .. _export-repos:

--- a/docs/user-guide/release-notes/2.10.x.rst
+++ b/docs/user-guide/release-notes/2.10.x.rst
@@ -17,9 +17,9 @@ New Features
 * The RPM rsync distributor has been added. The new distributor can be used to publish repositories
   published by yum_distributor to a remote server.
 
-* Package signature verification can be enabled. There are two new options that are responsible
-  for signature check behaviour ``--require-signature`` and ``--allowed-keys``. These options can
+* Package signature filtering can be enabled. There are two new options that are responsible
+  for signature filter behaviour ``--require-signature`` and ``--allowed-keys``. These options can
   be specified via pulp-admin repo "create" and "update" commands, or via API by specifing them in
   the importer configuration. More details can be found in `RPM Features
-  <http://docs.pulpproject.org/user-guide/features.html#package-signature-verification>`_ or in
-  `Recipes <http://docs.pulpproject.org/user-guide/recipes.html#sync-a-repo-with-signature-verification>`_.
+  <http://docs.pulpproject.org/user-guide/features.html#package-signatures-and-gpg-key-id-filtering>`_ or in
+  `Recipes <http://docs.pulpproject.org/user-guide/recipes.html#sync-a-repo-with-gpg-key-id-filtering>`_.

--- a/extensions_admin/pulp_rpm/extensions/admin/status.py
+++ b/extensions_admin/pulp_rpm/extensions/admin/status.py
@@ -254,7 +254,7 @@ class RpmStatusRenderer(StatusRenderer):
                             message_data = {
                                 'count': error['count'],
                             }
-                            template = _('%(count)s packages failed signature check and were not '
+                            template = _('%(count)s packages failed signature filter and were not '
                                          'imported.')
 
                         elif error.get(

--- a/extensions_admin/test/unit/extensions/admin/test_status.py
+++ b/extensions_admin/test/unit/extensions/admin/test_status.py
@@ -49,7 +49,7 @@ class RpmStatusRendererTests(client_base.PulpClientTests):
     def test_render_download_step_invalid_signature_error(self):
         """
         Assert correct behavior from render_download_step() when the progress report contains errors
-        about packages that did not pass signature verification.
+        about packages that did not pass signature filtering.
         """
         self.prompt.render_failure_message = mock.MagicMock()
         content_report = report.ContentReport()
@@ -70,7 +70,7 @@ class RpmStatusRendererTests(client_base.PulpClientTests):
         # been printed for the user.
         self.assertTrue('package errors encountered' in
                         self.prompt.render_failure_message.mock_calls[0][1][0])
-        self.assertTrue('32 packages failed signature check and were not imported.' in
+        self.assertTrue('32 packages failed signature filter and were not imported.' in
                         self.prompt.render_failure_message.mock_calls[1][1][0])
 
     def test_render_distribution_sync_step_with_error(self):

--- a/plugins/pulp_rpm/plugins/db/models.py
+++ b/plugins/pulp_rpm/plugins/db/models.py
@@ -121,7 +121,7 @@ class NonMetadataPackage(UnitMixin, FileContentUnit):
     :ivar checksum: The checksum of the package.
     :type checksum: mongoengine.StringField
 
-    :ivar signing_key: 8-character abbreviated fingerprint signing key of the package.
+    :ivar signing_key: 8-character abbreviated signing key fingerprint that signed the package.
     :type signing_key: mongoengine.StringField
 
     :ivar version_sort_index: ???

--- a/plugins/pulp_rpm/plugins/error_codes.py
+++ b/plugins/pulp_rpm/plugins/error_codes.py
@@ -32,6 +32,6 @@ RPM1012 = Error("RPM1012", _('Checksum type "%(checksumtype)s" requested for upd
                              'available for all packages listed in the errata.'),
                 ['checksumtype'])
 RPM1013 = Error("RPM1013", _('Cannot import unsigned Package "%(package)s".'), ['package'])
-RPM1014 = Error("RPM1014", _('Invalid signature key "%(key)s" found for Package: "%(package)s". '
+RPM1014 = Error("RPM1014", _('Invalid signature key ID "%(key)s" found for Package: "%(package)s". '
                              'Allowed Signatures keys "%(allowed)s".'),
                 ['key', 'package', 'allowed'])

--- a/plugins/pulp_rpm/plugins/importers/yum/associate.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/associate.py
@@ -58,7 +58,7 @@ def associate(source_repo, dest_repo, import_conduit, config, units=None):
     associated_units = [_associate_unit(dest_repo, unit, config) for unit in units
                         if not isinstance(unit, models.RPM)]
     if None in associated_units:
-        _LOGGER.warning(_('%s packages failed signature check and were not imported.'
+        _LOGGER.warning(_('%s packages failed signature filter and were not imported.'
                         % len(associated_units)))
 
     associated_units = set(associated_units)
@@ -217,7 +217,7 @@ def copy_rpms(units, source_repo, dest_repo, import_conduit, config, copy_deps, 
         if rpm_parse.signature_enabled(config):
             if unit.downloaded:
                 try:
-                    rpm_parse.verify_signature(unit, config)
+                    rpm_parse.filter_signature(unit, config)
                 except PulpCodedException as e:
                     _LOGGER.debug(e)
                     failed_signature_check += 1
@@ -228,7 +228,7 @@ def copy_rpms(units, source_repo, dest_repo, import_conduit, config, copy_deps, 
         unit_set.add(unit)
 
     if failed_signature_check:
-        _LOGGER.warning(_('%s packages failed signature check and were not imported.'
+        _LOGGER.warning(_('%s packages failed signature filter and were not imported.'
                         % failed_signature_check))
 
     if copy_deps and unit_set:
@@ -373,7 +373,7 @@ def _associate_unit(dest_repo, unit, config):
             if rpm_parse.signature_enabled(config):
                 if unit.downloaded:
                     try:
-                        rpm_parse.verify_signature(unit, config)
+                        rpm_parse.filter_signature(unit, config)
                     except PulpCodedException as e:
                         _LOGGER.debug(e)
                         return

--- a/plugins/pulp_rpm/plugins/importers/yum/config_validate.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/config_validate.py
@@ -63,7 +63,7 @@ def _validate_allowed_keys(config, error_messages):
     allowed_keys = config.get(constants.CONFIG_ALLOWED_KEYS, [])
     for key in allowed_keys:
         if len(key) != 8:
-            msg = _('Signature key %s should be 8 characters long') % key
+            msg = _('Signature key ID %s should be 8 characters long') % key
             error_messages.append(msg)
 
 
@@ -85,5 +85,5 @@ def _validate_lazy_compatibility(config, error_messages):
     allowed_keys = config.get(constants.CONFIG_ALLOWED_KEYS)
     if download_policy != importer_constants.DOWNLOAD_IMMEDIATE and \
             (require_signature or allowed_keys):
-        msg = _('%s download policy and signature check are not compatible') % download_policy
+        msg = _('%s download policy and signature filter are not compatible') % download_policy
         error_messages.append(msg)

--- a/plugins/pulp_rpm/plugins/importers/yum/existing.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/existing.py
@@ -131,7 +131,7 @@ def check_all_and_associate(wanted, conduit, config, download_deferred, catalog)
             catalog.add(unit)
             if rpm_parse.signature_enabled(config):
                 try:
-                    rpm_parse.verify_signature(unit, config)
+                    rpm_parse.filter_signature(unit, config)
                 except PulpCodedException as e:
                     _LOGGER.debug(e)
                     continue

--- a/plugins/pulp_rpm/plugins/importers/yum/parse/rpm.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/parse/rpm.py
@@ -167,9 +167,9 @@ def signature_enabled(config):
     return False
 
 
-def verify_signature(unit, config):
+def filter_signature(unit, config):
     """
-    Verify package signature.
+    Filter package based on GPG signature and allowed GPG key IDs
 
     :param unit: model instance of the package
     :type  unit: pulp_rpm.plugins.db.models.RPM/DRPM/SRPM
@@ -177,7 +177,7 @@ def verify_signature(unit, config):
     :param config: configuration instance passed to the importer
     :type  config: pulp.plugins.config.PluginCallConfiguration
 
-    :raise: PulpCodedException if the signature check did not pass
+    :raise: PulpCodedException if the package signing key ID does not exist or is not allowed
     """
 
     signing_key = unit.signing_key

--- a/plugins/pulp_rpm/plugins/importers/yum/sync.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/sync.py
@@ -490,7 +490,7 @@ class RepoSync(object):
         failed_signature_check = 0
         new_report = []
         for error in self.progress_report['content']['error_details']:
-            if error[constants.ERROR_CODE] == constants.ERROR_SIGNATURE_VERIFICATION:
+            if error[constants.ERROR_CODE] == constants.ERROR_KEY_ID_FILTER:
                 failed_signature_check += 1
             else:
                 new_report.append(error)
@@ -499,7 +499,7 @@ class RepoSync(object):
                  'count': '%s' % failed_signature_check}
             new_report.append(d)
             self.progress_report['content']['error_details'] = new_report
-            _logger.warning(_('%s packages failed signature check and were not imported.'
+            _logger.warning(_('%s packages failed signature filter and were not imported.'
                             % failed_signature_check))
         self.conduit.build_success_report({}, {})
         # removes unwanted units according to the config settings
@@ -634,12 +634,12 @@ class RepoSync(object):
             unit = unit.__class__.objects.filter(**unit.unit_key).first()
         if rpm_parse.signature_enabled(self.config):
             try:
-                rpm_parse.verify_signature(unit, self.config)
+                rpm_parse.filter_signature(unit, self.config)
             except PulpCodedException as e:
                 _logger.debug(e)
                 error_report = {
                     constants.NAME: unit.filename,
-                    constants.ERROR_CODE: constants.ERROR_SIGNATURE_VERIFICATION,
+                    constants.ERROR_CODE: constants.ERROR_KEY_ID_FILTER,
                 }
 
                 self.progress_report['content'].failure(unit, error_report)

--- a/plugins/pulp_rpm/plugins/importers/yum/upload.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/upload.py
@@ -419,7 +419,7 @@ def _handle_package(repo, type_id, unit_key, metadata, file_path, conduit, confi
         unit = unit.__class__.objects.filter(**unit.unit_key).first()
 
     if rpm_parse.signature_enabled(config):
-        rpm_parse.verify_signature(unit, config)
+        rpm_parse.filter_signature(unit, config)
     repo_controller.associate_single_unit(repo, unit)
 
 

--- a/plugins/test/unit/plugins/importers/yum/parse/test_rpm.py
+++ b/plugins/test/unit/plugins/importers/yum/parse/test_rpm.py
@@ -75,9 +75,9 @@ class SignatureEnabled(unittest.TestCase):
         self.assertFalse(response)
 
 
-class VerifySignature(unittest.TestCase):
+class FilterSignature(unittest.TestCase):
     """
-    test for package signature verification
+    test for package signature filtering
     """
 
     def test_reject_unsigned_packages(self):
@@ -86,7 +86,7 @@ class VerifySignature(unittest.TestCase):
         config = {"require_signature": True}
 
         with self.assertRaises(PulpCodedException) as cm:
-                rpm.verify_signature(unit, config)
+                rpm.filter_signature(unit, config)
                 self.assertEqual(cm.exception.error_code.code, 'RPM1013')
 
     def test_invalid_package_signature(self):
@@ -95,5 +95,5 @@ class VerifySignature(unittest.TestCase):
         config = {"allowed_keys": ['87654321']}
 
         with self.assertRaises(PulpCodedException) as cm:
-            rpm.verify_signature(unit, config)
+            rpm.filter_signature(unit, config)
             self.assertEqual(cm.exception.error_code.code, 'RPM1014')

--- a/plugins/test/unit/plugins/importers/yum/test_sync.py
+++ b/plugins/test/unit/plugins/importers/yum/test_sync.py
@@ -83,7 +83,7 @@ class TestAddRpmUnit(BaseSyncTest):
 
     @mock.patch('pulp_rpm.plugins.importers.yum.sync.rpm_parse')
     @mock.patch('pulp.server.controllers.repository.associate_single_unit')
-    def test_rpm_signature_check_pass(self, mock_assoc, mock_rpm_parse):
+    def test_rpm_signature_filter_pass(self, mock_assoc, mock_rpm_parse):
         unit = models.RPM(name='foo', epoch=0, version='1.1.1', release='0', arch='x86_64',
                           checksumtype='sha256', checksum='abc123')
         self.metadata_files.add_repodata = mock.MagicMock()
@@ -95,12 +95,12 @@ class TestAddRpmUnit(BaseSyncTest):
         self.reposync.add_rpm_unit(self.metadata_files, unit)
 
         self.metadata_files.add_repodata.assert_called_once_with(unit)
-        mock_rpm_parse.verify_signature.assert_called_once_with(unit, self.config)
+        mock_rpm_parse.filter_signature.assert_called_once_with(unit, self.config)
         mock_assoc.assert_called_once_with(self.conduit.repo, unit)
 
     @mock.patch('pulp_rpm.plugins.importers.yum.sync.rpm_parse')
     @mock.patch('pulp.server.controllers.repository.associate_single_unit')
-    def test_rpm_signature_check_failed(self, mock_assoc, mock_rpm_parse):
+    def test_rpm_signature_filter_failed(self, mock_assoc, mock_rpm_parse):
         unit = models.RPM(name='foo', epoch=0, version='1.1.1', release='0', arch='x86_64',
                           checksumtype='sha256', checksum='abc123')
         self.metadata_files.add_repodata = mock.MagicMock()
@@ -108,17 +108,17 @@ class TestAddRpmUnit(BaseSyncTest):
         unit.save = mock.MagicMock()
         self.reposync.progress_report = mock.MagicMock()
         mock_rpm_parse.signature_enabled.return_value = True
-        mock_rpm_parse.verify_signature.side_effect = PulpCodedException()
+        mock_rpm_parse.filter_signature.side_effect = PulpCodedException()
 
         self.reposync.add_rpm_unit(self.metadata_files, unit)
 
         self.metadata_files.add_repodata.assert_called_once_with(unit)
-        mock_rpm_parse.verify_signature.assert_called_once_with(unit, self.config)
+        mock_rpm_parse.filter_signature.assert_called_once_with(unit, self.config)
         self.assertFalse(mock_assoc.called)
 
     @mock.patch('pulp_rpm.plugins.importers.yum.sync.rpm_parse')
     @mock.patch('pulp.server.controllers.repository.associate_single_unit')
-    def test_rpm_signature_check_disabled(self, mock_assoc, mock_rpm_parse):
+    def test_rpm_signature_filter_disabled(self, mock_assoc, mock_rpm_parse):
         unit = models.RPM(name='foo', epoch=0, version='1.1.1', release='0', arch='x86_64',
                           checksumtype='sha256', checksum='abc123')
         self.metadata_files.add_repodata = mock.MagicMock()
@@ -130,7 +130,7 @@ class TestAddRpmUnit(BaseSyncTest):
         self.reposync.add_rpm_unit(self.metadata_files, unit)
 
         self.metadata_files.add_repodata.assert_called_once_with(unit)
-        self.assertFalse(mock_rpm_parse.verify_signature.called)
+        self.assertFalse(mock_rpm_parse.filter_signature.called)
         mock_assoc.assert_called_once_with(self.conduit.repo, unit)
 
 


### PR DESCRIPTION
The features introduced in #1991 (https://pulp.plan.io/issues/1991) only act
as filters based on whether or not a package is signed, and the short key ID
of the key used to generate that signature. This changes any reference to
"verification" introduced with those changes to "GPG Key ID filtering", and
in general attempted to clarify that this is not a security feature, while
still leaving it possible to (hopefully) do GPG package signature verification
in a future version.

fixes #2188
https://pulp.plan.io/issues/2188