### PR TITLE
Add support for suse errata

### DIFF
--- a/common/pulp_rpm/common/ids.py
+++ b/common/pulp_rpm/common/ids.py
@@ -27,7 +27,8 @@ UNIT_KEY_ERRATA = ("id",)
 METADATA_ERRATA = (
     "title", "description", "version", "release", "type", "status", "updated",
     "issued", "severity", "references", "pkglist", "rights", "summary",
-    "solution", "from_str", "pushcount", "reboot_suggested")
+    "solution", "from_str", "pushcount", "reboot_suggested", "relogin_suggested",
+    "restart_suggested")
 
 TYPE_ID_PKG_GROUP = 'package_group'
 TYPE_ID_PKG_CATEGORY = 'package_category'
@@ -63,4 +64,4 @@ METADATA_DRPM = ("size", "sequence", "new_package", "relativepath")
 TYPE_ID_YUM_REPO_METADATA_FILE = 'yum_repo_metadata_file'
 
 # These types don't have support for the query-param auth token yet
-QUERY_AUTH_TOKEN_UNSUPPORTED = (TYPE_ID_ISO, TYPE_ID_ERRATA, TYPE_ID_DISTRO)
+QUERY_AUTH_TOKEN_UNSUPPORTED = (TYPE_ID_ISO, TYPE_ID_DISTRO)

--- a/docs/tech-reference/yum-plugins.rst
+++ b/docs/tech-reference/yum-plugins.rst
@@ -225,6 +225,14 @@ Metadata
 ``reboot_suggested``
  Flag indicating if this erratum is installed it will require a reboot of the system
 
+``relogin_suggested``
+ Flag indicating if this erratum is installed it will require a relogin of the system -
+ this flag exists only on SUSE erratum
+
+``restart_suggested``
+ Flag indicating if this erratum is installed it will require a restart of the system -
+ this flag exists only on SUSE erratum
+
 Distribution
 ------------
 
@@ -474,8 +482,8 @@ configuration values are optional.
 ``query_auth_token``
  An authorization token that will be added to every request made to the feed URL's
  server, which may be required to sync from repositories that use this method of
- authorization (SLES 12, for example). This mechanism only supports syncing RPM
- and deltarpm content.
+ authorization (SLES 12, for example). This mechanism only supports syncing RPM, deltarpm,
+ and errata content.
 
 ``max_speed``
  The maximum download speed in bytes/sec for a task (such as a sync);

--- a/docs/user-guide/release-notes/2.16.x.rst
+++ b/docs/user-guide/release-notes/2.16.x.rst
@@ -10,3 +10,8 @@ New Features
 
 * A new pulp-manifest tool that can be used to create PULP_MANIFEST for a
   directory that the user plans to use the iso importer with.
+
+* Add support for SUSE Errata format. This includes the addition of two new
+  fields on the Erratum model: `relogin_suggested` and `restart_suggested`.
+  Errata update logic has been modified so that if two Errata has the same `updated`
+  timestamp we also check to see if the `version` field has been updated.

--- a/extensions_admin/pulp_rpm/extensions/admin/upload/errata.py
+++ b/extensions_admin/pulp_rpm/extensions/admin/upload/errata.py
@@ -57,6 +57,12 @@ OPT_PUSHCOUNT = PulpCliOption('--pushcount', d, required=False, default=1)
 d = _('if specified, the erratum will be marked as \'reboot-suggested\'')
 OPT_REBOOT = PulpCliFlag('--reboot-suggested', d)
 
+d = _('if specified, the erratum will be marked as \'restart-suggested\'')
+OPT_RESTART = PulpCliFlag('--restart-suggested', d)
+
+d = _('if specified, the erratum will be marked as \'relogin-suggested\'')
+OPT_RELOGIN = PulpCliFlag('--relogin-suggested', d)
+
 d = _('severity of the erratum')
 OPT_SEVERITY = PulpCliOption('--severity', d, required=False)
 
@@ -94,6 +100,8 @@ class CreateErratumCommand(UploadCommand):
         self.add_option(OPT_FROM)
         self.add_option(OPT_PUSHCOUNT)
         self.add_option(OPT_REBOOT)
+        self.add_option(OPT_RESTART)
+        self.add_option(OPT_RELOGIN)
         self.add_option(OPT_SEVERITY)
         self.add_option(OPT_RIGHTS)
         self.add_option(OPT_SUMMARY)
@@ -122,6 +130,8 @@ class CreateErratumCommand(UploadCommand):
         solution = kwargs[OPT_SOLUTION.keyword]
         from_str = kwargs[OPT_FROM.keyword]
         reboot_suggested = kwargs[OPT_REBOOT.keyword]
+        restart_suggested = kwargs[OPT_RESTART.keyword]
+        relogin_suggested = kwargs[OPT_RELOGIN.keyword]
 
         references = []
         try:
@@ -160,6 +170,8 @@ class CreateErratumCommand(UploadCommand):
             'from': from_str,
             'pushcount': pushcount_str,
             'reboot_suggested': reboot_suggested,
+            'restart_suggested': restart_suggested,
+            'relogin_suggested': relogin_suggested,
         }
 
         return metadata

--- a/extensions_admin/test/unit/extensions/admin/upload/test_errata.py
+++ b/extensions_admin/test/unit/extensions/admin/upload/test_errata.py
@@ -30,7 +30,8 @@ class CreateRpmCommandTests(PulpClientTests):
                                 errata.OPT_VERSION, errata.OPT_RELEASE, errata.OPT_TYPE,
                                 errata.OPT_STATUS, errata.OPT_UPDATED, errata.OPT_ISSUED,
                                 errata.OPT_REFERENCE, errata.OPT_PKG_LIST, errata.OPT_FROM,
-                                errata.OPT_PUSHCOUNT, errata.OPT_REBOOT, errata.OPT_SEVERITY,
+                                errata.OPT_PUSHCOUNT, errata.OPT_REBOOT, errata.OPT_RESTART,
+                                errata.OPT_RELOGIN, errata.OPT_SEVERITY,
                                 errata.OPT_RIGHTS, errata.OPT_SUMMARY, errata.OPT_SOLUTION,
                                 FLAG_VERBOSE, OPTION_REPO_ID, FLAG_BACKGROUND])
         found_options = set(self.command.options)
@@ -68,6 +69,8 @@ class CreateRpmCommandTests(PulpClientTests):
             errata.OPT_SOLUTION.keyword: 'test-solution',
             errata.OPT_FROM.keyword: 'test-from',
             errata.OPT_REBOOT.keyword: 'test-reboot',
+            errata.OPT_RESTART.keyword: 'test-restart',
+            errata.OPT_RELOGIN.keyword: 'test-relogin',
             errata.OPT_PUSHCOUNT.keyword: '1',
         }
 
@@ -93,6 +96,8 @@ class CreateRpmCommandTests(PulpClientTests):
             'from': 'test-from',
             'pushcount': '1',
             'reboot_suggested': 'test-reboot',
+            'restart_suggested': 'test-restart',
+            'relogin_suggested': 'test-relogin',
             'pkglist': expected_package_list,
             'references': expected_reference_list,
         }
@@ -122,6 +127,8 @@ class CreateRpmCommandTests(PulpClientTests):
             errata.OPT_SOLUTION.keyword: 'test-solution',
             errata.OPT_FROM.keyword: 'test-from',
             errata.OPT_REBOOT.keyword: 'test-reboot',
+            errata.OPT_RESTART.keyword: 'test-restart',
+            errata.OPT_RELOGIN.keyword: 'test-relogin',
             errata.OPT_PUSHCOUNT.keyword: '1',
         }
 
@@ -152,6 +159,8 @@ class CreateRpmCommandTests(PulpClientTests):
             errata.OPT_SOLUTION.keyword: 'test-solution',
             errata.OPT_FROM.keyword: 'test-from',
             errata.OPT_REBOOT.keyword: 'test-reboot',
+            errata.OPT_RESTART.keyword: 'test-restart',
+            errata.OPT_RELOGIN.keyword: 'test-relogin',
             errata.OPT_PUSHCOUNT.keyword: '1',
         }
 

--- a/plugins/pulp_rpm/plugins/distributors/yum/metadata/updateinfo.py
+++ b/plugins/pulp_rpm/plugins/distributors/yum/metadata/updateinfo.py
@@ -173,6 +173,13 @@ class UpdateinfoXMLFileContext(FastForwardXmlFileContext):
 
             if package.get('reboot_suggested'):
                 self.xml_generator.completeElement('reboot_suggested', {}, 'True')
+            if package.get('relogin_suggested'):
+                self.xml_generator.completeElement('relogin_suggested', {},
+                                                   package['relogin_suggested'])
+            if package.get('restart_suggested'):
+                self.xml_generator.completeElement('restart_suggested', {},
+                                                   package['restart_suggested'])
+
             self.xml_generator.endElement('package')
 
         self.xml_generator.endElement('collection')

--- a/plugins/pulp_rpm/plugins/importers/yum/repomd/updateinfo.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/repomd/updateinfo.py
@@ -43,6 +43,8 @@ def process_package_element(element):
         # any collection has an element present with tag 'reboot_suggested'.
         # Note that yum, as of 3.4.3, does not check the contents of that element.
         'reboot_suggested': False,
+        'relogin_suggested': False,
+        'restart_suggested': False,
         'references': map(_parse_reference, element.find('references') or []),
         'release': '',
         'rights': '',
@@ -68,6 +70,11 @@ def process_package_element(element):
         child = element.find(attr_name)
         if child is not None:
             package_info[attr_name] = child.text
+
+    for bool_attr in ('relogin_suggested', 'restart_suggested'):
+        child = element.find(bool_attr)
+        if child is not None:
+            package_info[bool_attr] = child.text.lower() in ['true', '1']
 
     issued_element = element.find('issued')
     if issued_element is not None:
@@ -133,5 +140,13 @@ def _parse_package(element):
     reboot_suggested = element.find('reboot_suggested')
     if reboot_suggested is not None:
         ret['reboot_suggested'] = reboot_suggested.text
+
+    restart_suggested = element.find('restart_suggested')
+    if restart_suggested is not None:
+        ret['restart_suggested'] = restart_suggested.text
+
+    relogin_suggested = element.find('relogin_suggested')
+    if relogin_suggested is not None:
+        ret['relogin_suggested'] = relogin_suggested.text
 
     return ret

--- a/plugins/pulp_rpm/plugins/migrations/0042_add_suse_fields_to_errata.py
+++ b/plugins/pulp_rpm/plugins/migrations/0042_add_suse_fields_to_errata.py
@@ -1,0 +1,25 @@
+import logging
+
+from pulp.server.db.connection import get_collection
+from pulp.server.db.migrations.lib import utils
+
+
+_logger = logging.getLogger('pulp_rpm.plugins.migrations.0042')
+
+
+def migrate(*args, **kwargs):
+
+    erratum_collection = get_collection('units_erratum')
+    fields_to_add = ['relogin_suggested', 'restart_suggested']
+    for field in fields_to_add:
+        total_erratum_units = erratum_collection.count(
+            {field: {'$exists': False}})
+
+        with utils.MigrationProgressLog(field + ' field on Erratum',
+                                        total_erratum_units) as migration_log:
+            for errata in erratum_collection.find(
+                    {field: {'$exists': False}},
+                    ['errata_id']).batch_size(100):
+                erratum_collection.update({'_id': errata['_id']},
+                                          {'$set': {field: ''}})
+                migration_log.progress()

--- a/plugins/pulp_rpm/yum_plugin/util.py
+++ b/plugins/pulp_rpm/yum_plugin/util.py
@@ -186,3 +186,26 @@ def errata_format_to_datetime(datetime_str, msg):
     else:
         raise ValueError(msg)
     return datetime_obj
+
+
+def is_version_newer(new_version, old_version):
+    """
+    :param new_version
+    :type checksum_type str
+    :param old_version
+    :type checksum_type str
+    :return: true if version is a newer, false if it's not
+    :rtype bool
+
+    :raises ValueError: if a version cannot be converted to int
+    """
+    if not new_version:
+        return False
+
+    new = int(new_version)
+
+    if not old_version:
+        old = 0
+    else:
+        old = int(old_version)
+    return new > old

--- a/plugins/test/unit/plugins/db/test_models.py
+++ b/plugins/test/unit/plugins/db/test_models.py
@@ -430,7 +430,7 @@ class TestErrata(unittest.TestCase):
         existing_erratum, uploaded_erratum = models.Errata(), models.Errata()
         existing_erratum.updated = ''
         uploaded_erratum.updated = '2016-04-01 00:00:00 UTC'
-        self.assertEqual(True, existing_erratum.update_needed(uploaded_erratum))
+        self.assertTrue(existing_erratum.update_needed(uploaded_erratum))
 
     def test_update_needed_empty_date_uploaded(self):
         """
@@ -439,7 +439,43 @@ class TestErrata(unittest.TestCase):
         existing_erratum, uploaded_erratum = models.Errata(), models.Errata()
         existing_erratum.updated = '2016-01-01 00:00:00 UTC'
         uploaded_erratum.updated = ''
-        self.assertEqual(False, existing_erratum.update_needed(uploaded_erratum))
+        self.assertFalse(existing_erratum.update_needed(uploaded_erratum))
+
+    def test_update_needed_empty_date_uploaded_newer_version(self):
+        """
+        Test that an empty uploaded erratum `updated` field, but a newer version
+        returns True
+        """
+        existing_erratum, uploaded_erratum = models.Errata(), models.Errata()
+        existing_erratum.updated = '2016-01-01 00:00:00 UTC'
+        existing_erratum.version = 1
+        uploaded_erratum.updated = ''
+        uploaded_erratum.version = 2
+        self.assertTrue(existing_erratum.update_needed(uploaded_erratum))
+
+    def test_update_needed_older_erratum_newer_version(self):
+        """
+        Assert that if the older erratum is uploaded, but has a newer version
+        then the update is not needed.
+        """
+        existing_erratum, uploaded_erratum = models.Errata(), models.Errata()
+        existing_erratum.updated = '2016-01-01 00:00:00 UTC'
+        existing_erratum.version = 1
+        uploaded_erratum.updated = '2015-01-01 00:00:00 UTC'
+        uploaded_erratum.version = 2
+        self.assertFalse(existing_erratum.update_needed(uploaded_erratum))
+
+    def test_update_needed_same_updated_erratum_newer_version(self):
+        """
+        Assert that if the updated times of 2 erratum are the same
+        but one has a newer version then the update is needed.
+        """
+        existing_erratum, uploaded_erratum = models.Errata(), models.Errata()
+        existing_erratum.updated = '2016-01-01 00:00:00 UTC'
+        existing_erratum.version = 1
+        uploaded_erratum.updated = '2016-01-01 00:00:00 UTC'
+        uploaded_erratum.version = 2
+        self.assertTrue(existing_erratum.update_needed(uploaded_erratum))
 
     @mock.patch('pulp_rpm.plugins.db.models.Errata.update_needed')
     def test_merge_errata_newer_erratum(self, mock_update_needed):

--- a/plugins/test/unit/plugins/migrations/test_0042_add_suse_fields_to_errata.py
+++ b/plugins/test/unit/plugins/migrations/test_0042_add_suse_fields_to_errata.py
@@ -1,0 +1,41 @@
+import unittest
+
+from pulp.server.db.migrate.models import _import_all_the_way
+import mock
+
+migration = _import_all_the_way('pulp_rpm.plugins.migrations.0042_add_suse_'
+                                'fields_to_errata')
+
+
+class TestMigrate(unittest.TestCase):
+    """
+    Test the migrate() function.
+    """
+    def setUp(self):
+        super(TestMigrate, self).setUp()
+        self.errata_need_migration = {
+            '_id': '1'
+        }
+
+    @mock.patch.object(migration, 'get_collection')
+    def test_calls_correct_functions(self, mock_get_collection):
+        mock_get_collection.return_value.find.return_value.batch_size.return_value = [
+            self.errata_need_migration,
+        ]
+        migration.migrate()
+
+        self.assertEqual(mock_get_collection.call_count, 1)
+        mock_get_collection.return_value.update.assert_any_call(
+            {'_id': self.errata_need_migration['_id']},
+            {'$set': {'restart_suggested': ''}})
+        mock_get_collection.return_value.update.assert_any_call(
+            {'_id': self.errata_need_migration['_id']},
+            {'$set': {'relogin_suggested': ''}})
+
+    @mock.patch.object(migration, 'get_collection')
+    def test_no_migration_called(self, mock_get_collection):
+        mock_get_collection.return_value.find.return_value.batch_size.return_value = []
+        migration.migrate()
+
+        self.assertEqual(mock_get_collection.call_count, 1)
+        mock_get_collection.return_value.update.assert_not_called()


### PR DESCRIPTION
Metadata sync currently works with `query_auth_token`. Removing
`TYPE_ID_ERRATA` from `QUERY_AUTH_TOKEN_UNSUPPORTED` allows pulp to sync
`updateinfo.xml` from SLES, and generate errata content.

Add relogin_suggested, restart_suggested to errata model since these
fields are available on SUSE metadata.

Add migrations to create relogin_suggested and restart_suggested fields
to pulp's errata models in database

fixes #3377
https://pulp.plan.io/issues/3377