### PR TITLE
Extensible way to GPG-sign repository metadata.

### DIFF
--- a/common/pulp_rpm/common/constants.py
+++ b/common/pulp_rpm/common/constants.py
@@ -200,3 +200,6 @@ RPM_NAMESPACE = 'http://linux.duke.edu/metadata/rpm'
 PULP_PACKAGES_DIR = 'Packages'
 
 MANDATORY_METADATA_TYPES = ('primary', 'filelists', 'other')
+
+GPG_CMD = "gpg_cmd"
+GPG_KEY_ID = "gpg_key_id"

--- a/docs/user-guide/release-notes/2.16.x.rst
+++ b/docs/user-guide/release-notes/2.16.x.rst
@@ -15,3 +15,8 @@ New Features
   fields on the Erratum model: `relogin_suggested` and `restart_suggested`.
   Errata update logic has been modified so that if two Errata has the same `updated`
   timestamp we also check to see if the `version` field has been updated.
+
+* Added the ability to use different GPG signing keys for repository metadata.
+  To accomplish this, users can specify a key in the distributor configuration
+  and change the GPG signing command to know how to process it.
+  More information can be found in `GPG Signing Key https://docs.pulpproject.org/plugins/pulp_rpm/tech-reference/yum-plugins.html#gpg-signing-key`

--- a/plugins/pulp_rpm/plugins/distributors/yum/configuration.py
+++ b/plugins/pulp_rpm/plugins/distributors/yum/configuration.py
@@ -9,7 +9,8 @@ from pulp.server.exceptions import MissingResource
 
 from pulp_rpm.common.constants import SCRATCHPAD_DEFAULT_METADATA_CHECKSUM, \
     CONFIG_DEFAULT_CHECKSUM, CONFIG_KEY_CHECKSUM_TYPE, REPO_AUTH_CONFIG_FILE, \
-    PUBLISH_HTTP_KEYWORD, PUBLISH_HTTPS_KEYWORD, RELATIVE_URL_KEYWORD
+    PUBLISH_HTTP_KEYWORD, PUBLISH_HTTPS_KEYWORD, RELATIVE_URL_KEYWORD, \
+    GPG_CMD, GPG_KEY_ID
 from pulp_rpm.common.ids import TYPE_ID_DISTRIBUTOR_YUM
 from pulp.repoauth import protected_repo_utils, repo_cert_utils
 from pulp_rpm.yum_plugin import util
@@ -23,7 +24,8 @@ OPTIONAL_CONFIG_KEYS = ('gpgkey', 'auth_ca', 'auth_cert', 'https_ca', 'checksum_
                         'http_publish_dir', 'https_publish_dir', 'protected',
                         'skip', 'skip_pkg_tags', 'generate_sqlite', 'force_full',
                         'repoview', 'updateinfo_checksum_type', 'gpg_sign_metadata',
-                        'remove_old_repodata', 'remove_old_repodata_threshold')
+                        'remove_old_repodata', 'remove_old_repodata_threshold',
+                        GPG_CMD, GPG_KEY_ID)
 
 ROOT_PUBLISH_DIR = '/var/lib/pulp/published/yum'
 MASTER_PUBLISH_DIR = os.path.join(ROOT_PUBLISH_DIR, 'master')
@@ -376,6 +378,17 @@ def get_repo_checksum_type(publish_conduit, config):
         checksum_type = CONFIG_DEFAULT_CHECKSUM
 
     return checksum_type
+
+
+def get_gpg_sign_options(repo=None, config=None):
+    cfg = config or {}
+    cmd = cfg.get(GPG_CMD)
+    if not cmd:
+        # Default to plain gpg
+        cmd = '/usr/bin/gpg --yes --detach-sign --armor'
+    key_id = cfg.get(GPG_KEY_ID)
+    repository_name = None if repo is None else repo.id
+    return util.SignOptions(cmd, repository_name=repository_name, key_id=key_id)
 
 
 # -- required config validation ------------------------------------------------

--- a/plugins/pulp_rpm/plugins/distributors/yum/publish.py
+++ b/plugins/pulp_rpm/plugins/distributors/yum/publish.py
@@ -384,11 +384,16 @@ class InitRepoMetadataStep(platform_steps.PluginStep):
         super(InitRepoMetadataStep, self).__init__(step)
         self.description = _("Initializing repo metadata")
         self.gpg_sign = gpg_sign
+        self.sign_options = None
 
     def initialize(self):
+        if self.gpg_sign:
+            self.sign_options = configuration.get_gpg_sign_options(
+                self.get_repo(), self.get_config())
         self.parent.repomd_file_context = RepomdXMLFileContext(self.get_working_dir(),
                                                                self.parent.get_checksum_type(),
-                                                               self.gpg_sign)
+                                                               self.gpg_sign,
+                                                               sign_options=self.sign_options)
         self.parent.repomd_file_context.initialize()
 
 


### PR DESCRIPTION
In certain environments, GPG private keys are secured in an HSM,
instead of being in a keyring, unprotected by a passphrase.

This allows one to change the signing command, and passes
repository ID information as an envronment variable into
the signing command, in case different keys need to be used.

Fixes: #3444
https://pulp.plan.io/issues/3444