### PR TITLE
Create checksum for exported iso file

### DIFF
--- a/docs/tech-reference/export-distributor.rst
+++ b/docs/tech-reference/export-distributor.rst
@@ -8,7 +8,9 @@ images, or to the directory of your choice as one or more yum repositories. The 
 distributor uses the ID ``export_distributor``. The repository group distributor uses the ID
 ``group_export_distributor``. Exported repository ISOs will be published over HTTP or HTTPS at
 the path ``/pulp/exports/repo/<repo-id>/``, and exported repository group ISOs can be found at
-``/pulp/exports/repo_group/<group-id>/``.
+``/pulp/exports/repo_group/<group-id>/``. Along with the ISO there will also be a ``*.iso.DIGESTS``
+file published. This file will contain md5, sha1, sha224, sha256, sha384, and sha512 digests of the
+ISO.
 
 Configuration Parameters
 ========================

--- a/docs/user-guide/recipes.rst
+++ b/docs/user-guide/recipes.rst
@@ -342,7 +342,9 @@ The general workflow is as follows:
 
 Which, if publishing over HTTP, could be found at
 `http://localhost/pulp/exports/repo/demo-repo/ <http://localhost/pulp/exports/repo/demo-repo/>`_
-(adjust hostname and repo-id as necessary.)
+(adjust hostname and repo-id as necessary). Along with the ISO there will also be a 
+``*.iso.DIGESTS`` file published. This file will contain md5, sha1, sha224, sha256, sha384,
+and sha512 digests of the ISO.
 
 3. Transport the ISOs to the disconnected Pulp server
 4. Mount each ISO and copy its contents to a directory on the disconnected Pulp server

--- a/docs/user-guide/release-notes/2.17.x.rst
+++ b/docs/user-guide/release-notes/2.17.x.rst
@@ -11,3 +11,6 @@ New Features
 * The `gpg_key_id` yum distributor configuration value was previously ignored
   unless `gpg_cmd` was configured.  It is now used with the default GPG signing
   command when `gpg_cmd` is not configured.
+
+* The export distributor now generates a ``*.iso.DIGESTS`` file along with the ISO.
+  This file will contain md5, sha1, sha224, sha256, sha384, and sha512 digests of the ISO.

--- a/plugins/test/unit/plugins/distributors/export_distributor/test_generate_iso.py
+++ b/plugins/test/unit/plugins/distributors/export_distributor/test_generate_iso.py
@@ -46,6 +46,12 @@ class TestMakeIso(unittest.TestCase):
     """
     Test the _make_iso helper method in generate_iso
     """
+    def setUp(self):
+        self.add_digest_file = generate_iso._add_digest_file
+        generate_iso._add_digest_file = mock.Mock(return_value=[])
+
+    def tearDown(self):
+        generate_iso._add_digest_file = self.add_digest_file
 
     @mock.patch('os.path.isdir', autospec=True, return_value=True)
     @mock.patch('os.close', autospec=True)


### PR DESCRIPTION
When we export a .iso file,  we must also export a checksum file with it.