### PR TITLE
Updates API and pulp-admin to accept relative url configuration for ISO distributor.

### DIFF
--- a/common/pulp_rpm/common/constants.py
+++ b/common/pulp_rpm/common/constants.py
@@ -104,6 +104,7 @@ CONFIG_SERVE_HTTPS = 'serve_https'
 CONFIG_SERVE_HTTPS_DEFAULT = True
 CONFIG_KEY_CHECKSUM_TYPE = 'checksum_type'
 CONFIG_DEFAULT_CHECKSUM = 'sha256'
+CONFIG_RELATIVE_URL = 'relative_url'
 
 # list of types to skip at sync time
 CONFIG_SKIP = 'type_skip_list'

--- a/docs/tech-reference/iso-plugins.rst
+++ b/docs/tech-reference/iso-plugins.rst
@@ -152,3 +152,7 @@ configuration parameters are required.
  enabled, the distributed repository will become a protected repository. The given CA certificate will be used
  to verify the clients' entitlement certificates. If this certificate is not provided, the repository will be an
  unprotected repository.
+
+``relative_url``
+The path at which the repository will be served, relative to the root configured in
+``/etc/httpd/conf.d/pulp_rpm.conf``. The default root is ``/pulp/isos``.

--- a/docs/tech-reference/iso-rsync-distributor.rst
+++ b/docs/tech-reference/iso-rsync-distributor.rst
@@ -57,8 +57,8 @@ The ``distributor_config`` contains a ``remote`` section with the following sett
 
 ``root``
   The absolute path to the remote root directory where all the data (content and published content)
-  lives. This is the remote equivalent to ``/var/lib/pulp``. The repo id is appended to the
-  ``root`` path to determine the location of published repository.
+  lives. This is the remote equivalent to ``/var/lib/pulp``. The ``relative_url`` of the
+  predistributor is appended to the ``root`` to determine the location of published repository.
 
 Optional configuration
 ----------------------

--- a/docs/user-guide/release-notes/2.11.x.rst
+++ b/docs/user-guide/release-notes/2.11.x.rst
@@ -13,3 +13,4 @@ New Features
   since the last sync.
 * The yum_importer can sync a distribution unit even when no yum metadata is present in the repo.
   This is useful for kickstart trees related to Project Atomic.
+* Added support for publishing ISO repositories to custom relative paths.

--- a/extensions_admin/pulp_rpm/extensions/admin/iso/create_update.py
+++ b/extensions_admin/pulp_rpm/extensions/admin/iso/create_update.py
@@ -25,10 +25,15 @@ class ISODistributorConfigMixin(object):
         d = _('full path to the CA certificate that should be used to verify client authorization '
               'certificates; setting this turns on client authorization for the repository')
         self.opt_auth_ca = PulpCliOption('--auth-ca', d, required=False)
+        d = _(
+            'relative path the repository will be served from. Only alphanumeric characters, '
+            'forward slashes, underscores, and dashes are allowed.')
+        self.opt_relative_url = PulpCliOption('--relative-url', d, required=False)
 
         self.publishing_group.add_option(self.opt_http)
         self.publishing_group.add_option(self.opt_https)
         self.publishing_group.add_option(self.opt_auth_ca)
+        self.publishing_group.add_option(self.opt_relative_url)
 
         self.add_option_group(self.publishing_group)
 
@@ -43,6 +48,7 @@ class ISODistributorConfigMixin(object):
             (constants.CONFIG_SERVE_HTTP, self.opt_http.keyword),
             (constants.CONFIG_SERVE_HTTPS, self.opt_https.keyword),
             (constants.CONFIG_SSL_AUTH_CA_CERT, self.opt_auth_ca.keyword),
+            (constants.CONFIG_RELATIVE_URL, self.opt_relative_url.keyword),
         )
 
         config = {}

--- a/extensions_admin/test/unit/extensions/admin/iso/test_create_update.py
+++ b/extensions_admin/test/unit/extensions/admin/iso/test_create_update.py
@@ -77,7 +77,8 @@ class TestISODistributorConfigMixin(unittest.TestCase):
         # The HTTP, HTTPS, and CA options should be in the publishing group
         self.assertEqual(set(distributor_config_mixin.publishing_group.options),
                          set([distributor_config_mixin.opt_http, distributor_config_mixin.opt_https,
-                              distributor_config_mixin.opt_auth_ca]))
+                              distributor_config_mixin.opt_auth_ca,
+                              distributor_config_mixin.opt_relative_url]))
 
         # Lastly, the add_option_group mock should have been called once
         self.assertEqual(add_option_group.call_count, 1)

--- a/plugins/pulp_rpm/plugins/distributors/iso_distributor/distributor.py
+++ b/plugins/pulp_rpm/plugins/distributors/iso_distributor/distributor.py
@@ -5,6 +5,7 @@ from pulp.plugins.file.distributor import FileDistributor
 from pulp_rpm.common import ids
 from pulp_rpm.common import constants
 from pulp_rpm.plugins.distributors.iso_distributor import configuration, publish
+from pulp_rpm.plugins.distributors.yum.configuration import get_repo_relative_path
 
 
 def entry_point():
@@ -37,7 +38,7 @@ class ISODistributor(FileDistributor):
         }
 
     def validate_config(self, repo, config, config_conduit):
-        return configuration.validate(config)
+        return configuration.validate(config, repo.repo_obj, config_conduit)
 
     def publish_repo(self, transfer_repo, publish_conduit, config):
         """
@@ -90,8 +91,9 @@ class ISODistributor(FileDistributor):
         """
 
         hosting_locations = []
+        repo_relative_path = get_repo_relative_path(repo.repo_obj, config)
         # Publish the HTTP portion, if applicable
-        http_dest_dir = os.path.join(constants.ISO_HTTP_DIR, repo.id)
+        http_dest_dir = os.path.join(constants.ISO_HTTP_DIR, repo_relative_path)
 
         serve_http = config.get_boolean(constants.CONFIG_SERVE_HTTP)
         serve_http = serve_http if serve_http is not None else constants.CONFIG_SERVE_HTTP_DEFAULT
@@ -100,7 +102,7 @@ class ISODistributor(FileDistributor):
 
         # Publish the HTTPs portion, if applicable
         if self._is_https_supported(config):
-            https_dest_dir = os.path.join(constants.ISO_HTTPS_DIR, repo.id)
+            https_dest_dir = os.path.join(constants.ISO_HTTPS_DIR, repo_relative_path)
             hosting_locations.append(https_dest_dir)
 
         return hosting_locations

--- a/plugins/pulp_rpm/plugins/distributors/iso_rsync_distributor/publish.py
+++ b/plugins/pulp_rpm/plugins/distributors/iso_rsync_distributor/publish.py
@@ -1,5 +1,3 @@
-import os
-
 from pulp.plugins.rsync.publish import Publisher, RSyncPublishStep
 from pulp.plugins.util.publish_step import RSyncFastForwardUnitPublishStep
 from pulp.server.db.model import Distributor
@@ -8,6 +6,7 @@ from pulp.server.exceptions import PulpCodedException
 from pulp_rpm.common import constants
 from pulp_rpm.plugins.db import models
 from pulp_rpm.plugins import error_codes
+from pulp_rpm.plugins.distributors.yum.configuration import get_repo_relative_path
 
 
 class ISORsyncPublisher(Publisher):
@@ -39,15 +38,6 @@ class ISORsyncPublisher(Publisher):
         else:
             return constants.ISO_HTTPS_DIR
 
-    def get_master_directory(self):
-        """
-        Returns path to master directory of the predistributor.
-
-        :return: path to 'master' publish directory
-        :rtype: str
-        """
-        return os.path.join(self._get_root_publish_dir(), self.repo.id)
-
     def _add_necesary_steps(self, date_filter=None, config=None):
         """
         This method adds all the steps that are needed to accomplish an ISO rsync publish. This
@@ -66,7 +56,8 @@ class ISORsyncPublisher(Publisher):
         :param config: Pulp configuration for the distributor
         :type  config: pulp.plugins.config.PluginCallConfiguration
         """
-        remote_repo_path = self.repo.id
+        predistributor = self._get_predistributor()
+        remote_repo_path = get_repo_relative_path(self.repo.repo_obj, predistributor.config)
 
         # Find all the units associated with repo before last publish with predistributor
         gen_step = RSyncFastForwardUnitPublishStep("Unit query step (ISO)",

--- a/plugins/test/unit/plugins/distributors/iso_distributor/test_iso_distributor_configuration.py
+++ b/plugins/test/unit/plugins/distributors/iso_distributor/test_iso_distributor_configuration.py
@@ -24,7 +24,7 @@ class TestValidate(unittest.TestCase):
         config = get_basic_config(
             **{constants.CONFIG_SERVE_HTTP: True, constants.CONFIG_SERVE_HTTPS: False})
 
-        valid, msg = configuration.validate(config)
+        valid, msg = configuration.validate(config, None, None)
 
         # Assert the return values
         self.assertEqual(valid, True)
@@ -48,7 +48,7 @@ class TestValidate(unittest.TestCase):
             **{constants.CONFIG_SERVE_HTTP: True, constants.CONFIG_SERVE_HTTPS: False,
                constants.CONFIG_SSL_AUTH_CA_CERT: 'Invalid cert.'})
 
-        valid, msg = configuration.validate(config)
+        valid, msg = configuration.validate(config, None, None)
 
         # We passed a valid config, so validate() should have indicated that everything was cool
         self.assertFalse(valid)
@@ -61,7 +61,7 @@ class TestValidate(unittest.TestCase):
         config = get_basic_config(
             **{constants.CONFIG_SERVE_HTTP: True, constants.CONFIG_SERVE_HTTPS: False})
 
-        valid, msg = configuration.validate(config)
+        valid, msg = configuration.validate(config, None, None)
 
         # We passed a valid config, so validate() should have indicated that everything was cool
         self.assertTrue(valid)


### PR DESCRIPTION
The relative url works in the same way it does for the Yum distributor. When then ISO distributor is
used as predistributor, the ISO rsync distributor uses the relative url of the predistributor when
publishing.

re: 2132
https://pulp.plan.io/issues/2132