### PR TITLE
Fixing arity problem in iso's DownloadEventListener

### DIFF
--- a/plugins/pulp_rpm/plugins/importers/iso/sync.py
+++ b/plugins/pulp_rpm/plugins/importers/iso/sync.py
@@ -108,7 +108,7 @@ class ISOSyncRun(listener.DownloadEventListener):
             importer_constants.DOWNLOAD_IMMEDIATE)
         return policy != importer_constants.DOWNLOAD_IMMEDIATE
 
-    def download_failed(self, report, exception):
+    def download_failed(self, report):
         """
         This is the callback that we will get from the downloader library when any individual
         download fails.
@@ -116,14 +116,14 @@ class ISOSyncRun(listener.DownloadEventListener):
         # If we have a download failure during the manifest phase, we should set the report to
         # failed for that phase.
         msg = _('Failed to download %(url)s: %(error_msg)s.')
-        msg = msg % {'url': report.url, 'error_msg': exception}
+        msg = msg % {'url': report.url, 'error_msg': report.error_msg}
         _logger.error(msg)
         if self.progress_report.state == self.progress_report.STATE_MANIFEST_IN_PROGRESS:
             self.progress_report.state = self.progress_report.STATE_MANIFEST_FAILED
-            self.progress_report.error_message = exception
+            self.progress_report.error_message = report.error_report
         elif self.progress_report.state == self.progress_report.STATE_ISOS_IN_PROGRESS:
             iso = report.data
-            self.progress_report.add_failed_iso(iso, exception)
+            self.progress_report.add_failed_iso(iso, report.error_report)
         self.progress_report.update_progress()
 
     def download_progress(self, report):
@@ -171,7 +171,9 @@ class ISOSyncRun(listener.DownloadEventListener):
                 self.progress_report.num_isos_finished += 1
                 self.progress_report.update_progress()
             except ValueError as e:
-                self.download_failed(report, e)
+                report.error_msg = str(e)
+                report.error_report = str(e)
+                self.download_failed(report)
 
     def add_catalog_entries(self, units):
         """


### PR DESCRIPTION
The DownloadEventListener interface defines download_failed(self,
report) and this restores the arity.

fixes #3899
https://pulp.plan.io/issues/3899