### PR TITLE
Fix the errata merge logic

### DIFF
--- a/plugins/pulp_rpm/plugins/migrations/0038_errata_pkglist_duplicates_cleanup.py
+++ b/plugins/pulp_rpm/plugins/migrations/0038_errata_pkglist_duplicates_cleanup.py
@@ -1,0 +1,48 @@
+from pulp.server.db import connection
+
+
+def migrate(*args, **kwargs):
+    """
+    Clean up duplicated collections in erratum pkglist.
+
+    :param args:   unused
+    :type  args:   list
+    :param kwargs: unused
+    :type  kwargs: dict
+    """
+    db = connection.get_database()
+    erratum_collection = db['units_erratum']
+
+    for erratum in erratum_collection.find({}, ['pkglist']).batch_size(100):
+        migrate_erratum(erratum_collection, erratum)
+
+
+def migrate_erratum(erratum_collection, erratum):
+    """
+    Leave only the newest collections in erratum pkglist in case of duplicates.
+
+    The newest collections are determined by their position in pkglist.
+    They are at the end of the list.
+
+    :param erratum_collection:  collection of erratum units
+    :type  erratum_collection:  pymongo.collection.Collection
+    :param erratum:        the erratum unit being migrated
+    :type  erratum:        dict
+    """
+    pkglist = erratum.get('pkglist', [])
+    new_pkglist = []
+    added_collections = set()
+
+    for collection in pkglist[::-1]:
+        coll_name = collection.get('name')
+        repo_id = collection.get('_pulp_repo_id')
+        coll_id = (coll_name, repo_id)
+        if coll_id not in added_collections:
+            new_pkglist.append(collection)
+            added_collections.add(coll_id)
+
+    # to keep the order of the original pkglist
+    new_pkglist = new_pkglist[::-1]
+    if pkglist != new_pkglist:
+        erratum_collection.update({'_id': erratum['_id']},
+                                  {'$set': {'pkglist': new_pkglist}})

--- a/plugins/test/unit/plugins/migrations/test_0038_errata_pkglist_duplicates_cleanup.py
+++ b/plugins/test/unit/plugins/migrations/test_0038_errata_pkglist_duplicates_cleanup.py
@@ -1,0 +1,60 @@
+from pulp.common.compat import unittest
+
+import mock
+
+from pulp.server.db.migrate.models import _import_all_the_way
+
+
+PATH_TO_MODULE = 'pulp_rpm.plugins.migrations.0038_errata_pkglist_duplicates_cleanup'
+migration = _import_all_the_way(PATH_TO_MODULE)
+
+
+@mock.patch('pulp.server.db.connection.get_database')
+@mock.patch.object(migration, 'migrate_erratum')
+class TestMigrate(unittest.TestCase):
+    def test_calls_migrate_erratum(self, mock_migrate_erratum, mock_get_db):
+        mock_db = mock_get_db.return_value
+        mock_unit = mock.MagicMock()
+        mock_erratum_collection = mock_db['units_erratum']
+        mock_erratum_collection.find.return_value.batch_size.return_value = [mock_unit]
+
+        migration.migrate()
+
+        self.assertEqual(mock_migrate_erratum.call_count, 1)
+        mock_migrate_erratum.assert_called_with(mock_erratum_collection, mock_unit)
+
+
+class TestMigrateErratum(unittest.TestCase):
+    def setUp(self):
+        super(TestMigrateErratum, self).setUp()
+        self.erratum = {
+            '_id': '1234',
+            'pkglist': [{'name': 'coll_name'},
+                        {'name': 'coll_name', '_pulp_repo_id': 'myrepo', 'smth': 1},
+                        {'name': 'coll_name', '_pulp_repo_id': 'testrepo'},
+                        {'name': 'some_name', '_pulp_repo_id': 'myrepo'},
+                        {'name': 'coll_name', '_pulp_repo_id': 'myrepo', 'smth': 2}]
+        }
+
+    def test_calls_update(self):
+        mock_collection = mock.MagicMock()
+
+        migration.migrate_erratum(mock_collection, self.erratum)
+
+        expected_delta = {
+            'pkglist': [{'name': 'coll_name'},
+                        {'name': 'coll_name', '_pulp_repo_id': 'testrepo'},
+                        {'name': 'some_name', '_pulp_repo_id': 'myrepo'},
+                        {'name': 'coll_name', '_pulp_repo_id': 'myrepo', 'smth': 2}]
+        }
+        mock_collection.update.assert_called_once_with({'_id': '1234'},
+                                                       {'$set': expected_delta})
+
+    def test_calls_no_update(self):
+        mock_collection = mock.MagicMock()
+        self.erratum['pkglist'] = [{'name': 'coll_name'},
+                                   {'name': 'coll_name', '_pulp_repo_id': 'myrepo', 'smth': 2}]
+
+        migration.migrate_erratum(mock_collection, self.erratum)
+
+        self.assertFalse(mock_collection.update.called)


### PR DESCRIPTION
Pkglists should no longer be extended with the collections for the same repository.
Migration is introduced to clean up duplicates in the affected pkglists.

closes #2568
https://pulp.plan.io/issues/2568