### PR TITLE
Add provides for python2-* packages

### DIFF
--- a/pulp-rpm.spec
+++ b/pulp-rpm.spec
@@ -131,6 +131,7 @@ rm -rf %{buildroot}
 %package -n python-pulp-rpm-common
 Summary: Pulp RPM support common library
 Group: Development/Languages
+Provides: python2-pulp-rpm-common
 Requires: python-pulp-common = %{pulp_version}
 Obsoletes: python-pulp-rpm-extension <= 2.4.0
 


### PR DESCRIPTION
Add provides for python2-* packages.  Fedora downstream packages are
named python2-* and provide python-*.  Upstream needs to mirror this for
dependency resolution to work properly

re #2687