### PR TITLE
Prevent a cursor timeout when syncing rpm repos

### DIFF
--- a/plugins/pulp_rpm/plugins/importers/yum/purge.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/purge.py
@@ -393,7 +393,9 @@ def _duplicate_key_id_generator_aggregation(unit, fields):
 
     # When aggregating over hundreds of thousands of packages, mongo can overflow
     # To prevent this, mongo needs to be allowed to temporarily use the disk for this transaction
-    aggregation = unit.objects.aggregate(sort, project, allowDiskUse=True)
+    # Set the batch size to 5 to prevent a cursor timeout
+    aggregation = unit.objects.aggregate(sort, project, allowDiskUse=True,
+                                         batchSize=5)
 
     # loop state tracking vars
     previous_nevra = None


### PR DESCRIPTION
I couldn't actually reproduce the cursor timeout using a variety of
configurations for my VM but using a batch size here didn't seem to slow
down syncs significantly when I benchmarked this change.

fixes #2502
https://pulp.plan.io/issues/2502