### PR TITLE
Fix unit association if unit was downloaded for the second time

### DIFF
--- a/plugins/pulp_rpm/plugins/importers/yum/listener.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/listener.py
@@ -197,7 +197,7 @@ class RPMListener(PackageListener):
                 return
             added_unit = self.sync.add_rpm_unit(self.metadata_files, unit)
             added_unit.safe_import_content(report.destination)
-            self.sync.associate_rpm_unit(unit)
+            self.sync.associate_rpm_unit(added_unit)
             if not added_unit.downloaded:
                 added_unit.downloaded = True
                 added_unit.save()


### PR DESCRIPTION
re #2190
https://pulp.plan.io/issues/2190