### PR TITLE
Advise users on using setsebool to set pulp_manage_rsync selinux boolean

### DIFF
--- a/docs/tech-reference/iso-rsync-distributor.rst
+++ b/docs/tech-reference/iso-rsync-distributor.rst
@@ -14,7 +14,7 @@ Pulp's SELinux policy includes a ``pulp_manage_rsync`` boolean. When enabled, th
 disabled by default. The ISO Rsync distributor will fail to publish with SELinux Enforcing unless
 the boolean is enabled. To enable it, you can do this::
 
-    $ sudo semanage boolean --modify --on pulp_manage_rsync
+    $ sudo setsebool -P pulp_manage_rsync on
 
 Here is an example iso_rsync_distributor configuration::
 

--- a/docs/tech-reference/rsync-distributor.rst
+++ b/docs/tech-reference/rsync-distributor.rst
@@ -14,7 +14,7 @@ Pulp's SELinux policy includes a ``pulp_manage_rsync`` boolean. When enabled, th
 disabled by default. The RPM Rsync distributor will fail to publish with SELinux Enforcing unless
 the boolean is enabled. To enable it, you can do this::
 
-    $ sudo semanage boolean --modify --on pulp_manage_rsync
+    $ sudo setsebool -P pulp_manage_rsync on
 
 Here's an example of rpm_rsync_distributor configuration::
 


### PR DESCRIPTION
F27+ changed the behavior of semanage to set a selinux boolean by
default, but not change its current state. Update docs to advise users
of this to avoid confusion when rsync distributors fail to run with
selinux in F27.

closes #3347
https://pulp.plan.io/issues/3347