### PR TITLE
Renaming model names to be consistent with createrepo

### DIFF
--- a/pulp_rpm/app/models.py
+++ b/pulp_rpm/app/models.py
@@ -9,9 +9,9 @@ from pulp_rpm.app.constants import CHECKSUM_CHOICES
 log = getLogger(__name__)
 
 
-class RpmContent(Content):
+class Package(Content):
     """
-    The "rpm" content type.
+    The "Package" content type. Formerly "rpm" in Pulp 2.
 
     Maps directly to the fields provided by createrepo_c.
     https://github.com/rpm-software-management/createrepo_c/
@@ -103,7 +103,7 @@ class RpmContent(Content):
             attribute in the primary XML.
     """
 
-    TYPE = 'rpm'
+    TYPE = 'package'
 
     # Required metadata
     name = models.TextField()
@@ -193,16 +193,6 @@ class RpmContent(Content):
         unique_together = (
             'name', 'epoch', 'version', 'release', 'arch', 'checksum_type', 'pkgId'
         )
-
-
-class SrpmContent(RpmContent):
-    """
-    The "srpm" content type.
-
-    (same as the "rpm" content type)
-    """
-
-    TYPE = 'srpm'
 
 
 class UpdateRecord(Content):

--- a/pulp_rpm/app/serializers.py
+++ b/pulp_rpm/app/serializers.py
@@ -1,15 +1,14 @@
 from pulpcore.plugin.serializers import ContentSerializer, RemoteSerializer, PublisherSerializer
 
-from pulp_rpm.app.models import RpmContent, RpmRemote, RpmPublisher
+from pulp_rpm.app.models import Package, RpmRemote, RpmPublisher
 
 
-class RpmContentSerializer(ContentSerializer):
+class PackageSerializer(ContentSerializer):
     """
-    A Serializer for RpmContent.
+    A Serializer for Package.
 
-    Add serializers for the new fields defined in RpmContent and
-    add those fields to the Meta class keeping fields from the parent class as well.
-    Provide help_text.
+    Add serializers for the new fields defined in Package and add those fields to the Meta class
+    keeping fields from the parent class as well. Provide help_text.
 
     For example::
 
@@ -19,12 +18,12 @@ class RpmContentSerializer(ContentSerializer):
 
     class Meta:
         fields = ContentSerializer.Meta.fields + ('field1', 'field2', 'field3')
-        model = RpmContent
+        model = Package
     """
 
     class Meta:
         fields = ContentSerializer.Meta.fields
-        model = RpmContent
+        model = Package
 
 
 class RpmRemoteSerializer(RemoteSerializer):
@@ -32,7 +31,7 @@ class RpmRemoteSerializer(RemoteSerializer):
     A Serializer for RpmRemote.
 
     Add any new fields if defined on RpmRemote.
-    Similar to the example above, in RpmContentSerializer.
+    Similar to the example above, in PackageSerializer.
     Additional validators can be added to the parent validators list
 
     For example::
@@ -51,7 +50,7 @@ class RpmPublisherSerializer(PublisherSerializer):
     A Serializer for RpmPublisher.
 
     Add any new fields if defined on RpmPublisher.
-    Similar to the example above, in RpmContentSerializer.
+    Similar to the example above, in PackageSerializer.
     Additional validators can be added to the parent validators list
 
     For example::

--- a/pulp_rpm/app/viewsets.py
+++ b/pulp_rpm/app/viewsets.py
@@ -18,28 +18,28 @@ from pulpcore.plugin.viewsets import (
 )
 
 from pulp_rpm.app import tasks
-from pulp_rpm.app.models import RpmContent, RpmRemote, RpmPublisher
+from pulp_rpm.app.models import Package, RpmRemote, RpmPublisher
 from pulp_rpm.app.serializers import (
-    RpmContentSerializer,
+    PackageSerializer,
     RpmRemoteSerializer,
     RpmPublisherSerializer
 )
 
 
-class RpmContentViewSet(ContentViewSet):
+class PackageViewSet(ContentViewSet):
     """
-    A ViewSet for RpmContent.
+    A ViewSet for Package.
 
     Define endpoint name which will appear in the API endpoint for this content type.
     For example::
-        http://pulp.example.com/pulp/api/v3/content/rpm/
+        http://pulp.example.com/pulp/api/v3/content/rpm/packages/
 
-    Also specify queryset and serializer for RpmContent.
+    Also specify queryset and serializer for Package.
     """
 
-    endpoint_name = 'rpm'
-    queryset = RpmContent.objects.all()
-    serializer_class = RpmContentSerializer
+    endpoint_name = 'rpm/packages'
+    queryset = Package.objects.all()
+    serializer_class = PackageSerializer
 
 
 class RpmRemoteViewSet(RemoteViewSet):


### PR DESCRIPTION
In createrepo, rpm packages are called packages and not rpms. Updating the model names to be consistent.