### PR TITLE
Calling method to remove old isos by name before associating them

### DIFF
--- a/plugins/pulp_rpm/plugins/importers/iso/sync.py
+++ b/plugins/pulp_rpm/plugins/importers/iso/sync.py
@@ -224,8 +224,8 @@ class ISOSyncRun(listener.DownloadEventListener):
 
         # Associate units that are already in Pulp
         if local_available_isos:
-            search_dicts = [unit.unit_key for unit in local_available_isos]
-            self.sync_conduit.associate_existing(models.ISO._content_type_id.default, search_dicts)
+            for iso in local_available_isos:
+                self._associate_unit(self.sync_conduit.repo, iso)
 
         # Deferred downloading (Lazy) entries.
         self.add_catalog_entries(local_available_isos)


### PR DESCRIPTION
Forgot to update the code in #2773 when associating existing content with an iso repo. This fixes that.

fixes #3047
https://pulp.plan.io/issues/3047