### PR TITLE
Fix URL in catalog entry created for existing package.

### DIFF
--- a/plugins/pulp_rpm/plugins/importers/yum/existing.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/existing.py
@@ -98,8 +98,9 @@ def check_all_and_associate(wanted, conduit, download_deferred, catalog):
     also associates the unit to the given repo. Note that the check for the actual file
     is performed only for the supported unit types.
 
-    :param wanted:            iterable of units as namedtuples
-    :type  wanted:            iterable
+    :param wanted:            dict where keys are units as namedtuples, and values are
+                              WantedUnitInfo instances
+    :type  wanted:            dict
     :param conduit:           repo sync conduit
     :type  conduit:           pulp.plugins.conduits.repo_sync.RepoSync
     :param download_deferred: indicates downloading is deferred (or not).
@@ -111,7 +112,7 @@ def check_all_and_associate(wanted, conduit, download_deferred, catalog):
                 named tuples received as input were not found on the server.
     :rtype:     set
     """
-    sorted_units = _sort_by_type(wanted)
+    sorted_units = _sort_by_type(wanted.iterkeys())
     for unit_type, values in sorted_units.iteritems():
         model = plugin_api.get_unit_model_by_id(unit_type)
         # FIXME "fields" does not get used, but it should
@@ -130,7 +131,7 @@ def check_all_and_associate(wanted, conduit, download_deferred, catalog):
                 # package file does not exist and downloading is not deferred.
                 if not download_deferred and not file_exists:
                     continue
-            catalog.add(unit)
+            catalog.add(unit, wanted[unit.unit_key_as_named_tuple].download_path)
             repo_controller.associate_single_unit(conduit.repo, unit)
             values.discard(unit.unit_key_as_named_tuple)
     still_wanted = set()

--- a/plugins/pulp_rpm/plugins/importers/yum/sync.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/sync.py
@@ -8,6 +8,7 @@ import shutil
 import tempfile
 import traceback
 
+from collections import namedtuple
 from gettext import gettext as _
 from cStringIO import StringIO
 from urlparse import urljoin
@@ -36,6 +37,13 @@ from pulp_rpm.plugins.importers.yum.utils import RepoURLModifier
 
 
 _logger = logging.getLogger(__name__)
+
+
+# Data about wanted units.
+# size - The size in bytes for the associated file.
+# download_path - The relative path within the upstream YUM repository
+#                 used to construct the download URL.
+WantedUnitInfo = namedtuple('WantedUnitInfo', ('size', 'download_path'))
 
 
 class RepoSync(object):
@@ -518,11 +526,11 @@ class RepoSync(object):
             # check for the units that are not in the repo, but exist on the server
             # and associate them to the repo
             to_download = existing.check_all_and_associate(
-                wanted.iterkeys(), self.conduit, self.download_deferred, catalog)
+                wanted, self.conduit, self.download_deferred, catalog)
             count = len(to_download)
             size = 0
             for unit in to_download:
-                size += wanted[unit]
+                size += wanted[unit].size
             return to_download, count, size
         finally:
             primary_file_handle.close()
@@ -562,10 +570,10 @@ class RepoSync(object):
                     # check for the units that are not in the repo, but exist on the server
                     # and associate them to the repo
                     to_download = existing.check_all_and_associate(
-                        wanted.iterkeys(), self.conduit, self.download_deferred, catalog)
+                        wanted, self.conduit, self.download_deferred, catalog)
                     count += len(to_download)
                     for unit in to_download:
-                        size += wanted[unit]
+                        size += wanted[unit].size
                 finally:
                     presto_file_handle.close()
 
@@ -630,7 +638,7 @@ class RepoSync(object):
                 for unit in units_to_download:
                     unit.downloaded = False
                     unit = self.add_rpm_unit(metadata_files, unit)
-                    catalog.add(unit)
+                    catalog.add(unit, unit.download_path)
                 return
 
             download_wrapper = alternate.Packages(
@@ -685,7 +693,7 @@ class RepoSync(object):
                         for unit in units_to_download:
                             unit.downloaded = False
                             unit = self.add_drpm_unit(metadata_files, unit)
-                            catalog.add(unit)
+                            catalog.add(unit, unit.download_path)
                         continue
 
                     download_wrapper = packages.Packages(
@@ -886,28 +894,29 @@ class RepoSync(object):
         for model in package_info_generator:
             versions = wanted.setdefault(model.key_string_without_version, {})
             serialized_version = model.complete_version_serialized
-            size = model.size
+            info = WantedUnitInfo(model.size, model.download_path)
 
             # if we are limited on the number of old versions we can have,
             if number_old_versions_to_keep is not None:
                 number_to_keep = number_old_versions_to_keep + 1
                 if len(versions) < number_to_keep:
-                    versions[serialized_version] = (model.unit_key_as_named_tuple, size)
+                    versions[serialized_version] = (model.unit_key_as_named_tuple, info)
                 else:
                     smallest_version = sorted(versions.keys(), reverse=True)[:number_to_keep][-1]
                     if serialized_version > smallest_version:
                         del versions[smallest_version]
-                        versions[serialized_version] = (model.unit_key_as_named_tuple, size)
+                        versions[serialized_version] = (model.unit_key_as_named_tuple, info)
             else:
-                versions[serialized_version] = (model.unit_key_as_named_tuple, size)
+                versions[serialized_version] = (model.unit_key_as_named_tuple, info)
         ret = {}
         for units in wanted.itervalues():
-            for unit, size in units.itervalues():
-                ret[unit] = size
+            for unit, info in units.itervalues():
+                ret[unit] = info
 
         return ret
 
-    def _filtered_unit_generator(self, units, to_download=None):
+    @staticmethod
+    def _filtered_unit_generator(units, to_download=None):
         """
         Given an iterator of Package instances and a collection (preferably a
         set for performance reasons) of Packages as named tuples, this returns
@@ -952,12 +961,15 @@ class PackageCatalog(object):
         self.importer_id = importer_id
         self.base_url = base_url
 
-    def add(self, unit):
+    def add(self, unit, path):
         """
         Add the specified content unit to the catalog.
 
         :param unit: A unit being added.
         :type unit: pulp_rpm.plugins.db.models.RpmBase
+        :param path: The relative path within the upstream YUM repository
+#           used to construct the download URL.
+        :type path: str
         """
         unit.set_storage_path(unit.filename)
         entry = LazyCatalogEntry()
@@ -965,7 +977,7 @@ class PackageCatalog(object):
         entry.importer_id = str(self.importer_id)
         entry.unit_id = unit.id
         entry.unit_type_id = unit.type_id
-        entry.url = urljoin(self.base_url, unit.download_path)
+        entry.url = urljoin(self.base_url, path)
         entry.checksum = unit.checksum
         entry.checksum_algorithm = unit.checksumtype
         entry.save_revision()


### PR DESCRIPTION
https://pulp.plan.io/issues/2354

Adding catalog entries in 2.8 really just got shoehorned in as best we could but the code organization and procedural flows made it very difficult.  This patch is not pretty but resolves the issue.