### PR TITLE
Reduce number of writes to db during sync

### DIFF
--- a/plugins/pulp_rpm/plugins/db/models.py
+++ b/plugins/pulp_rpm/plugins/db/models.py
@@ -1189,8 +1189,10 @@ class Errata(UnitMixin, ContentUnit):
         # the pkglist, because mongoengine does not allow to modify existing items in the list
         # and add new items to the list at the same time.
         self.save()
-        self.pkglist += collections_to_add
-        self.save()
+
+        if collections_to_add:
+            self.pkglist += collections_to_add
+            self.save()
 
 
 class PackageGroup(UnitMixin, ContentUnit):

--- a/plugins/test/unit/plugins/db/test_models.py
+++ b/plugins/test/unit/plugins/db/test_models.py
@@ -431,8 +431,8 @@ class TestErrata(unittest.TestCase):
         self.assertEqual(existing_erratum.pkglist[0]['_pulp_repo_id'],
                          uploaded_erratum.pkglist[0]['_pulp_repo_id'])
 
-        # make sure save() is called
-        self.assertEqual(mock_save.call_count, 2)
+        # make sure save() is called once since no collections were added
+        self.assertEqual(mock_save.call_count, 1)
 
     @mock.patch('pulp_rpm.plugins.db.models.Errata.save')
     def test_merge_pkglists_oldstyle_newstyle_different_collection(self, mock_save):
@@ -487,8 +487,8 @@ class TestErrata(unittest.TestCase):
         self.assertEqual(existing_erratum.pkglist[0]['packages'][0]['version'],
                          uploaded_erratum.pkglist[0]['packages'][0]['version'])
 
-        # make sure save() is called
-        self.assertEqual(mock_save.call_count, 2)
+        # make sure save() is called once since no collections were added
+        self.assertEqual(mock_save.call_count, 1)
 
     @mock.patch('pulp_rpm.plugins.db.models.Errata.save')
     @mock.patch('pulp_rpm.plugins.db.models.Errata.update_needed')


### PR DESCRIPTION
This commit eliminates the following unnecessary operations:
 - addition of  RPM/SRPM/DRPM to PackageCatalog when unit is already
   associated with the repository
 - re-association of RPM/SRPM/DRPM with repository when such
   association already exists
 - additional `save()` to errata model even when no new collections
   were added

closes #2457
https://pulp.plan.io/issues/2457