### PR TITLE
Ensure path in catalog entry matches storage path for existing units.

### DIFF
--- a/plugins/pulp_rpm/plugins/importers/iso/sync.py
+++ b/plugins/pulp_rpm/plugins/importers/iso/sync.py
@@ -183,7 +183,8 @@ class ISOSyncRun(listener.DownloadEventListener):
             # Unit is from pulp manifest
             if not hasattr(unit, "url"):
                 continue
-            unit.set_storage_path(unit.name)
+            if not unit.storage_path:
+                unit.set_storage_path(unit.name)
             entry = LazyCatalogEntry()
             entry.path = unit.storage_path
             entry.importer_id = str(self.sync_conduit.importer_object_id)

--- a/plugins/pulp_rpm/plugins/importers/yum/sync.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/sync.py
@@ -1113,7 +1113,8 @@ class PackageCatalog(object):
 #           used to construct the download URL.
         :type path: str
         """
-        unit.set_storage_path(unit.filename)
+        if not unit.storage_path:
+            unit.set_storage_path(unit.filename)
         entry = LazyCatalogEntry()
         entry.path = unit.storage_path
         entry.importer_id = str(self.importer_id)


### PR DESCRIPTION
https://pulp.plan.io/issues/2704

A better fix would be to call `set_storage_path()` when _new_ models are instantiated.  Since models are created in multiple places, I don't want to take the chance of missing something and causing a regression.  This fix less than ideal but lower risk. 