### PR TITLE
Fixes KeyError when Nectar download fails.

### DIFF
--- a/common/pulp_rpm/common/constants.py
+++ b/common/pulp_rpm/common/constants.py
@@ -159,7 +159,7 @@ EXPORT_HTTPS_DIR = '/var/lib/pulp/published/https/exports/repo'
 GROUP_EXPORT_HTTP_DIR = '/var/lib/pulp/published/http/exports/repo_group'
 GROUP_EXPORT_HTTPS_DIR = '/var/lib/pulp/published/https/exports/repo_group'
 
-# Keys used for reading & writing messages from server to clinet
+# Keys used for reading & writing messages from server to client
 UNIT_KEY = 'unit_key'
 ERROR_CODE = 'error_code'
 NAME = 'name'

--- a/plugins/pulp_rpm/plugins/importers/yum/sync.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/sync.py
@@ -243,6 +243,7 @@ class RepoSync(object):
         # was not able to find any valid url
         if not self.sync_feed:
             raise PulpCodedException(error_code=error_codes.RPM1004, reason='Not found')
+
         url_count = 0
         for url in self.sync_feed:
             # Verify that we have a feed url.
@@ -550,7 +551,9 @@ class RepoSync(object):
         failed_signature_check = 0
         new_report = []
         for error in self.progress_report['content']['error_details']:
-            if error[constants.ERROR_CODE] == constants.ERROR_KEY_ID_FILTER:
+            # Nectar doesn't return error reports in the same format as other parts of the code
+            # Use getattr() here to avoid KeyErrors
+            if getattr(error, constants.ERROR_CODE, None) == constants.ERROR_KEY_ID_FILTER:
                 failed_signature_check += 1
             else:
                 new_report.append(error)


### PR DESCRIPTION
Pulp RPM is doing some wonky stuff with error reporting. It's
set up to accept errors in a particular format which Nectar does
not abide by. This causes a KeyError when Nectar encounters a
download failure, because one of the fields it expects to find
does not exist.

closes #2505