### PR TITLE
Allow ISOs to be re-uploaded

### DIFF
--- a/plugins/pulp_rpm/plugins/importers/iso/importer.py
+++ b/plugins/pulp_rpm/plugins/importers/iso/importer.py
@@ -1,5 +1,3 @@
-from gettext import gettext as _
-
 from mongoengine import NotUniqueError
 
 from pulp.common import config as config_utils
@@ -129,10 +127,14 @@ class ISOImporter(Importer):
         :param config: plugin configuration for the repository
         :type  config: pulp.plugins.config.PluginCallConfiguration
         """
-        if models.ISO.objects.filter(**unit_key).count() > 0:
-            return {'success_flag': False, 'summary': _('ISO already exists'), 'details': None}
+        qs = models.ISO.objects.filter(**unit_key)
+        if qs:
+            # iso with this key already exists, use it
+            iso = qs.first()
+        else:
+            # this is a new ISO, create it
+            iso = models.ISO(**unit_key)
 
-        iso = models.ISO(**unit_key)
         validate = config.get_boolean(importer_constants.KEY_VALIDATE)
         validate = validate if validate is not None else constants.CONFIG_VALIDATE_DEFAULT
         try:


### PR DESCRIPTION
This addresses a regression introduced in 2.8.0. Prior to this release
of Pulp, uploading an ISO that Pulp already had stored would use the
existing ISO in the upload step and succeed. This change restores the
prior behavior, removing this regression.

https://pulp.plan.io/issues/2274
closes #2274