### PR TITLE
Problem: ISO Importer reports a vague failure message

### DIFF
--- a/common/pulp_rpm/common/progress.py
+++ b/common/pulp_rpm/common/progress.py
@@ -303,4 +303,7 @@ class SyncProgressReport(ISOProgressReport):
 
         super(self.__class__, self)._set_state(new_state)
 
+        if new_state == self.STATE_ISOS_FAILED:
+            raise Exception(self.iso_error_messages)
+
     state = property(ISOProgressReport._get_state, _set_state)

--- a/common/test/unit/common/server/test_progress.py
+++ b/common/test/unit/common/server/test_progress.py
@@ -374,14 +374,14 @@ class TestSyncProgressReport(unittest.TestCase):
     def test__set_state_iso_errors(self):
         """
         Test the state property as a setter for the situation when the state is marked as COMPLETE,
-        but there are ISO errors. It should automatically get set to ISOS_FAILED instead.
+        but there are ISO errors. It should raise an exception with all the ISO errors.
         """
         report = progress.SyncProgressReport(
             self.conduit, iso_error_messages={'iso': 'error'},
             state=progress.SyncProgressReport.STATE_ISOS_IN_PROGRESS)
 
-        # This should trigger an automatic STATE_FAILED, since there are ISO errors
-        report.state = progress.SyncProgressReport.STATE_COMPLETE
+        # This should raise an Exception since there are ISO errors
+        self.assertRaises(Exception, report._set_state, progress.SyncProgressReport.STATE_COMPLETE)
 
         self.assertEqual(report._state, progress.SyncProgressReport.STATE_ISOS_FAILED)
         self.assertTrue(report._state in report.state_times)


### PR DESCRIPTION
Solution: When some downloads fail, raise an exception with the list of all
errors collected during the sync.

closes #2006
https://pulp.plan.io/issues/2006