### PR TITLE
Reduce number of writes to db during sync

### DIFF
--- a/plugins/pulp_rpm/plugins/importers/yum/existing.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/existing.py
@@ -131,8 +131,9 @@ def check_all_and_associate(wanted, conduit, download_deferred, catalog):
                 # package file does not exist and downloading is not deferred.
                 if not download_deferred and not file_exists:
                     continue
-            catalog.add(unit, wanted[unit.unit_key_as_named_tuple].download_path)
-            repo_controller.associate_single_unit(conduit.repo, unit)
+            if not unit.is_associated(conduit.repo.repo_id):
+                catalog.add(unit, wanted[unit.unit_key_as_named_tuple].download_path)
+                repo_controller.associate_single_unit(conduit.repo, unit)
             values.discard(unit.unit_key_as_named_tuple)
     still_wanted = set()
     still_wanted.update(*sorted_units.values())

--- a/plugins/test/unit/plugins/db/test_models.py
+++ b/plugins/test/unit/plugins/db/test_models.py
@@ -273,8 +273,8 @@ class TestErrata(unittest.TestCase):
         self.assertEqual(existing_erratum.pkglist[0]['_pulp_repo_id'],
                          uploaded_erratum.pkglist[0]['_pulp_repo_id'])
 
-        # make sure save() is called
-        self.assertEqual(mock_save.call_count, 2)
+        # make sure save() is called once since no collections were added
+        self.assertEqual(mock_save.call_count, 1)
 
     @mock.patch('pulp_rpm.plugins.db.models.Errata.save')
     def test_merge_pkglists_oldstyle_newstyle_different_collection(self, mock_save):
@@ -329,8 +329,8 @@ class TestErrata(unittest.TestCase):
         self.assertEqual(existing_erratum.pkglist[0]['packages'][0]['version'],
                          uploaded_erratum.pkglist[0]['packages'][0]['version'])
 
-        # make sure save() is called
-        self.assertEqual(mock_save.call_count, 2)
+        # make sure save() is called once since no collections were added
+        self.assertEqual(mock_save.call_count, 1)
 
     @mock.patch('pulp_rpm.plugins.db.models.Errata.save')
     @mock.patch('pulp_rpm.plugins.db.models.Errata.update_needed')


### PR DESCRIPTION
This commit eliminates the following unnecessary operations:
 - addition of  RPM/SRPM/DRPM to PackageCatalog when unit is already
   associated with the repository
 - re-association of RPM/SRPM/DRPM with repository when such
   association already exists
 - additional `save()` to errata model even when no new collections
   were added

closes #2457
https://pulp.plan.io/issues/2457