### PR TITLE
Use aggregation to identify unique errata pkglists

### DIFF
--- a/plugins/pulp_rpm/plugins/db/models.py
+++ b/plugins/pulp_rpm/plugins/db/models.py
@@ -1137,10 +1137,10 @@ class Errata(UnitMixin, ContentUnit):
     @property
     def rpm_search_dicts(self):
         ret = []
-        pkglists = ErratumPkglist.objects(errata_id=self.errata_id)
+        pkglists = Errata.get_unique_pkglists(errata_id=self.errata_id)
         for pkglist in pkglists:
-            for collection in pkglist['collections']:
-                for package in collection.get('packages', []):
+            for collection in pkglist:
+                for package in collection:
                     if len(package.get('sum') or []) == 2:
                         checksum = package['sum'][1]
                         checksumtype = server_util.sanitize_checksum_type(package['sum'][0])
@@ -1173,7 +1173,7 @@ class Errata(UnitMixin, ContentUnit):
         :param errata_id: The erratum to generate a unique set of pkglists for
         :type  errata_id: str
         :return: unique pkglists for a specified erratum
-        :rtype: list of dicts
+        :rtype: list of lists of dicts
         """
         match_stage = {'$match': {'errata_id': errata_id}}
         group_stage = {'$group': {'_id': '$errata_id',

--- a/plugins/pulp_rpm/plugins/db/models.py
+++ b/plugins/pulp_rpm/plugins/db/models.py
@@ -1163,6 +1163,26 @@ class Errata(UnitMixin, ContentUnit):
                     ret.append(unit_key)
         return ret
 
+    @classmethod
+    def get_unique_pkglists(cls, errata_id):
+        """
+        Generate a list of unique pkglists for a specified erratum.
+
+        Those pkglists contain only information about packages.
+
+        :param errata_id: The erratum to generate a unique set of pkglists for
+        :type  errata_id: str
+        :return: unique pkglists for a specified erratum
+        :rtype: list of dicts
+        """
+        match_stage = {'$match': {'errata_id': errata_id}}
+        group_stage = {'$group': {'_id': '$errata_id',
+                                  'pkglists': {'$addToSet': '$collections.packages'}}}
+        pkglists = ErratumPkglist.objects.aggregate(match_stage, group_stage,
+                                                    allowDiskUse=True,
+                                                    batchSize=5).next()['pkglists']
+        return pkglists
+
     def create_legacy_metadata_dict(self):
         """
         Generate metadata dict and add erratum pkglist to it since it is stored

--- a/plugins/pulp_rpm/plugins/serializers.py
+++ b/plugins/pulp_rpm/plugins/serializers.py
@@ -62,7 +62,18 @@ class Errata(platform_serializers.ModelSerializer):
         from pulp_rpm.plugins.db import models
 
         pkglists = models.Errata.get_unique_pkglists(unit.get('errata_id'))
-        unit['pkglist'] = [coll for pkglist in pkglists for coll in pkglist]
+        unit['pkglist'] = []
+        coll_num = 0
+        for pkglist in pkglists:
+            for coll in pkglist:
+                # To preserve the original format of a pkglist the 'short' and 'name'
+                # keys are added. 'short' can be an empty string, collection 'name'
+                # should be unique within an erratum.
+                unit['pkglist'].append({'packages': coll,
+                                        'short': '',
+                                        'name': 'collection-%s' % coll_num})
+                coll_num += 1
+
         return super(Errata, self).serialize(unit)
 
 

--- a/plugins/pulp_rpm/plugins/serializers.py
+++ b/plugins/pulp_rpm/plugins/serializers.py
@@ -54,14 +54,15 @@ class Errata(platform_serializers.ModelSerializer):
         Convert a single unit to it's dictionary form.
 
         Add to errratum unit its pkglist.
+        Duplicated pkglists are eliminated.
 
         :param unit: The object to be converted
         :type unit: object
         """
-        from pulp_rpm.plugins.db.models import ErratumPkglist
+        from pulp_rpm.plugins.db import models
 
-        pkglists = ErratumPkglist.objects(errata_id=unit.get('errata_id'))
-        unit['pkglist'] = [coll for pkglist in pkglists for coll in pkglist['collections']]
+        pkglists = models.Errata.get_unique_pkglists(unit.get('errata_id'))
+        unit['pkglist'] = [coll for pkglist in pkglists for coll in pkglist]
         return super(Errata, self).serialize(unit)
 
 

--- a/plugins/test/unit/plugins/db/test_models.py
+++ b/plugins/test/unit/plugins/db/test_models.py
@@ -307,8 +307,8 @@ class TestErrata(unittest.TestCase):
             'name': 'test-name',
             'short': ''}
 
-    @mock.patch('pulp_rpm.plugins.db.models.ErratumPkglist.objects')
-    def test_rpm_search_dicts_sanitizes_checksum_type_sum(self, mock_erratumpkglist_objects):
+    @mock.patch('pulp_rpm.plugins.db.models.Errata.get_unique_pkglists')
+    def test_rpm_search_dicts_sanitizes_checksum_type_sum(self, mock_get_unique_pkglists):
         """
         Assert that the rpm_search_dicts() method properly sanitizes checksum types with the sum
         is specified with the 'sum' attribute.
@@ -320,15 +320,15 @@ class TestErrata(unittest.TestCase):
                 {'name': 'name', 'epoch': '0', 'version': '0.0', 'sum': ['sha', 'sum'],
                  'release': 'release', 'arch': 'arch'}]}]
 
-        mock_erratumpkglist_objects.return_value = [errata_pkglist]
+        mock_get_unique_pkglists.return_value = [[errata_pkglist.collections[0]['packages']]]
 
         ret = errata.rpm_search_dicts
 
         self.assertEqual(len(ret), 1)
         self.assertEqual(ret[0]['checksumtype'], 'sha1')
 
-    @mock.patch('pulp_rpm.plugins.db.models.ErratumPkglist.objects')
-    def test_rpm_search_dicts_sanitizes_checksum_type_sums(self, mock_erratumpkglist_objects):
+    @mock.patch('pulp_rpm.plugins.db.models.Errata.get_unique_pkglists')
+    def test_rpm_search_dicts_sanitizes_checksum_type_sums(self, mock_get_unique_pkglists):
         """
         Assert that the rpm_search_dicts() method properly sanitizes checksum types with the sum
         is specified with the 'type' attribute.
@@ -340,15 +340,15 @@ class TestErrata(unittest.TestCase):
                 {'name': 'name', 'epoch': '0', 'version': '0.0', 'sums': ['sum1', 'sum2'],
                  'release': 'release', 'arch': 'arch', 'type': 'sha'}]}]
 
-        mock_erratumpkglist_objects.return_value = [errata_pkglist]
+        mock_get_unique_pkglists.return_value = [[errata_pkglist.collections[0]['packages']]]
 
         ret = errata.rpm_search_dicts
 
         self.assertEqual(len(ret), 1)
         self.assertEqual(ret[0]['checksumtype'], 'sha1')
 
-    @mock.patch('pulp_rpm.plugins.db.models.ErratumPkglist.objects')
-    def test_rpm_search_dicts_no_checksum(self, mock_erratumpkglist_objects):
+    @mock.patch('pulp_rpm.plugins.db.models.Errata.get_unique_pkglists')
+    def test_rpm_search_dicts_no_checksum(self, mock_get_unique_pkglists):
         """
         Assert that the rpm_search_dicts() method tolerates a missing checksumtype, as is found
         when using this demo repo: https://repos.fedorapeople.org/repos/pulp/pulp/demo_repos/zoo/
@@ -360,7 +360,7 @@ class TestErrata(unittest.TestCase):
                 {'name': 'foo', 'epoch': '0', 'version': '0.0', 'sum': None,
                  'release': 'release', 'arch': 'arch'}]}]
 
-        mock_erratumpkglist_objects.return_value = [errata_pkglist]
+        mock_get_unique_pkglists.return_value = [[errata_pkglist.collections[0]['packages']]]
 
         ret = errata.rpm_search_dicts
 


### PR DESCRIPTION
To improve both performance and memory consumption of celery
workers during applicability regeneration.
Serializer for Errata now deals wit unique pkglists as well.

closes #3172
https://pulp.plan.io/issues/3172