### PR TITLE
As a user I can copy modulemd units

### DIFF
--- a/common/pulp_rpm/common/ids.py
+++ b/common/pulp_rpm/common/ids.py
@@ -63,5 +63,9 @@ METADATA_DRPM = ("size", "sequence", "new_package", "relativepath")
 
 TYPE_ID_YUM_REPO_METADATA_FILE = 'yum_repo_metadata_file'
 
+# modulemd types
+TYPE_ID_MODULEMD = 'modulemd'
+TYPE_ID_MODULEMD_DEFAULTS = 'modulemd_defaults'
+
 # These types don't have support for the query-param auth token yet
 QUERY_AUTH_TOKEN_UNSUPPORTED = (TYPE_ID_ISO, TYPE_ID_DISTRO)

--- a/extensions_admin/pulp_rpm/extensions/admin/units_display.py
+++ b/extensions_admin/pulp_rpm/extensions/admin/units_display.py
@@ -1,7 +1,8 @@
 from pulp_rpm.common.ids import (TYPE_ID_RPM, TYPE_ID_SRPM, TYPE_ID_DRPM, TYPE_ID_ERRATA,
                                  TYPE_ID_DISTRO, TYPE_ID_PKG_GROUP, TYPE_ID_PKG_CATEGORY,
                                  TYPE_ID_PKG_ENVIRONMENT, TYPE_ID_PKG_LANGPACKS,
-                                 TYPE_ID_YUM_REPO_METADATA_FILE)
+                                 TYPE_ID_YUM_REPO_METADATA_FILE, TYPE_ID_MODULEMD,
+                                 TYPE_ID_MODULEMD_DEFAULTS)
 
 
 def get_formatter_for_type(type_id):
@@ -23,7 +24,10 @@ def get_formatter_for_type(type_id):
         TYPE_ID_PKG_ENVIRONMENT: lambda x: x.get('id'),
         TYPE_ID_PKG_LANGPACKS: lambda x: x.get('repo_id'),
         TYPE_ID_YUM_REPO_METADATA_FILE: _yum_repo_metadata_name_only,
+        TYPE_ID_MODULEMD: _details_modulemd,
+        TYPE_ID_MODULEMD_DEFAULTS: _details_modulemd_defaults,
     }
+
     return type_formatters[type_id]
 
 
@@ -79,3 +83,32 @@ def _yum_repo_metadata_name_only(unit):
     :rtype: str
     """
     return unit['data_type']
+
+
+def _details_modulemd(module):
+    """
+    A formatter for modulemd content units.
+
+    Format display with name, stream, version, context, arch
+
+    :param unit: The unit to have its formatting returned.
+    :type unit: dict
+    :return: The display string of the unit
+    :rtype: str
+    """
+    return '%s-%s-%s-%s-%s' % (module['name'], module['stream'], module['version'],
+                               module['context'], module['arch'])
+
+
+def _details_modulemd_defaults(default):
+    """
+    A formatter for modulemd defaults content units.
+
+    Format display with name.
+
+    :param unit: The unit to have its formatting returned.
+    :type unit: dict
+    :return: The display string of the unit
+    :rtype: str
+    """
+    return default['name']

--- a/plugins/pulp_rpm/plugins/db/models.py
+++ b/plugins/pulp_rpm/plugins/db/models.py
@@ -22,7 +22,7 @@ from pulp.server.exceptions import PulpCodedException
 from pulp_rpm.common import constants, version_utils, file_utils
 from pulp_rpm.plugins import error_codes, serializers
 from pulp_rpm.plugins.db.fields import ChecksumTypeStringField
-from pulp_rpm.plugins.importers.yum import utils
+from pulp_rpm.plugins.importers.yum import utils, parse
 from pulp_rpm.yum_plugin import util
 
 
@@ -1694,6 +1694,25 @@ class Modulemd(FileContentUnit):
         :rtype:             string
         """
         return file_utils.calculate_checksum(file_handle)
+
+    @property
+    def rpm_search_dicts(self):
+        """
+        Return a list of dictionaries with NEVRA data for each artifact (RPM) this modulemd includes
+
+        :return:            A list of of dicts that contain one NEVRA for each artifact
+        :rtype:             list
+        """
+        rpm_dicts = []
+        for artifact in self.artifacts:
+            nevra = parse.rpm.nevra(artifact)
+            rpm_dicts.append({'name': nevra[0],
+                              'epoch': unicode(nevra[1]),
+                              'version': nevra[2],
+                              'release': nevra[3],
+                              'arch': nevra[4]})
+
+        return rpm_dicts
 
 
 class ModulemdDefaults(UnitMixin, FileContentUnit):

--- a/plugins/pulp_rpm/plugins/importers/yum/associate.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/associate.py
@@ -93,7 +93,7 @@ def associate(source_repo, dest_repo, import_conduit, config, units=None):
             associated_units |= tmp_associated_units
             failed_units |= tmp_failed_units
 
-    # ------ get RPM children of errata ------
+    # ------ get RPM children of errata and modules ------
     wanted_rpms = get_rpms_to_copy_by_key(rpm_search_dicts, import_conduit, source_repo)
     rpm_search_dicts = None
     rpms_to_copy = filter_available_rpms(wanted_rpms, import_conduit, source_repo)
@@ -326,7 +326,7 @@ def identify_children_to_copy(units):
         elif isinstance(unit, models.PackageEnvironment):
             groups.update(unit.group_ids)
             groups.update(unit.optional_group_ids)
-        elif isinstance(unit, models.Errata):
+        elif isinstance(unit, (models.Errata, models.Modulemd)):
             rpm_search_dicts.extend(unit.rpm_search_dicts)
     return groups, rpm_names, rpm_search_dicts
 


### PR DESCRIPTION
fixes #3864
https://pulp.plan.io/issues/3864

Example calls to test recursive copy:

```
pulp-admin rpm repo update --repo-id zoo --feed "https://repos.fedorapeople.org/repos/pulp/pulp/fixtures/rpm-with-modules/"
pulp-admin rpm repo sync run --repo-id zoo
pulp-admin rpm repo create --repo-id zoo2
phttp https://localhost/pulp/api/v2/repositories/zoo2/actions/associate/ source_repo_id=zoo criteria:='{"type_ids": ["modulemd"]}' override_config:='{"recursive": true}'
```