### PR TITLE
Change publish layout to Packages/[a-z]/*

### DIFF
--- a/common/pulp_rpm/common/constants.py
+++ b/common/pulp_rpm/common/constants.py
@@ -195,3 +195,5 @@ REPOMD_REVISION_KEY = 'repomd_revision'
 
 COMMON_NAMESPACE = 'http://linux.duke.edu/metadata/common'
 RPM_NAMESPACE = 'http://linux.duke.edu/metadata/rpm'
+
+PULP_PACKAGES_DIR = 'Packages'

--- a/common/pulp_rpm/common/file_utils.py
+++ b/common/pulp_rpm/common/file_utils.py
@@ -1,4 +1,7 @@
 import hashlib
+import os
+
+from .constants import PULP_PACKAGES_DIR
 
 CHECKSUM_CHUNK_SIZE = 32 * 1024 * 1024
 
@@ -34,3 +37,17 @@ def calculate_size(file_handle):
     file_handle.seek(0, 2)
     size = file_handle.tell()
     return size
+
+
+def make_packages_relative_path(filename):
+    """Create relative path for package inside repository.
+
+    e.g. "foo.rpm" -> "Packages/f/foo.rpm"
+
+    :param filename: Path to RPM/SRPM file or just it's filename
+    :type  filename: string
+    :return:         Relative path to package inside repository
+    :rtype:          string
+    """
+    _filename = os.path.basename(filename)
+    return os.path.join(PULP_PACKAGES_DIR, _filename[0].lower(), _filename)

--- a/common/test/unit/common/test_file_utils.py
+++ b/common/test/unit/common/test_file_utils.py
@@ -1,7 +1,7 @@
 import unittest
 import os
 
-from pulp_rpm.common import file_utils
+from pulp_rpm.common import file_utils, constants
 
 
 DATA_DIR = os.path.abspath(os.path.dirname(__file__)) + '/../../data'
@@ -29,3 +29,34 @@ class TestFileUtils(unittest.TestCase):
             test_file.close()
 
         self.assertEquals(file_size, 1675)
+
+
+class MakePackagesRelativePathTests(unittest.TestCase):
+    def test_PULP_PACKAGES_DIR(self):
+        """Test that PULP_PACKAGES_DIR is in returned path."""
+        self.assertTrue(file_utils.make_packages_relative_path("foo.rpm").startswith(
+            constants.PULP_PACKAGES_DIR))
+
+    def test_lower_letter(self):
+        """Test if folder is created from name starting with lowercase letter."""
+        expected = constants.PULP_PACKAGES_DIR + "/f/foo.rpm"
+        result = file_utils.make_packages_relative_path("foo.rpm")
+        self.assertEqual(expected, result)
+
+    def test_upper_letter(self):
+        """Test if folder is created from name starting with uppercase letter."""
+        expected = constants.PULP_PACKAGES_DIR + "/f/Foo.rpm"
+        result = file_utils.make_packages_relative_path("Foo.rpm")
+        self.assertEqual(expected, result)
+
+    def test_number(self):
+        """Test if folder is created from name starting with number."""
+        expected = constants.PULP_PACKAGES_DIR + "/1/1foo.rpm"
+        result = file_utils.make_packages_relative_path("1foo.rpm")
+        self.assertEqual(expected, result)
+
+    def test_not_basename(self):
+        """Test if correct path is returned when supplied filename is not basename."""
+        expected = constants.PULP_PACKAGES_DIR + "/f/foo.rpm"
+        result = file_utils.make_packages_relative_path("bar/foo.rpm")
+        self.assertEqual(expected, result)

--- a/docs/user-guide/release-notes/2.11.x.rst
+++ b/docs/user-guide/release-notes/2.11.x.rst
@@ -14,3 +14,9 @@ New Features
 * The yum_importer can sync a distribution unit even when no yum metadata is present in the repo.
   This is useful for kickstart trees related to Project Atomic.
 * Added support for publishing ISO repositories to custom relative paths.
+* RPMs are now being published into new folder structure e.g. "Packages/d/dnf.rpm". This applies
+  to all RPMs which will be published after this update, even during incremental publish in a repo
+  with the old folder structure. Incremental publishes will place newly-added RPMs into
+  the new folder structure while leaving previously-published RPMs in the old locations. This is
+  safe and correct. If you prefer to have all RPMs published in the new layout, simply perform
+  a full publish on each repository.

--- a/plugins/pulp_rpm/plugins/db/models.py
+++ b/plugins/pulp_rpm/plugins/db/models.py
@@ -971,7 +971,7 @@ class RpmBase(NonMetadataPackage):
         :type  filename:        basestring
         """
         location_element = package_element.find('location')
-        location_element.set('href', filename)
+        location_element.set('href', file_utils.make_packages_relative_path(filename))
 
     def get_symlink_name(self):
         """
@@ -980,7 +980,7 @@ class RpmBase(NonMetadataPackage):
         :return: file name as it appears in a published repository
         :rtype: str
         """
-        return self.filename
+        return file_utils.make_packages_relative_path(self.filename)
 
 
 class RPM(RpmBase):

--- a/plugins/pulp_rpm/plugins/distributors/yum/publish.py
+++ b/plugins/pulp_rpm/plugins/distributors/yum/publish.py
@@ -16,7 +16,7 @@ from pulp.server.db import model
 from pulp.server.exceptions import InvalidValue, PulpCodedException
 from pulp.server.controllers import repository as repo_controller
 
-from pulp_rpm.common import constants, ids
+from pulp_rpm.common import constants, ids, file_utils
 from pulp_rpm.yum_plugin import util
 from pulp_rpm.plugins import error_codes
 from pulp_rpm.plugins.db import models
@@ -63,7 +63,6 @@ class BaseYumRepoPublisher(platform_steps.PluginStep):
         super(BaseYumRepoPublisher, self).__init__(constants.PUBLISH_REPO_STEP, repo,
                                                    publish_conduit, config,
                                                    plugin_type=distributor_type, **kwargs)
-
         self.repomd_file_context = None
         self.checksum_type = None
 
@@ -475,7 +474,8 @@ class PublishRpmStep(platform_steps.UnitModelPluginStep):
         """
         unit = item
         source_path = unit._storage_path
-        destination_path = os.path.join(self.get_working_dir(), unit.filename)
+        relative_path = file_utils.make_packages_relative_path(unit.filename)
+        destination_path = os.path.join(self.get_working_dir(), relative_path)
         plugin_misc.create_symlink(source_path, destination_path)
         for package_dir in self.dist_step.package_dirs:
             destination_path = os.path.join(package_dir, unit.filename)
@@ -666,7 +666,7 @@ class PublishRpmAndDrpmStepIncremental(platform_steps.UnitModelPluginStep):
         """
         unit = item
         source_path = unit._storage_path
-        relative_path = unit.filename
+        relative_path = file_utils.make_packages_relative_path(unit.filename)
         destination_path = os.path.join(self.get_working_dir(), relative_path)
         plugin_misc.create_symlink(source_path, destination_path)
 

--- a/plugins/pulp_rpm/plugins/importers/yum/parse/rpm.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/parse/rpm.py
@@ -10,7 +10,7 @@ import rpmUtils
 from createrepo import yumbased
 from pulp.server import util
 from pulp.server.exceptions import PulpCodedException
-from pulp_rpm.common import constants
+from pulp_rpm.common import constants, file_utils
 from pulp_rpm.plugins import error_codes
 
 
@@ -55,8 +55,7 @@ def get_package_xml(pkg_path, sumtype=util.TYPE_SHA256):
 
 def change_location_tag(primary_xml_snippet, relpath):
     """
-    Transform the <location> tag to strip out leading directories so it
-    puts all rpms in same the directory as 'repodata'
+    Transform the <location> tag to strip out leading directories and add `Packages/<first_letter>`.
 
     :param primary_xml_snippet: snippet of primary xml text for a single package
     :type  primary_xml_snippet: str
@@ -65,13 +64,13 @@ def change_location_tag(primary_xml_snippet, relpath):
     :type  relpath: str
     """
 
-    basename = os.path.basename(relpath)
     start_index = primary_xml_snippet.find("<location ")
     end_index = primary_xml_snippet.find("/>", start_index) + 2  # adjust to end of closing tag
 
     first_portion = string_to_unicode(primary_xml_snippet[:start_index])
     end_portion = string_to_unicode(primary_xml_snippet[end_index:])
-    location = string_to_unicode("""<location href="%s"/>""" % (basename))
+    location = string_to_unicode("""<location href="%s"/>""" % (
+        file_utils.make_packages_relative_path(relpath)))
     return first_portion + location + end_portion
 
 

--- a/plugins/pulp_rpm/plugins/importers/yum/repomd/primary.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/repomd/primary.py
@@ -4,6 +4,7 @@ import os
 
 from pulp.server import util
 
+from pulp_rpm.common import file_utils
 from pulp_rpm.plugins.db import models
 from pulp_rpm.plugins.importers.yum import utils
 
@@ -151,7 +152,7 @@ def process_package_element(package_element):
         # we don't make any attempt to preserve the original directory structure
         # this element will end up being converted back to XML and stuffed into
         # the DB on the unit object, so this  is our chance to modify it.
-        location_element.attrib['href'] = filename
+        location_element.attrib['href'] = file_utils.make_packages_relative_path(filename)
 
     format_element = package_element.find(FORMAT_TAG)
     package_info.update(_process_format_element(format_element))

--- a/plugins/pulp_rpm/plugins/migrations/0037_rpm_primary_repodata_new_location.py
+++ b/plugins/pulp_rpm/plugins/migrations/0037_rpm_primary_repodata_new_location.py
@@ -1,0 +1,155 @@
+from cStringIO import StringIO
+import sys
+import os
+
+from pulp.server.db import connection
+
+if sys.version < (2, 7):
+    # We need the non-C implementation so we can shove a namespace into its internal data structure,
+    # since in python 2.6, the register_namespace function wasn't present.
+    import xml.etree.ElementTree as ET
+else:
+    import xml.etree.cElementTree as ET
+
+
+RPM_NAMESPACE = 'http://linux.duke.edu/metadata/rpm'
+PULP_PACKAGES_DIR = 'Packages'
+
+# this is required because some of the pre-migration XML tags use the "rpm"
+# namespace, which causes a parse error if that namespace isn't declared.
+FAKE_XML = '<?xml version="1.0" encoding="%(encoding)s"?><faketag ' \
+           'xmlns:rpm="%(namespace)s">%(xml)s</faketag>'
+
+
+def migrate(*args, **kwargs):
+    """Migrate RPMs and SRPMs location to new format "Packages/[a-z]/.*".
+
+
+    :param args:   unused
+    :type  args:   list
+    :param kwargs: unused
+    :type  kwargs: dict
+    """
+    try:
+        ET.register_namespace('rpm', RPM_NAMESPACE)
+    except AttributeError:
+        # python 2.6 doesn't have the register_namespace function
+        ET._namespace_map[RPM_NAMESPACE] = 'rpm'
+
+    db = connection.get_database()
+    rpm_collection = db['units_rpm']
+    srpm_collection = db['units_srpm']
+
+    for rpm in rpm_collection.find({}, ['repodata', 'filename']):
+        migrate_rpm_base(rpm_collection, rpm)
+    for srpm in srpm_collection.find({}, ['repodata', 'filename']):
+        migrate_rpm_base(srpm_collection, srpm)
+
+
+def migrate_rpm_base(collection, unit):
+    """
+    Migrate RPMs or SRPMs primary repodata location to new schema.
+
+    :param collection:  collection of RPM units
+    :type  collection:  pymongo.collection.Collection
+    :param unit:        the RPM unit being migrated
+    :type  unit:        dict
+    """
+    delta = {}
+    delta['repodata'] = fix_location(unit['repodata'], unit['filename'])
+
+    collection.update_one({'_id': unit['_id']}, {'$set': delta})
+
+
+def fix_location(repodata, filename):
+    """
+    Parse primary repodata and return repodata with location tag matching new publish schema.
+
+    :param package_element: XML element with name "package" from primary.xml
+    :type  package_element: xml.etree.ElementTree.Element
+    :param filename:        the name of the RPM's file
+    :type  filename:        basestring
+    """
+    faked_primary = fake_xml_element(repodata['primary'])
+    primary = faked_primary.find('package')
+
+    _update_location(primary, filename)
+
+    return {
+        'primary': remove_fake_element(element_to_text(faked_primary)),
+        'other': repodata["other"],
+        'filelists': repodata["filelists"],
+    }
+
+
+def _update_location(package_element, filename):
+    """
+    Update location tag to match new publish schema.
+
+    :param package_element: XML element with name "package" from primary.xml
+    :type  package_element: xml.etree.ElementTree.Element
+    :param filename:        the name of the RPM's file
+    :type  filename:        basestring
+    """
+    location_element = package_element.find('location')
+    location_element.set('href', os.path.join(PULP_PACKAGES_DIR, filename[0].lower(), filename))
+
+
+def fake_xml_element(repodata_snippet):
+    """
+    Wrap a snippet of xml in a fake element so it can be coerced to an ElementTree Element.
+
+    :param repodata_snippet: Snippet of XML to be turn into an ElementTree Element
+    :type  repodata_snippet: str
+
+    :return: Parsed ElementTree Element containing the parsed repodata snippet
+    :rtype:  xml.etree.ElementTree.Element
+    """
+    try:
+        # make a guess at the encoding
+        codec = 'UTF-8'
+        repodata_snippet.encode(codec)
+    except UnicodeEncodeError:
+        # best second guess we have, and it will never fail due to the nature
+        # of the encoding.
+        codec = 'ISO-8859-1'
+    fake_xml = FAKE_XML % {'encoding': codec, 'xml': repodata_snippet,
+                           'namespace': RPM_NAMESPACE}
+    # s/fromstring/phone_home/
+    return ET.fromstring(fake_xml.encode(codec))
+
+
+def remove_fake_element(xml_text, first_expected_name='package'):
+    """
+    Given XML text that results from data that ran through the fake_xml_element() function above,
+    remove the beginning and ending "faketag" elements.
+
+    :param xml_text:    XML that starts and ends with a <faketag> element
+    :type  xml_text:    basestring
+    :param first_expected_name: the name of the first element expected after the opening faketag
+                                element. Defaults to 'package'.
+    :type  first_expected_name: basestring
+
+    :return:    new XML string
+    :rtype:     basestring
+    """
+    start_index = xml_text.find('<' + first_expected_name)
+    end_index = xml_text.rfind('</faketag')
+
+    return xml_text[start_index:end_index]
+
+
+def element_to_text(element):
+    """
+    Given an element, return the raw XML as a string.
+
+    :param element: an element instance that should be written as XML text
+    :type  element: xml.etree.ElementTree.Element
+
+    :return:    XML text
+    :rtype:     basestring
+    """
+    out = StringIO()
+    tree = ET.ElementTree(element)
+    tree.write(out, encoding='utf-8')
+    return out.getvalue()

--- a/plugins/test/unit/plugins/db/test_models.py
+++ b/plugins/test/unit/plugins/db/test_models.py
@@ -13,7 +13,7 @@ from pulp.common.compat import unittest
 import pulp.common.error_codes as platform_error_codes
 from pulp.server.exceptions import PulpCodedException
 
-from pulp_rpm.common import ids
+from pulp_rpm.common import ids, constants
 from pulp_rpm.devel.skip import skip_broken
 from pulp_rpm.plugins import error_codes
 from pulp_rpm.plugins.db import models
@@ -162,7 +162,7 @@ class TestRpmBaseModifyXML(unittest.TestCase):
         self.unit.modify_xml()
 
         self.assertTrue('fixme' not in self.unit.repodata['primary'])
-        self.assertTrue('<location href="fixed-filename.rpm"'
+        self.assertTrue('<location href="%s/f/fixed-filename.rpm"' % (constants.PULP_PACKAGES_DIR)
                         in self.unit.repodata['primary'])
 
     def test_checksum_template(self):

--- a/plugins/test/unit/plugins/migrations/test_0037_rpm_primary_repodata_new_location.py
+++ b/plugins/test/unit/plugins/migrations/test_0037_rpm_primary_repodata_new_location.py
@@ -1,0 +1,136 @@
+import mock
+
+from pulp.common.compat import unittest
+from pulp.server.db.migrate.models import _import_all_the_way
+
+
+PATH_TO_MODULE = 'pulp_rpm.plugins.migrations.0037_rpm_primary_repodata_new_location'
+migration = _import_all_the_way(PATH_TO_MODULE)
+
+
+@mock.patch('pulp.server.db.connection.get_database')
+@mock.patch.object(migration, 'migrate_rpm_base')
+class TestMigrate(unittest.TestCase):
+    def test_calls_migrate(self, mock_migrate_rpm_base, mock_get_db):
+        mock_db = mock_get_db.return_value
+        mock_unit = mock.MagicMock()
+        mock_rpm_collection = mock_db['units_rpm']
+        mock_rpm_collection.find.return_value = [mock_unit]
+        mock_srpm_collection = mock_db['units_srpm']
+        mock_srpm_collection.find.return_value = [mock_unit]
+
+        migration.migrate()
+
+        self.assertEqual(mock_migrate_rpm_base.call_count, 2)
+        mock_migrate_rpm_base.assert_called_with(mock_rpm_collection, mock_unit)
+        mock_migrate_rpm_base.assert_called_with(mock_srpm_collection, mock_unit)
+
+
+@mock.patch.object(migration, 'fix_location')
+class TestMigrateRPMBase(unittest.TestCase):
+    def test_migrate_rpm_base(self, fix_location_mock):
+        unit = {
+            "_id": "123",
+            "filename": "foo-bar.rpm",
+            "repodata": "some-repo-data"
+        }
+        expected_delta = {
+            "repodata": fix_location_mock.return_value
+        }
+        mock_collection = mock.MagicMock()
+
+        migration.migrate_rpm_base(mock_collection, unit)
+
+        fix_location_mock.assert_called_once_with("some-repo-data", "foo-bar.rpm")
+        mock_collection.update_one.assert_called_once_with({'_id': '123'}, {'$set': expected_delta})
+
+
+class TestFixLocation(unittest.TestCase):
+    def test_fix_location_lowercase(self):
+        rpm = "mouse-0.1.12-1.noarch.rpm"
+        repodata = {
+            'primary': PRIMARY,
+            'other': OTHER,
+            'filelists': FILELISTS,
+        }
+
+        ret = migration.fix_location(repodata, rpm)
+
+        self.assertIn('Packages/m/%s"' % rpm, ret["primary"])
+        self.assertNotIn('<location href="foo-bar.rpm"/>', ret["primary"])
+        self.assertEqual(ret["other"], OTHER)
+        self.assertEqual(ret["filelists"], FILELISTS)
+
+    def test_fix_location_uppercase(self):
+        rpm = "Mouse-0.1.12-1.noarch.rpm"
+        repodata = {
+            'primary': PRIMARY,
+            'other': OTHER,
+            'filelists': FILELISTS,
+        }
+
+        ret = migration.fix_location(repodata, rpm)
+
+        self.assertIn('Packages/m/%s"' % rpm, ret["primary"])
+        self.assertNotIn('foo-bar.rpm"', ret["primary"])
+        self.assertEqual(ret["other"], OTHER)
+        self.assertEqual(ret["filelists"], FILELISTS)
+
+    def test_fix_location_number(self):
+        rpm = "1-mouse-0.1.12-1.noarch.rpm"
+        repodata = {
+            'primary': PRIMARY,
+            'other': OTHER,
+            'filelists': FILELISTS,
+        }
+
+        ret = migration.fix_location(repodata, rpm)
+
+        self.assertIn('Packages/1/%s"' % rpm, ret["primary"])
+        self.assertNotIn('foo-bar.rpm"', ret["primary"])
+        self.assertEqual(ret["other"], OTHER)
+        self.assertEqual(ret["filelists"], FILELISTS)
+
+PRIMARY = '''
+<package type="rpm">
+  <name>mouse</name>
+  <arch>noarch</arch>
+  <version epoch="0" rel="1" ver="0.1.12" />
+  <checksum pkgid="YES"
+    type="sha256">f4200643b0845fdc55ee002c92c0404a9f3a2a49f596c78b40ab56749de226ce</checksum>
+  <summary>A dummy package of mouse</summary>
+  <description>A dummy package of mouse</description>
+  <packager />
+  <url>http://tstrachota.fedorapeople.org</url>
+  <time build="1331831376" file="1463813415" />
+  <size archive="296" installed="42" package="2476" />
+  <location href="foo-bar.rpm"/>
+  <format>
+    <rpm:license>GPLv2</rpm:license>
+    <rpm:vendor />
+    <rpm:group>Internet/Applications</rpm:group>
+    <rpm:buildhost>smqe-ws15</rpm:buildhost>
+    <rpm:sourcerpm>mouse-0.1.12-1.src.rpm</rpm:sourcerpm>
+    <rpm:header-range end="2325" start="872" />
+    <rpm:provides>
+      <rpm:entry epoch="0" flags="EQ" name="mouse" rel="1" ver="0.1.12" />
+    </rpm:provides>
+    <rpm:requires>
+      <rpm:entry name="dolphin" />
+      <rpm:entry name="zebra" />
+    </rpm:requires>
+  </format>
+</package>'''
+
+OTHER = '''
+<package arch="noarch" name="mouse"
+  pkgid="f4200643b0845fdc55ee002c92c0404a9f3a2a49f596c78b40ab56749de226ce">
+  <version epoch="0" rel="1" ver="0.1.12" />
+</package>'''
+
+FILELISTS = '''
+<package arch="noarch" name="mouse"
+  pkgid="f4200643b0845fdc55ee002c92c0404a9f3a2a49f596c78b40ab56749de226ce">
+  <version epoch="0" rel="1" ver="0.1.12" />
+  <file>/tmp/mouse.txt</file>
+</package>'''


### PR DESCRIPTION
closes #1976
https://pulp.plan.io/issues/1976

Include
* [x] Sync RPMs/SRPMs into new layout
* [x] Publish packages RPMs/SRPMs into new layout
* [x] Incremental Publish packages RPMs/SRPMs/DRPMs into new layout
* [x] Publish metadata RPMs/SRPMs into new layout
* [x] Upload RPMs/SRPMs into new layout
* [x] Publish packages DRPMs into new layout
* [x] Publish metadata DRPMs into new layout
* [x] Sync DRPMs into new layout
* [x] Upload DRPMs into new layout
* [x] Database metadata migration
* [x] Write database migration test

Tested:
* [x] Sync RPMs/SRPMs into new layout
* [x] Publish RPMs/SRPMs into new layout
* [x] Upload RPMs/SRPMs into new layout
* [x] dnf test RPMs/SRPMs
* [x] Sync DRPMs into new layout
* [x] Upload DRPMs into new layout
* [x] Publish DRPMs into new layout
* [x] dnf test DRPMs
* [ ] Incremental Publish packages RPMs/SRPMs/DRPMs into new layout
* [x] Migration of RPMs/SRPMs
* [x] Migration of DRPMs
* [ ] Repoview