### PR TITLE
Fix signature tests

### DIFF
--- a/plugins/test/unit/plugins/importers/yum/test_sync.py
+++ b/plugins/test/unit/plugins/importers/yum/test_sync.py
@@ -81,8 +81,7 @@ class TestAddRpmUnit(BaseSyncTest):
         self.metadata_files.add_repodata.assert_called_once_with(unit)
 
     @mock.patch('pulp_rpm.plugins.importers.yum.sync.rpm_parse')
-    @mock.patch('pulp.server.controllers.repository.associate_single_unit')
-    def test_rpm_signature_filter_pass(self, mock_assoc, mock_rpm_parse):
+    def test_rpm_signature_filter_pass(self, mock_rpm_parse):
         unit = models.RPM(name='foo', epoch=0, version='1.1.1', release='0', arch='x86_64',
                           checksumtype='sha256', checksum='abc123')
         self.metadata_files.add_repodata = mock.MagicMock()
@@ -95,11 +94,9 @@ class TestAddRpmUnit(BaseSyncTest):
 
         self.metadata_files.add_repodata.assert_called_once_with(unit)
         mock_rpm_parse.filter_signature.assert_called_once_with(unit, self.config)
-        mock_assoc.assert_called_once_with(self.conduit.repo, unit)
 
     @mock.patch('pulp_rpm.plugins.importers.yum.sync.rpm_parse')
-    @mock.patch('pulp.server.controllers.repository.associate_single_unit')
-    def test_rpm_signature_filter_failed(self, mock_assoc, mock_rpm_parse):
+    def test_rpm_signature_filter_failed(self, mock_rpm_parse):
         unit = models.RPM(name='foo', epoch=0, version='1.1.1', release='0', arch='x86_64',
                           checksumtype='sha256', checksum='abc123')
         self.metadata_files.add_repodata = mock.MagicMock()
@@ -113,11 +110,9 @@ class TestAddRpmUnit(BaseSyncTest):
 
         self.metadata_files.add_repodata.assert_called_once_with(unit)
         mock_rpm_parse.filter_signature.assert_called_once_with(unit, self.config)
-        self.assertFalse(mock_assoc.called)
 
     @mock.patch('pulp_rpm.plugins.importers.yum.sync.rpm_parse')
-    @mock.patch('pulp.server.controllers.repository.associate_single_unit')
-    def test_rpm_signature_filter_disabled(self, mock_assoc, mock_rpm_parse):
+    def test_rpm_signature_filter_disabled(self, mock_rpm_parse):
         unit = models.RPM(name='foo', epoch=0, version='1.1.1', release='0', arch='x86_64',
                           checksumtype='sha256', checksum='abc123')
         self.metadata_files.add_repodata = mock.MagicMock()
@@ -130,7 +125,6 @@ class TestAddRpmUnit(BaseSyncTest):
 
         self.metadata_files.add_repodata.assert_called_once_with(unit)
         self.assertFalse(mock_rpm_parse.filter_signature.called)
-        mock_assoc.assert_called_once_with(self.conduit.repo, unit)
 
 
 @skip_broken


### PR DESCRIPTION
Unit association is no longer performed in `RepoSync.add_rpm_unit`.