### PR TITLE
Drop spurious blank line from docs

### DIFF
--- a/docs/tech-reference/export-distributor.rst
+++ b/docs/tech-reference/export-distributor.rst
@@ -64,7 +64,6 @@ Optional Configuration Parameters
 
 ``relative_url``
  Relative path at which the repository will be served when exported. If this option is specified with
-
 ``export_dir``, this will become the exported subdirectory name instead of the default, which is the
  repository id.
 


### PR DESCRIPTION
The extra blank line caused a single definition list entry to appear as
two definition list entries.