### PR TITLE
Ensure unique errata collection names on publish

### DIFF
--- a/plugins/pulp_rpm/plugins/db/models.py
+++ b/plugins/pulp_rpm/plugins/db/models.py
@@ -30,7 +30,28 @@ from pulp_rpm.yum_plugin import util
 _LOGGER = logging.getLogger(__name__)
 
 
-NEVRA = namedtuple('NEVRA', ['name', 'epoch', 'version', 'release', 'arch'])
+_NEVRA = namedtuple('NEVRA', ['name', 'epoch', 'version', 'release', 'arch'])
+
+
+class NEVRA(_NEVRA):
+    @classmethod
+    def _fromdict(cls, nevra_dict):
+        """
+        Given a dict with NEVRA keys, return a NEVRA namedtuple using its values.
+
+        Extra keys can be included, but will be ignored.
+
+        :param nevra_dict: dict with NEVRA keys (name, epoch, version, release, arch)
+        :type: dict of str
+        :return: NEVRA tuple made using the values passed in the nevra_dict
+        :rtype: NEVRA
+        """
+        # if epoch is Falsey, set to string '0' in a preprocessing step
+        if not nevra_dict['epoch']:
+            # make a shallow copy to avoid modifying the passed-in dict
+            nevra_dict = nevra_dict.copy()
+            nevra_dict['epoch'] = '0'
+        return cls(*[nevra_dict[field] for field in cls._fields])
 
 
 class UnitMixin(object):

--- a/plugins/pulp_rpm/plugins/distributors/yum/publish.py
+++ b/plugins/pulp_rpm/plugins/distributors/yum/publish.py
@@ -595,19 +595,10 @@ class PublishErrataStep(platform_steps.UnitModelPluginStep):
         Initialize the UpdateInfo file and set the method used to process the unit to the
         one that is built into the UpdateinfoXMLFileContext
         """
-        repo_id = self.get_repo().id
-        nevra_fields = ('name', 'epoch', 'version', 'release', 'arch')
-        querysets = repo_controller.get_unit_model_querysets(repo_id, models.RPM)
-        nevra_scalars = itertools.chain(*[q.scalar(*nevra_fields) for q in querysets])
-        nevra_in_repo = set()
-        for scalar in nevra_scalars:
-            nevra_in_repo.add(models.NEVRA(*scalar))
-
         checksum_type = self.parent.get_checksum_type()
         updateinfo_checksum_type = self.get_config().get('updateinfo_checksum_type')
-        self.context = UpdateinfoXMLFileContext(self.get_working_dir(), nevra_in_repo,
-                                                checksum_type, self.get_conduit(),
-                                                updateinfo_checksum_type)
+        self.context = UpdateinfoXMLFileContext(self.get_working_dir(), checksum_type,
+                                                self.get_conduit(), updateinfo_checksum_type)
         self.context.initialize()
 
     def process_main(self, item=None):
@@ -619,9 +610,10 @@ class PublishErrataStep(platform_steps.UnitModelPluginStep):
         """
         erratum_unit = item
         if erratum_unit:
-            pkglists_to_publish = self._get_pkglists_to_publish(erratum_unit)
-            if pkglists_to_publish:
-                self.context.add_unit_metadata(erratum_unit, pkglists_to_publish)
+            pkglist_to_publish = self._get_pkglist_to_publish(erratum_unit)
+            if pkglist_to_publish.get('packages'):
+                # only publish this errata if it references packages in the repo being published
+                self.context.add_unit_metadata(erratum_unit, pkglist_to_publish)
 
     def finalize(self):
         """
@@ -633,57 +625,81 @@ class PublishErrataStep(platform_steps.UnitModelPluginStep):
                 add_metadata_file_metadata('updateinfo', self.context.metadata_file_path,
                                            self.context.checksum)
 
-    def _get_pkglists_to_publish(self, erratum_unit):
+    def _get_repo_unit_nevra(self, repo_id):
+        """
+        Return a set of NEVRA tuples for units in a single repo referenced by the given errata.
+
+        Pulp errata units combine the known packages from all synced repos. Given an errata unit
+        and a repo, return a set of NEVRA tuples that can be used to filter out packages not
+        linked to that repo when generating a repo's updateinfo XML file.
+
+        :param repo_id: Repository ID for which to return the set of nevra
+        :type repo_id: str
+
+        :return: a set of NEVRA dicts for units in a single repo referenced by the given errata
+        :rtype: set of pulp_rpm.plugins.models.NEVRA tuples
+        """
+        repo_unit_nevra = set()
+        querysets = repo_controller.get_unit_model_querysets(repo_id, models.RPM)
+        nevra_scalars = itertools.chain(*[q.scalar(*models.NEVRA._fields) for q in querysets])
+        for scalar in nevra_scalars:
+            repo_unit_nevra.add(models.NEVRA(*scalar))
+        return repo_unit_nevra
+
+    def _get_pkglist_to_publish(self, erratum_unit):
         """
         Make a list of packages which will be listed in the published erratum.
 
-        It is possible to filter packages only if `repo_unit_nevra` is available,
-        otherwise publish everything except duplicated collections.
+        Only packages contained in the repository being published will be included in this
+        errata's pkglist.
+
+        This merges multiple Pulp pkglists into a single pkglist for publication.
 
         :param erratum_unit: the erratum unit to analyze
         :param type: pulp_rpm.plugins.db.models.Errata
-        :return: list of pkglists to publish
-        :rtype: list of dicts
+        :return: pkglist to publish
+        :rtype: dict
         """
-        pkglists_to_publish = []
+        repo_id = self.get_repo().id
+        repo_unit_nevra = self._get_repo_unit_nevra(repo_id)
 
-        # If we can pull a repo_id off the conduit, use that to generate repo-specific nevra
-        if self.context.conduit and hasattr(self.context.conduit, 'repo_id'):
-            repo_unit_nevra = self.context.get_repo_unit_nevra(erratum_unit)
-        else:
-            repo_unit_nevra = None
+        new_pkglist = {
+            # Due to a quirk in how yum merges pkglists in errata that appear in multiple
+            # repos, the pkglist collection name needs to be unique per-repo when published.
+            # repo_id is already unique and presumably validated, so use that. This is normally a
+            # human-readable string, like "A Human-Readable Repository Description". Pulp doesn't
+            # require storing that sort of string with a repo, so repo_id is the best we've got.
+            'name': repo_id,
 
-        seen_pkglists = set()
+            # The repo "short name", like 'repo-name-short'. It also makes sense to use repo_id
+            # here. This appears to be unused by yum when parsing errata, but consistency with the
+            # "long" name field should help in the event that some consumer does use this field.
+            'short': repo_id,
+
+            # Related to the need for a unique collection name, errata should only contain one
+            # pkglist. While filtering packages to include in this errata, add them to this single
+            # list of packages. pkglists can contain multiple collections of packages, but limiting
+            # the published errata to one collection per pkglist and one pkglist per errata per
+            # repository makes the collection name uniqueness requirement easy to fulfill using
+            # the repo_id only.
+            'packages': [],
+
+        }
+
+        if not repo_unit_nevra:
+            # if repo_unit_nevra is empty, this repo has no RPMs, which makes filtering easy:
+            # no pkglist will ever contain packages, so short out and return the empty pkglist
+            return new_pkglist
+
+        seen_packages = set()
         for pkglist in erratum_unit.pkglist:
-            packages = tuple(sorted(p['filename'] for p in pkglist['packages']))
-            if packages in seen_pkglists:
-                continue
-            seen_pkglists.add(packages)
+            for package in pkglist.get('packages', []):
+                if package['filename'] not in seen_packages:
+                    seen_packages.add(package['filename'])
+                    if models.NEVRA._fromdict(package) in repo_unit_nevra:
+                        new_pkglist['packages'].append(package)
 
-            if repo_unit_nevra is None:
-                pkglists_to_publish.append(pkglist)
-                continue
-
-            packages_to_publish = []
-            for package in pkglist['packages']:
-                package_nevra = {'name': package['name'],
-                                 'version': package['version'],
-                                 'release': package['release'],
-                                 'epoch': package['epoch'] or '0',
-                                 'arch': package['arch']}
-
-                if package_nevra not in repo_unit_nevra:
-                    # current package not in the specified repo, don't add it to the pkglist
-                    continue
-
-                packages_to_publish.append(package)
-
-            if packages_to_publish:
-                new_pkglist = dict((key, val) for key, val in pkglist.items() if key != 'packages')
-                new_pkglist['packages'] = packages_to_publish
-                pkglists_to_publish.append(new_pkglist)
-
-        return pkglists_to_publish
+        return new_pkglist
 
 
 class PublishRpmAndDrpmStepIncremental(platform_steps.UnitModelPluginStep):

--- a/plugins/test/unit/plugins/db/test_models.py
+++ b/plugins/test/unit/plugins/db/test_models.py
@@ -30,6 +30,46 @@ class TestNonMetadataModel(unittest.TestCase):
         models.NonMetadataPackage(version='1.0.0', release='2', checksumtype=None, checksum=None)
 
 
+class TestNEVRATuple(unittest.TestCase):
+    """Test that the NEVRA namedtuple properly converts to and from dictionaries"""
+    pkg_dict_noepoch = {
+        'name': 'package',
+        'version': '0.0',
+        'release': '0',
+        'arch': 'pulp',
+    }
+
+    # a tuple with correct values in the expected order
+    expected = (
+        pkg_dict_noepoch['name'],
+        '0',
+        pkg_dict_noepoch['version'],
+        pkg_dict_noepoch['release'],
+        pkg_dict_noepoch['arch'],
+    )
+
+    def _pkg_dict(self, epoch):
+        # package dict builder, DRYs inserting different values for the epoch field
+        pkg_dict = self.pkg_dict_noepoch.copy()
+        pkg_dict['epoch'] = epoch
+        return pkg_dict
+
+    def test_dict_conversion(self):
+        """ensure the correct field names are mapped to the correct values"""
+        pkg_dict = self._pkg_dict(epoch='0')
+        pkg_nevra = models.NEVRA._fromdict(pkg_dict)
+        self.assertEqual(pkg_nevra, self.expected)
+        self.assertEqual(pkg_nevra._asdict(), pkg_dict)
+
+    def test_dict_conversion_falsey_epoch(self):
+        """ensure the special handling for a "falsey" epoch (usually None) functions properly"""
+        # epoch should become string '0' in this case
+        for falsey in (0, None, False, ''):
+            pkg_dict = self._pkg_dict(epoch=falsey)
+            pkg_nevra = models.NEVRA._fromdict(pkg_dict)
+            self.assertEqual(pkg_nevra, self.expected)
+
+
 class TestNonMetadataGetOrCalculateChecksum(unittest.TestCase):
     def setUp(self):
         super(TestNonMetadataGetOrCalculateChecksum, self).setUp()

--- a/plugins/test/unit/plugins/distributors/yum/test_publish.py
+++ b/plugins/test/unit/plugins/distributors/yum/test_publish.py
@@ -24,7 +24,7 @@ from pulp_rpm.common.ids import (
     TYPE_ID_PKG_GROUP, TYPE_ID_PKG_CATEGORY, TYPE_ID_DISTRO, TYPE_ID_DRPM, TYPE_ID_RPM,
     TYPE_ID_YUM_REPO_METADATA_FILE, YUM_DISTRIBUTOR_ID, EXPORT_DISTRIBUTOR_ID)
 from pulp_rpm.devel.skip import skip_broken
-from pulp_rpm.plugins.db.models import Errata
+from pulp_rpm.plugins.db.models import Errata, NEVRA
 from pulp_rpm.plugins.distributors.yum import configuration, publish
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), '../../../../data/')
@@ -1052,25 +1052,17 @@ class PublishRpmStepTests(BaseYumDistributorPublishStepTests):
 class PublishErrataStepTests(BaseYumDistributorPublishStepTests):
 
     @mock.patch('pulp_rpm.plugins.distributors.yum.publish.UpdateinfoXMLFileContext')
-    @mock.patch('pulp_rpm.plugins.distributors.yum.publish.models')
-    @mock.patch('pulp_rpm.plugins.distributors.yum.publish.repo_controller')
-    def test_initialize_metadata(self, mock_repo_controller, mock_models, mock_context):
+    def test_initialize_metadata(self, mock_context):
         self._init_publisher()
         step = publish.PublishErrataStep()
         step.parent = self.publisher
-        mock_queryset = mock.Mock()
-        mock_repo_controller.get_unit_model_querysets.return_value = [mock_queryset]
-        mock_queryset.scalar.return_value = [('n1', 'e1', 'v1', 'r1', 'a1')]
 
         step.initialize()
+
         mock_context.return_value.initialize.assert_called_once_with()
-        repo_id = step.get_repo().id
-        mock_repo_controller.get_unit_model_querysets.assert_called_once_with(repo_id,
-                                                                              mock_models.RPM)
-        mock_queryset.scalar.assert_called_once_with('name', 'epoch', 'version', 'release', 'arch')
 
     @mock.patch('pulp_rpm.plugins.distributors.yum.publish.UpdateinfoXMLFileContext')
-    @mock.patch.object(publish.PublishErrataStep, '_get_pkglists_to_publish')
+    @mock.patch.object(publish.PublishErrataStep, '_get_pkglist_to_publish')
     def test_process_main(self, mock_get_pkglist, mock_context):
         """
         Test that the erratum is published if pkglist is not empty.
@@ -1078,8 +1070,8 @@ class PublishErrataStepTests(BaseYumDistributorPublishStepTests):
         self._init_publisher()
         step = publish.PublishErrataStep()
         erratum_unit = Errata(errata_id='some_id')
-        pkglist = [{'name': 'collection name',
-                    'packages': ['p1', 'p2']}]
+        pkglist = {'name': 'collection name',
+                   'packages': ['p1', 'p2']}
         mock_get_pkglist.return_value = pkglist
         step.context = mock_context()
 
@@ -1089,7 +1081,7 @@ class PublishErrataStepTests(BaseYumDistributorPublishStepTests):
         step.context.add_unit_metadata.assert_called_once_with(erratum_unit, pkglist)
 
     @mock.patch('pulp_rpm.plugins.distributors.yum.publish.UpdateinfoXMLFileContext')
-    @mock.patch.object(publish.PublishErrataStep, '_get_pkglists_to_publish')
+    @mock.patch.object(publish.PublishErrataStep, '_get_pkglist_to_publish')
     def test_process_main_no_pkglist(self, mock_get_pkglist, mock_context):
         """
         Test that the erratum is not published if pkglist is empty.
@@ -1097,7 +1089,7 @@ class PublishErrataStepTests(BaseYumDistributorPublishStepTests):
         self._init_publisher()
         step = publish.PublishErrataStep()
         erratum_unit = Errata(errata_id='some_id')
-        pkglist = []
+        pkglist = {}
         mock_get_pkglist.return_value = pkglist
         step.context = mock_context()
 
@@ -1126,14 +1118,28 @@ class PublishErrataStepTests(BaseYumDistributorPublishStepTests):
         step.parent = self.publisher
         step.finalize()
 
-    @mock.patch('pulp_rpm.plugins.distributors.yum.publish.UpdateinfoXMLFileContext')
-    def test__get_pkglists_to_publish(self, mock_context):
+    @mock.patch('pulp_rpm.plugins.distributors.yum.publish.repo_controller')
+    def test__get_repo_unit_nevra(self, mock_repo_controller):
+        """Test that a set of NEVRA in a repo is correctly generated from a repo queryset"""
+        repo_id = 'test_repo'
+        step = publish.PublishErrataStep(repo=Repository(id=repo_id))
+        mock_scalar_1 = ('n1', 'e1', 'v1', 'r1', 'a1')
+        mock_scalar_2 = ('n2', 'e2', 'v2', 'r2', 'a2')
+        mock_queryset = mock.Mock()
+        mock_queryset.scalar.return_value = [mock_scalar_1, mock_scalar_2]
+        mock_repo_controller.get_unit_model_querysets.return_value = [mock_queryset]
+
+        repo_unit_nevra = step._get_repo_unit_nevra(repo_id)
+        expected = set([NEVRA(*values) for values in (mock_scalar_1, mock_scalar_2)])
+        self.assertEqual(repo_unit_nevra, expected)
+
+    @mock.patch.object(publish.PublishErrataStep, '_get_repo_unit_nevra')
+    def test__get_pkglist_to_publish(self, mock_grun):
         """
         Test that packages not presented in repo are filtered out
         """
         self._init_publisher()
-        step = publish.PublishErrataStep()
-        step.context = mock_context
+        step = publish.PublishErrataStep(repo=Repository(id='test_repo'))
         erratum_unit = Errata(errata_id='some_id')
 
         pkg_fields = ('name', 'epoch', 'version', 'release', 'arch', 'filename')
@@ -1145,25 +1151,27 @@ class PublishErrataStepTests(BaseYumDistributorPublishStepTests):
 
         repo_package = pkg1.copy()
         del(repo_package['filename'])
-        mock_context.get_repo_unit_nevra.return_value = [repo_package]
+        mock_grun.return_value = [NEVRA._fromdict(pkg1)]
 
-        pkglists_to_publish = step._get_pkglists_to_publish(erratum_unit)
+        pkglist_to_publish = step._get_pkglist_to_publish(erratum_unit)
 
         # still one pkglist
-        self.assertTrue(len(pkglists_to_publish), 1)
+        self.assertTrue(len(pkglist_to_publish), 1)
 
         # pkglist contains only one package, the second one was filtered out
-        self.assertTrue(len(pkglists_to_publish[0]['packages']), 1)
-        self.assertEqual(pkglists_to_publish[0]['packages'][0], pkg1)
+        self.assertTrue(len(pkglist_to_publish['packages']), 1)
+        self.assertEqual(pkglist_to_publish['packages'][0], pkg1)
+        self.assertEqual(pkglist_to_publish['name'], 'test_repo')
+        mock_grun.assert_called_once_with('test_repo')
 
-    @mock.patch('pulp_rpm.plugins.distributors.yum.publish.UpdateinfoXMLFileContext')
-    def test__get_pkglists_to_publish_duplicated(self, mock_context):
+    @mock.patch.object(publish.PublishErrataStep, 'get_repo')
+    @mock.patch.object(publish.PublishErrataStep, '_get_repo_unit_nevra')
+    def test__get_pkglist_to_publish_duplicated(self, mock_grun, mock_get_repo):
         """
         Test that duplicated pkglists are filtered out
         """
         self._init_publisher()
         step = publish.PublishErrataStep()
-        step.context = mock_context
         erratum_unit = Errata(errata_id='some_id')
 
         pkg_fields = ('name', 'epoch', 'version', 'release', 'arch', 'filename')
@@ -1174,16 +1182,47 @@ class PublishErrataStepTests(BaseYumDistributorPublishStepTests):
 
         repo_package = pkg1.copy()
         del(repo_package['filename'])
-        mock_context.get_repo_unit_nevra.return_value = [repo_package]
+        mock_grun.return_value = [NEVRA._fromdict(pkg1)]
 
-        pkglists_to_publish = step._get_pkglists_to_publish(erratum_unit)
+        pkglist_to_publish = step._get_pkglist_to_publish(erratum_unit)
 
         # only one pkglist
-        self.assertTrue(len(pkglists_to_publish), 1)
+        self.assertTrue(len(pkglist_to_publish), 1)
 
         # pkglist contains one expected package
-        self.assertTrue(len(pkglists_to_publish[0]['packages']), 1)
-        self.assertEqual(pkglists_to_publish[0]['packages'][0], pkg1)
+        self.assertTrue(len(pkglist_to_publish['packages']), 1)
+        self.assertEqual(pkglist_to_publish['packages'][0], pkg1)
+        mock_grun.assert_called_once_with(mock_get_repo().id)
+
+    @mock.patch.object(publish.PublishErrataStep, '_get_repo_unit_nevra')
+    def test__get_pkglist_to_publish_merge(self, mock_grun):
+        """
+        Test that multiple pkglists are merged into one
+        """
+        self._init_publisher()
+        step = publish.PublishErrataStep(repo=Repository(id='test_repo'))
+        erratum_unit = Errata(errata_id='some_id')
+
+        pkg_fields = ('name', 'epoch', 'version', 'release', 'arch', 'filename')
+        pkg1_values = ('n1', 'e1', 'v1', 'r1', 'a1', 'f1')
+        pkg1 = dict(zip(pkg_fields, pkg1_values))
+        pkg2_values = ('n2', 'e2', 'v2', 'r2', 'a2', 'f2')
+        pkg2 = dict(zip(pkg_fields, pkg2_values))
+        erratum_unit.pkglist = [{'packages': [pkg1]}, {'packages': [pkg2]}]
+
+        mock_grun.return_value = [NEVRA._fromdict(pkg1), NEVRA._fromdict(pkg2)]
+
+        pkglist_to_publish = step._get_pkglist_to_publish(erratum_unit)
+
+        # one pkglist published
+        self.assertTrue(len(pkglist_to_publish), 1)
+
+        # pkglist contains both packages, since they were included in repo_unit_nevra
+        self.assertTrue(len(pkglist_to_publish['packages']), 2)
+        self.assertTrue(pkg1 in pkglist_to_publish['packages'])
+        self.assertTrue(pkg2 in pkglist_to_publish['packages'])
+        self.assertEqual(pkglist_to_publish['name'], 'test_repo')
+        mock_grun.assert_called_once_with('test_repo')
 
 
 class PublishMetadataStepTests(BaseYumDistributorPublishStepTests):


### PR DESCRIPTION
Published errata collection names are unique per-repo

This ended up being a pain because of how much filtering work we were
doing in the updateinfo XML context. I was able to make it work as-is,
and just about had a PR up, but then Tanya posted this PR: 

https://github.com/pulp/pulp_rpm/pull/1024

That PR opened up a possibility that I hasn't seriously considered,
which was to move the unit/repo filtering logic out of the XML 
generation context. Now, the UpdatinfoXMLFileContext writes *whatever
you tell it to write* in the add_unit_metadata step, and the filtering
takes place in calling Publish steps. Since the PublishErrataStep
knows what repo it's publishing (er, "distributing"), all of the 
business of trying to pull a repo_id off the conduit can go away.

Buried deep in all of this is the single line that actually fixes the 
bug, which is to set errata pkglist names to repo_id when publishing, as
well as related tests to make sure that happens.

If desired, I can break out refactor from the collection name bugfix,
and even open up a refactor issue in redmine going into more detail
about why just making the change right in UpdateinfoXMLFileContext was 
not the right solution.

tl;dr we painted ourselves into a corner, Tanya gave us a way out, and I
took it. :)

closes #2560
https://pulp.plan.io/issues/2560

Edit: Thinking about it more, I'm definitely going to split this into multiple commits, splitting out the refactor from the bugfix, in the event we have to revert one or the other.