### PR TITLE
Fix ISO sync of already existing units

### DIFF
--- a/plugins/pulp_rpm/plugins/importers/iso/sync.py
+++ b/plugins/pulp_rpm/plugins/importers/iso/sync.py
@@ -173,10 +173,16 @@ class ISOSyncRun(listener.DownloadEventListener):
         """
         Add entries to the deferred downloading (lazy) catalog.
 
+        Skip entries which are not eligible for lazy catalog.
+        (Don't have url attribute.)
+
         :param units: A list of: pulp_rpm.plugins.db.models.ISO.
         :type units: list
         """
         for unit in units:
+            # Unit is from pulp manifest
+            if not hasattr(unit, "url"):
+                continue
             unit.set_storage_path(unit.name)
             entry = LazyCatalogEntry()
             entry.path = unit.storage_path
@@ -229,7 +235,8 @@ class ISOSyncRun(listener.DownloadEventListener):
                     iso.save()
                 except NotUniqueError:
                     iso = iso.__class__.objects.filter(**iso.unit_key).first()
-                self.add_catalog_entries([iso])
+                else:
+                    self.add_catalog_entries([iso])
                 repo_controller.associate_single_unit(self.sync_conduit.repo, iso)
         else:
             self._download_isos(local_missing_isos)


### PR DESCRIPTION
Added check to sync.add_catalog_entries to ignore units not coming from
Pulp ISO manifest.

closes #2195
https://pulp.plan.io/issues/2195

After this commit no exceptions are begin raised anymore. But I would like to know what @jortel thinks about this because I think this arises from fix https://pulp.plan.io/issues/1897 and I'm not sure how it should work and if it does work correctly now.
