### PR TITLE
Remove create kwarg since by default it's true

### DIFF
--- a/plugins/pulp_rpm/plugins/importers/yum/pulp_solv.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/pulp_solv.py
@@ -187,7 +187,7 @@ def rpm_filelist_conversion(solvable, unit):
     unit_files.extend(unit.get('files', {}).get('dir', []))
     for filename in unit_files:
         dirname = os.path.dirname(filename).encode('utf-8')
-        dirname_id = repodata.str2dir(dirname, create=True)
+        dirname_id = repodata.str2dir(dirname)
         repodata.add_dirstr(solvable.id, solv.SOLVABLE_FILELIST,
                             dirname_id, os.path.basename(filename).encode('utf-8'))
 


### PR DESCRIPTION
We discovered an issue where on some versions of python2-solv, there was
no create kwarg for str2dir. So we're removing it from this call since by
default it's True anyway.

Note that this is not really a fix for #3876

https://pulp.plan.io/issues/3876
ref #3876