### PR TITLE
Remove no longer used checksum_type field from srpm/drpm collections.

### DIFF
--- a/plugins/pulp_rpm/plugins/migrations/0036_remove_srpm_drpm_checksum_type_field.py
+++ b/plugins/pulp_rpm/plugins/migrations/0036_remove_srpm_drpm_checksum_type_field.py
@@ -1,0 +1,30 @@
+"""
+Migration to remove the `checksum_type` field from SRPM/DRPM units,
+that is no longer used.
+"""
+
+from pulp.server.db import connection
+
+
+def migrate(*args, **kwargs):
+    """
+    Perform the migration as described in this module's docblock.
+
+    :param args:   unused
+    :type  args:   list
+    :param kwargs: unused
+    :type  kwargs: dict
+    """
+    db = connection.get_database()
+    units_srpm_collection = db['units_srpm']
+    units_drpm_collection = db['units_drpm']
+    units_srpm_collection.update(
+        {'checksum_type': {'$exists': True}},
+        {'$unset': {'checksum_type': True}},
+        multi=True
+    )
+    units_drpm_collection.update(
+        {'checksum_type': {'$exists': True}},
+        {'$unset': {'checksum_type': True}},
+        multi=True
+    )

--- a/plugins/test/unit/plugins/migrations/test_0036_remove_srpm_drpm_checksum_type_field.py
+++ b/plugins/test/unit/plugins/migrations/test_0036_remove_srpm_drpm_checksum_type_field.py
@@ -1,0 +1,35 @@
+import unittest
+
+import mock
+
+from pulp.server.db.migrate.models import _import_all_the_way
+
+
+PATH_TO_MODULE = 'pulp_rpm.plugins.migrations.0036_remove_srpm_drpm_checksum_type_field'
+
+migration = _import_all_the_way(PATH_TO_MODULE)
+
+
+class TestMigrate(unittest.TestCase):
+    """
+    Test migration 0036.
+    """
+
+    @mock.patch(PATH_TO_MODULE + '.connection')
+    def test_migration(self, mock_connection):
+        mock_units_srpm = mock.Mock()
+        mock_units_drpm = mock.Mock()
+        mock_connection.get_database.return_value = {
+            'units_srpm': mock_units_srpm, 'units_drpm': mock_units_drpm
+        }
+
+        migration.migrate()
+        mock_connection.get_database.assert_called_once_with()
+        self.assertEqual(mock_units_srpm.update.call_count, 1)
+        self.assertEqual(mock_units_drpm.update.call_count, 1)
+        expected_calls = [
+            mock.call({'checksum_type': {'$exists': True}},
+                      {'$unset': {'checksum_type': True}}, multi=True)
+        ]
+        mock_units_srpm.update.assert_has_calls(expected_calls)
+        mock_units_drpm.update.assert_has_calls(expected_calls)


### PR DESCRIPTION
closes #2278
https://pulp.plan.io/issues/2278