### PR TITLE
Use gpg_key_id even when gpg_cmd is not configured

### DIFF
--- a/docs/tech-reference/yum-plugins.rst
+++ b/docs/tech-reference/yum-plugins.rst
@@ -638,6 +638,9 @@ Optional Configuration Parameters
  ``/etc/pulp/server/plugins.conf.d/yum_distributor.json`` file containing
  ``{ "gpg_sign_metadata": true }``.
 
+``gpg_key_id``
+ GPG key ID to use for signing repository metadata.
+
 ``gpg_cmd``
  Path to a signing command that will be used for signing repository
  metadata, if ``gpg_sign_metadata`` is set.
@@ -651,7 +654,7 @@ Optional Configuration Parameters
  Also, the signing command will be passed the name of the repository as the
  ``GPG_REPOSITORY_NAME`` environment variable.
 
- Additionally, if ``gpg_key_id`` is set (see below), its value will
+ Additionally, if ``gpg_key_id`` is set (see above), its value will
  be passed to the signing command as the ``GPG_KEY_ID`` environment variable.
  This option should be added to the JSON configuration file described above,
  or may be supplied in the distributor configuration.
@@ -661,9 +664,6 @@ Optional Configuration Parameters
    ``/etc/pulp/server/plugins.conf.d/yum_distributor.json``. For security
    reasons, it cannot be set in the distrirbutor configuration or as an
    override option at publish time.
-
-``gpg_key_id``
- Key ID to be used for signing. See ``gpg_cmd``.
 
 ``skip``
  List of content types to skip during the repository publish.

--- a/docs/user-guide/release-notes/2.17.x.rst
+++ b/docs/user-guide/release-notes/2.17.x.rst
@@ -1,0 +1,13 @@
+=======================
+Pulp 2.17 Release Notes
+=======================
+
+Pulp 2.17.0
+===========
+
+New Features
+------------
+
+* The `gpg_key_id` yum distributor configuration value was previously ignored
+  unless `gpg_cmd` was configured.  It is now used with the default GPG signing
+  command when `gpg_cmd` is not configured.

--- a/docs/user-guide/release-notes/index.rst
+++ b/docs/user-guide/release-notes/index.rst
@@ -6,6 +6,7 @@ Contents:
 .. toctree::
    :maxdepth: 2
 
+   2.17.x
    2.16.x
    2.15.x
    2.14.x

--- a/plugins/pulp_rpm/plugins/distributors/yum/configuration.py
+++ b/plugins/pulp_rpm/plugins/distributors/yum/configuration.py
@@ -393,10 +393,12 @@ def get_repo_checksum_type(publish_conduit, config):
 def get_gpg_sign_options(repo=None, config=None):
     cfg = config or {}
     cmd = cfg.get(GPG_CMD)
+    key_id = cfg.get(GPG_KEY_ID)
     if not cmd:
         # Default to plain gpg
-        cmd = '/usr/bin/gpg --yes --detach-sign --armor'
-    key_id = cfg.get(GPG_KEY_ID)
+        cmd = ['/usr/bin/gpg', '--yes', '--detach-sign', '--armor']
+        if key_id:
+            cmd += ['--default-key', key_id]
     repository_name = None if repo is None else repo.id
     return util.SignOptions(cmd, repository_name=repository_name, key_id=key_id)
 

--- a/plugins/pulp_rpm/yum_plugin/util.py
+++ b/plugins/pulp_rpm/yum_plugin/util.py
@@ -231,17 +231,16 @@ class SignOptions(object):
 
     The command should accept one argument, a path to a file.
 
-    This class' fields, prepended with GPG_ and upper-cased, will be
-    presented to the command as environment variables. The
-    command may determine which gpg key to use based on GPG_KEY_ID
-    or GPG_REPOSITORY_NAME
+    With the exception of cmd, this class' fields will be presented to the
+    command as environment variables with the name prepended with GPG_ and
+    upper-cased. The command may determine which gpg key to use based on
+    GPG_KEY_ID or GPG_REPOSITORY_NAME
     """
 
     def __init__(self, cmd=None, key_id=None, **kwargs):
         if not cmd:
             raise SignerError("Command not specified")
-        self.cmd = cmd
-        self._cmdargs = shlex.split(cmd)
+        self._cmdargs = (cmd if isinstance(cmd, list) else shlex.split(cmd))
         if not os.path.isfile(self._cmdargs[0]):
             raise SignerError(
                 "Command %s is not a file" % (self._cmdargs[0], ))

--- a/plugins/test/unit/plugins/distributors/yum/test_configuration.py
+++ b/plugins/test/unit/plugins/distributors/yum/test_configuration.py
@@ -623,7 +623,7 @@ class YumDistributorConfigurationTests(unittest.TestCase):
         config = dict(gpg_cmd=cmd)
         opts = configuration.get_gpg_sign_options(repo, config)
         self.assertEqual(
-            dict(GPG_CMD=cmd, GPG_REPOSITORY_NAME="myrepo"),
+            dict(GPG_REPOSITORY_NAME="myrepo"),
             opts.as_environment())
 
     @mock.patch("pulp_rpm.yum_plugin.util.os.access")
@@ -631,9 +631,18 @@ class YumDistributorConfigurationTests(unittest.TestCase):
         "Make sure the test passes even if gpg is not installed"
         _os_access.return_value = 1
         opts = configuration.get_gpg_sign_options()
-        cmd = "/usr/bin/gpg --yes --detach-sign --armor"
+        self.assertEqual(dict(), opts.as_environment())
+        _os_access.assert_called_once_with("/usr/bin/gpg", 1)
+
+    @mock.patch("pulp_rpm.yum_plugin.util.os.access")
+    def test_get_gpg_sign_options__default_cmd_with_key(self, _os_access):
+        "Make sure the test passes even if gpg is not installed"
+        _os_access.return_value = 1
+        repo = mock.MagicMock(id="myrepo")
+        config = dict(gpg_key_id='12345')
+        opts = configuration.get_gpg_sign_options(repo, config)
         self.assertEqual(
-            dict(GPG_CMD=cmd),
+            dict(GPG_KEY_ID='12345', GPG_REPOSITORY_NAME="myrepo"),
             opts.as_environment())
         _os_access.assert_called_once_with("/usr/bin/gpg", 1)
 

--- a/plugins/test/unit/plugins/distributors/yum/test_publish.py
+++ b/plugins/test/unit/plugins/distributors/yum/test_publish.py
@@ -501,7 +501,7 @@ class PublisherTests(BaseYumDistributorPublishStepTests):
 
         self.assertEquals(_configuration.get_gpg_sign_options.return_value,
                           substep.sign_options)
-        # Make sure we're assing the sign options to the xml file context
+        # Make sure we're passing the sign options to the xml file context
         _RepomdXMLFileContext.assert_called_once_with(
             self.working_dir,
             _configuration.get_repo_checksum_type.return_value,

--- a/plugins/test/unit/yum_plugin/test_util.py
+++ b/plugins/test/unit/yum_plugin/test_util.py
@@ -121,7 +121,6 @@ class SignerTest(rpm_support_base.PulpRPMTests):
         _Popen.assert_called_once_with(
             [self.sign_cmd, filename],
             env=dict(
-                GPG_CMD=self.sign_cmd,
                 GPG_KEY_ID=self.key_id,
                 GPG_REPOSITORY_NAME=self.repository_name,
                 GPG_DIST=self.dist,


### PR DESCRIPTION
https://github.com/pulp/pulp_rpm/pull/1093 introduced new `gpg_cmd` and `gpg_key_id` configuration options, but only used `gpg_key_id` when `gpg_cmd` is specified.  Some users may want to specify a `gpg_key_id` when using the default gpg command (when `gpg_cmd` is not specified).  This PR adds support for that.

@mibanescu 