### PR TITLE
Raise coded exception for invalid package header.

### DIFF
--- a/plugins/pulp_rpm/plugins/error_codes.py
+++ b/plugins/pulp_rpm/plugins/error_codes.py
@@ -36,3 +36,5 @@ RPM1014 = Error("RPM1014", _('Invalid signature key ID "%(key)s" found for Packa
                              'Allowed Signatures keys "%(allowed)s".'),
                 ['key', 'package', 'allowed'])
 RPM1015 = Error("RPM1015", _("Malformed repository: %(reason)s"), ['reason'])
+
+RPM1016 = Error("RPM1016", _('Error reading uploaded package header.'), [])

--- a/plugins/pulp_rpm/plugins/importers/yum/upload.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/upload.py
@@ -134,9 +134,9 @@ def upload(repo, type_id, unit_key, metadata, file_path, conduit, config):
         msg = 'RPM only DRPMs are not supported'
         _LOGGER.warning(msg)
         return _fail_report(msg)
-    except PulpCodedException, e:
-        _LOGGER.exception(e)
-        return _fail_report(str(e))
+    except PulpCodedException:
+        # propagate coded exceptions.
+        raise
     except Exception as e:
         msg = 'unexpected error occurred importing uploaded file: %s' % e
         _LOGGER.exception(msg)
@@ -380,9 +380,8 @@ def _handle_package(repo, type_id, unit_key, metadata, file_path, conduit, confi
             package_xml = (utils.fake_xml_element(repodata['primary'], constants.COMMON_NAMESPACE)
                                 .find(primary.PACKAGE_TAG))
             unit = primary.process_package_element(package_xml)
-    except:
-        _LOGGER.exception('Error extracting RPM metadata for [%s]' % file_path)
-        raise
+    except Exception:
+        raise PulpCodedException(error_codes.RPM1016)
 
     # metadata can be None
     metadata = metadata or {}


### PR DESCRIPTION
Raise coded exception.  Removed the logging here because exceptions are caught and logged in `upload()`.

https://pulp.plan.io/issues/3090

Requires: https://github.com/pulp/pulp/pull/3212