### PR TITLE
Sanitize Invalid Changelogs Too

### DIFF
--- a/plugins/pulp_rpm/plugins/db/models.py
+++ b/plugins/pulp_rpm/plugins/db/models.py
@@ -903,7 +903,7 @@ class RpmBase(NonMetadataPackage):
         """
         start_tag_pattern = r'<%s.*?(?<!/)>' % tag_name
         end_tag_pattern = r'</%s>' % tag_name
-        complete_tag_pattern = r'(%s)(.*?)(%s)' % (start_tag_pattern, end_tag_pattern)
+        complete_tag_pattern = r'(%s)(.*)(%s)' % (start_tag_pattern, end_tag_pattern)
         tag_re = re.compile(complete_tag_pattern, flags=re.DOTALL)
         template = tag_re.sub(RpmBase._generate_tag_replacement_str, template)
         return template


### PR DESCRIPTION
The diff below causes the selection of input to be sanitized to be
greedy instead of non-greedy. This causes it work sanitize more
data in the cases of invalid entries such as Changelogs with too
many <changelog></changelog> sections in one rpm.

This fix is very safe for several reasons:

1. Escaping all data for the template layer should be safe. This is
essentially user-provided data given that we got it from the
internet, so it probably all should be escaped. Since this fixes
this issue I'm not going to rewrite the sanitizer now to keep it
low-risk.

2. The extra-greedyness added is still limited by the end tag
matched

https://pulp.plan.io/issues/3535
closes #3535