### PR TITLE
fix client cert file not be called 'client.crt' for every protected repo

### DIFF
--- a/handlers/pulp_rpm/handlers/repo_file.py
+++ b/handlers/pulp_rpm/handlers/repo_file.py
@@ -437,6 +437,7 @@ class CertFiles(object):
         '''
         self.rootdir = os.path.join(rootdir, repoid)
         self.clientcert = None
+        self.CLIENT = "{0}_client.crt".format(repoid)
 
     def update(self, clientcert):
         '''


### PR DESCRIPTION
This PR is for https://pulp.plan.io/issues/3256.

The new naming for the client certificate (on a client system) will be '%repoid%_client.crt' instead of hardcoded 'client.crt' which causes an issue within yum.