### PR TITLE
gpg_cmd is not allowed as plugin or override configuration

### DIFF
--- a/docs/tech-reference/yum-plugins.rst
+++ b/docs/tech-reference/yum-plugins.rst
@@ -656,6 +656,11 @@ Optional Configuration Parameters
  or may be supplied in the distributor configuration.
  Example: ``{ "gpg_sign_metadata": true, "gpg_cmd": "/usr/local/bin/sign.sh" }``
 
+.. note:: ``gpg_cmd`` can only be set in the plugin configuration file
+   ``/etc/pulp/server/plugins.conf.d/yum_distributor.json``. For security
+   reasons, it cannot be set in the distrirbutor configuration or as an
+   override option at publish time.
+
 ``gpg_key_id``
  Key ID to be used for signing. See ``gpg_cmd``.
 
@@ -738,6 +743,12 @@ as a signing solution, given that private keys cannot be passphrase-protected.
 
 If a different signing command is necessary, one can set the ``gpg_cmd``
 configuration variable to point to such command.
+
+.. note:: ``gpg_cmd`` can only be set in the plugin configuration file
+   ``/etc/pulp/server/plugins.conf.d/yum_distributor.json``. For security
+   reasons, it cannot be set in the distrirbutor configuration or as an
+   override option at publish time.
+
 
 The signing command will be passed the following environment variables:
 * ``GPG_CMD``

--- a/plugins/pulp_rpm/plugins/distributors/yum/configuration.py
+++ b/plugins/pulp_rpm/plugins/distributors/yum/configuration.py
@@ -27,6 +27,8 @@ OPTIONAL_CONFIG_KEYS = ('gpgkey', 'auth_ca', 'auth_cert', 'https_ca', 'checksum_
                         'remove_old_repodata', 'remove_old_repodata_threshold',
                         GPG_CMD, GPG_KEY_ID)
 
+LOCAL_CONFIG_KEYS = [GPG_CMD]
+
 ROOT_PUBLISH_DIR = '/var/lib/pulp/published/yum'
 MASTER_PUBLISH_DIR = os.path.join(ROOT_PUBLISH_DIR, 'master')
 HTTP_PUBLISH_DIR = os.path.join(ROOT_PUBLISH_DIR, 'http', 'repos')
@@ -71,9 +73,17 @@ def validate_config(repo, config, config_conduit):
     :return: tuple of (bool, str) stating that the configuration is valid or not and why
     :rtype:  tuple of (bool, str or None)
     """
+    error_messages = []
+    msg = _('Configuration key [%(k)s] is not allowed in %(config)s configuration')
+    remote_configs = [
+        (config.repo_plugin_config, "repository plugin"),
+        (config.override_config, "override")]
+    for key in LOCAL_CONFIG_KEYS:
+        for cfgdict, cfgname in remote_configs:
+            if cfgdict.get(key):
+                error_messages.append(msg % dict(k=key, config=cfgname))
 
     config = config.flatten()  # squish it into a dictionary so we can manipulate it
-    error_messages = []
 
     configured_keys = set(config)
     required_keys = set(REQUIRED_CONFIG_KEYS)

--- a/plugins/test/unit/plugins/distributors/yum/test_configuration.py
+++ b/plugins/test/unit/plugins/distributors/yum/test_configuration.py
@@ -470,6 +470,21 @@ class YumDistributorConfigurationTests(unittest.TestCase):
 
         self.assertEqual(mock_check.call_count, 1)
 
+    def test_validate_config__repocfg_gpg_cmd(self):
+        repo = Repository('test')
+        config = self._generate_call_config(http=False, https=True,
+                                            relative_url="a/b")
+        config.repo_plugin_config["gpg_cmd"] = "this should fail"
+        conduit = RepoConfigConduit(TYPE_ID_DISTRIBUTOR_YUM)
+
+        valid, reasons = configuration.validate_config(repo, config, conduit)
+
+        self.assertFalse(valid)
+
+        expected_reason = ('Configuration key [gpg_cmd] is not allowed '
+                           'in repository plugin configuration')
+        self.assertEqual(reasons, expected_reason)
+
     def test_load_config(self):
         config_handle, config_path = tempfile.mkstemp(prefix='test_yum_distributor-')
         os.close(config_handle)


### PR DESCRIPTION
Since the command configured with gpg_cmd executes remotely as user apache,
a user should not be allowed to change it via a distributor config or
an override at publish time.

Fixes #3474
https://pulp.plan.io/issues/3474