### PR TITLE
Fix non-utf8 when found in uploaded RPMs.

### DIFF
--- a/plugins/pulp_rpm/plugins/importers/yum/parse/rpm.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/parse/rpm.py
@@ -44,7 +44,9 @@ def get_package_xml(pkg_path, sumtype=util.TYPE_SHA256):
         return {}
     # RHEL6 createrepo throws a ValueError if _cachedir is not set
     po._cachedir = None
-    primary_xml_snippet = change_location_tag(po.xml_dump_primary_metadata(), pkg_path)
+    primary_xml_snippet = po.xml_dump_primary_metadata()
+    primary_xml_snippet = primary_xml_snippet.decode('utf-8', 'replace')
+    primary_xml_snippet = change_location_tag(primary_xml_snippet, pkg_path)
     metadata = {
         'primary': primary_xml_snippet,
         'filelists': po.xml_dump_filelists_metadata(),
@@ -58,45 +60,19 @@ def change_location_tag(primary_xml_snippet, relpath):
     Transform the <location> tag to strip out leading directories and add `Packages/<first_letter>`.
 
     :param primary_xml_snippet: snippet of primary xml text for a single package
-    :type  primary_xml_snippet: str
+    :type  primary_xml_snippet: unicode
 
     :param relpath: Package's 'relativepath'
-    :type  relpath: str
+    :type  relpath: unicode
     """
 
     start_index = primary_xml_snippet.find("<location ")
     end_index = primary_xml_snippet.find("/>", start_index) + 2  # adjust to end of closing tag
 
-    first_portion = string_to_unicode(primary_xml_snippet[:start_index])
-    end_portion = string_to_unicode(primary_xml_snippet[end_index:])
-    location = string_to_unicode("""<location href="%s"/>""" % (
-        file_utils.make_packages_relative_path(relpath)))
+    first_portion = primary_xml_snippet[:start_index]
+    end_portion = primary_xml_snippet[end_index:]
+    location = """<location href="%s"/>""" % file_utils.make_packages_relative_path(relpath)
     return first_portion + location + end_portion
-
-
-ENCODING_LIST = ('utf8', 'iso-8859-1')
-
-
-def string_to_unicode(data):
-    """
-    Make a best effort to decode a string, trying encodings in a sensible order
-    based on unscientific expectations of each one's probability of use.
-    ISO 8859-1 (aka latin1) will never fail, so this will always return some
-    unicode object. Lack of decoding error does not mean decoding was correct
-    though.
-
-    :param data:        string to decode
-    :type  data:        str
-
-    :return: data as a unicode object
-    :rtype:  unicode
-    """
-    for code in ENCODING_LIST:
-        try:
-            return data.decode(code)
-        except UnicodeError:
-            # try others
-            continue
 
 
 def package_headers(filename):

--- a/plugins/pulp_rpm/yum_plugin/util.py
+++ b/plugins/pulp_rpm/yum_plugin/util.py
@@ -98,31 +98,6 @@ def is_rpm_newer(a, b):
     return False
 
 
-ENCODING_LIST = ('utf8', 'iso-8859-1')
-
-
-def string_to_unicode(data):
-    """
-    Make a best effort to decode a string, trying encodings in a sensible order
-    based on unscientific expectations of each one's probability of use.
-    ISO 8859-1 (aka latin1) will never fail, so this will always return some
-    unicode object. Lack of decoding error does not mean decoding was correct
-    though.
-
-    :param data:        string to decode
-    :type  data:        str
-
-    :return: data as a unicode object
-    :rtype:  unicode
-    """
-    for code in ENCODING_LIST:
-        try:
-            return data.decode(code)
-        except UnicodeError:
-            # try others
-            continue
-
-
 LISTING_FILE_NAME = 'listing'
 
 

--- a/plugins/test/unit/yum_plugin/test_util.py
+++ b/plugins/test/unit/yum_plugin/test_util.py
@@ -42,29 +42,6 @@ class TestUtil(rpm_support_base.PulpRPMTests):
         self.assertFalse(util.is_rpm_newer(newer_a, rpm_b))
 
 
-class TestStringToUnicode(unittest.TestCase):
-    def test_ascii(self):
-        result = util.string_to_unicode('abc')
-        self.assertTrue(isinstance(result, unicode))
-        self.assertEqual(result, u'abc')
-
-    def test_empty(self):
-        result = util.string_to_unicode('')
-        self.assertTrue(isinstance(result, unicode))
-        self.assertEqual(result, u'')
-
-    def test_latin1(self):
-        data = '/usr/share/doc/man-pages-da-0.1.1/l\xe6smig'
-        result = util.string_to_unicode(data)
-        self.assertTrue(isinstance(result, unicode))
-        self.assertEqual(result, data.decode('iso-8859-1'))
-
-    def test_utf8(self):
-        result = util.string_to_unicode(u'€'.encode('utf8'))
-        self.assertTrue(isinstance(result, unicode))
-        self.assertEqual(result, u'€')
-
-
 class TestGenerateListingFiles(unittest.TestCase):
     def test_repo_dir_not_descendant(self):
         self.assertRaises(ValueError, util.generate_listing_files, '/a/b/c', '/d/e/f')


### PR DESCRIPTION
https://pulp.plan.io/issues/1903

Seemed to make more sense to decode entire primary XML fragment instead of doing it element-by-element.  This approach is simpler and more comprehensive.