### PR TITLE
Add full set of smash tests

### DIFF
--- a/pulp_rpm/tests/functional/api/test_crd_publications.py
+++ b/pulp_rpm/tests/functional/api/test_crd_publications.py
@@ -1,0 +1,129 @@
+# coding=utf-8
+"""Tests that perform actions over publications."""
+import unittest
+
+from requests.exceptions import HTTPError
+
+from pulp_smash import api, config
+from pulp_smash.pulp3.constants import DISTRIBUTION_PATH, PUBLICATIONS_PATH, REPO_PATH
+from pulp_smash.pulp3.utils import (
+    gen_distribution,
+    gen_repo,
+    publish,
+    sync,
+)
+
+from pulp_rpm.tests.functional.constants import (
+    RPM_PUBLISHER_PATH,
+    RPM_REMOTE_PATH
+)
+from pulp_rpm.tests.functional.utils import (
+    gen_rpm_publisher,
+    gen_rpm_remote,
+    skip_if,
+)
+from pulp_rpm.tests.functional.utils import set_up_module as setUpModule  # noqa:F401
+
+
+@unittest.skip("FIXME: Implement publish support")
+class PublicationsTestCase(unittest.TestCase):
+    """Perform actions over publications."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create class-wide variables."""
+        cls.cfg = config.get_config()
+        cls.client = api.Client(cls.cfg, api.page_handler)
+        cls.remote = {}
+        cls.publication = {}
+        cls.publisher = {}
+        cls.repo = {}
+        try:
+            cls.repo.update(cls.client.post(REPO_PATH, gen_repo()))
+            body = gen_rpm_remote()
+            cls.remote.update(cls.client.post(RPM_REMOTE_PATH, body))
+            cls.publisher.update(
+                cls.client.post(RPM_PUBLISHER_PATH, gen_rpm_publisher())
+            )
+            sync(cls.cfg, cls.remote, cls.repo)
+        except Exception:
+            cls.tearDownClass()
+            raise
+
+    @classmethod
+    def tearDownClass(cls):
+        """Clean class-wide variables."""
+        for resource in (cls.remote, cls.publisher, cls.repo):
+            if resource:
+                cls.client.delete(resource['_href'])
+
+    def test_01_create_publication(self):
+        """Create a publication."""
+        self.publication.update(
+            publish(self.cfg, self.publisher, self.repo)
+        )
+
+    @skip_if(bool, 'publication', False)
+    def test_02_read_publication(self):
+        """Read a publication by its href."""
+        publication = self.client.get(self.publication['_href'])
+        for key, val in self.publication.items():
+            with self.subTest(key=key):
+                self.assertEqual(publication[key], val)
+
+    @skip_if(bool, 'publication', False)
+    def test_02_read_publications(self):
+        """Read a publication by its repository version."""
+        publications = self.client.get(PUBLICATIONS_PATH, params={
+            'repository_version': self.repo['_href']
+        })
+        self.assertEqual(len(publications), 1, publications)
+        for key, val in self.publication.items():
+            with self.subTest(key=key):
+                self.assertEqual(publications[0][key], val)
+
+    @skip_if(bool, 'publication', False)
+    def test_03_read_publications(self):
+        """Read a publication by its publisher."""
+        publications = self.client.get(PUBLICATIONS_PATH, params={
+            'publisher': self.publisher['_href']
+        })
+        self.assertEqual(len(publications), 1, publications)
+        for key, val in self.publication.items():
+            with self.subTest(key=key):
+                self.assertEqual(publications[0][key], val)
+
+    @skip_if(bool, 'publication', False)
+    def test_04_read_publications(self):
+        """Read a publication by its created time."""
+        publications = self.client.get(PUBLICATIONS_PATH, params={
+            'created': self.publication['created']
+        })
+        self.assertEqual(len(publications), 1, publications)
+        for key, val in self.publication.items():
+            with self.subTest(key=key):
+                self.assertEqual(publications[0][key], val)
+
+    @skip_if(bool, 'publication', False)
+    def test_05_read_publications(self):
+        """Read a publication by its distribution."""
+        body = gen_distribution()
+        body['publication'] = self.publication['_href']
+        distribution = self.client.post(DISTRIBUTION_PATH, body)
+        self.addCleanup(self.client.delete, distribution['_href'])
+
+        self.publication.update(self.client.get(self.publication['_href']))
+        publications = self.client.get(PUBLICATIONS_PATH, params={
+            'distributions': distribution['_href']
+        })
+        self.assertEqual(len(publications), 1, publications)
+        for key, val in self.publication.items():
+            with self.subTest(key=key):
+                self.assertEqual(publications[0][key], val)
+
+    @skip_if(bool, 'publication', False)
+    def test_06_delete(self):
+        """Delete a publication."""
+        self.client.delete(self.publication['_href'])
+        with self.assertRaises(HTTPError):
+            self.client.get(self.publication['_href'])

--- a/pulp_rpm/tests/functional/api/test_crud_content_unit.py
+++ b/pulp_rpm/tests/functional/api/test_crud_content_unit.py
@@ -1,0 +1,149 @@
+# coding=utf-8
+"""Tests that CRUD rpm content units."""
+import unittest
+from random import choice
+
+from requests.exceptions import HTTPError
+
+from pulp_smash import api, config, utils
+from pulp_smash.pulp3.constants import ARTIFACTS_PATH, REPO_PATH
+from pulp_smash.pulp3.utils import (
+    delete_orphans,
+    gen_repo,
+    get_content,
+    sync,
+)
+
+from pulp_rpm.tests.functional.constants import (
+    RPM_URL,
+    RPM_CONTENT_PATH,
+    RPM_REMOTE_PATH,
+)
+from pulp_rpm.tests.functional.utils import gen_rpm_remote, skip_if
+from pulp_rpm.tests.functional.utils import set_up_module as setUpModule  # noqa:F401
+
+
+# Read the instructions provided below on the steps needed to enable this test.
+@unittest.skip("FIXME: plugin writer action required")
+class ContentUnitTestCase(unittest.TestCase):
+    """CRUD content unit.
+
+    This test targets the following issues:
+
+    * `Pulp #2872 <https://pulp.plan.io/issues/2872>`_
+    * `Pulp Smash #870 <https://github.com/PulpQE/pulp-smash/issues/870>`_
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Create class-wide variable."""
+        cls.cfg = config.get_config()
+        delete_orphans(cls.cfg)
+        cls.content_unit = {}
+        cls.client = api.Client(cls.cfg, api.json_handler)
+        files = {'file': utils.http_get(RPM_URL)}
+        cls.artifact = cls.client.post(ARTIFACTS_PATH, files=files)
+
+    @classmethod
+    def tearDownClass(cls):
+        """Clean class-wide variable."""
+        delete_orphans(cls.cfg)
+
+    def test_01_create_content_unit(self):
+        """Create content unit."""
+        attrs = _gen_content_unit_attrs(self.artifact)
+        self.content_unit.update(self.client.post(RPM_CONTENT_PATH, attrs))
+        for key, val in attrs.items():
+            with self.subTest(key=key):
+                self.assertEqual(self.content_unit[key], val)
+
+    @skip_if(bool, 'content_unit', False)
+    def test_02_read_content_unit(self):
+        """Read a content unit by its href."""
+        content_unit = self.client.get(self.content_unit['_href'])
+        for key, val in self.content_unit.items():
+            with self.subTest(key=key):
+                self.assertEqual(content_unit[key], val)
+
+    @skip_if(bool, 'content_unit', False)
+    def test_02_read_content_units(self):
+        """Read a content unit by its relative_path."""
+        # FIXME: 'relative_path' is an attribute specific to the File plugin. It is only an
+        # example. You should replace this with some other field specific to your content type.
+        page = self.client.get(RPM_CONTENT_PATH, params={
+            'relative_path': self.content_unit['relative_path']
+        })
+        self.assertEqual(len(page['results']), 1)
+        for key, val in self.content_unit.items():
+            with self.subTest(key=key):
+                self.assertEqual(page['results'][0][key], val)
+
+    @skip_if(bool, 'content_unit', False)
+    def test_03_partially_update(self):
+        """Attempt to update a content unit using HTTP PATCH.
+
+        This HTTP method is not supported and a HTTP exception is expected.
+        """
+        attrs = _gen_content_unit_attrs(self.artifact)
+        with self.assertRaises(HTTPError):
+            self.client.patch(self.content_unit['_href'], attrs)
+
+    @skip_if(bool, 'content_unit', False)
+    def test_03_fully_update(self):
+        """Attempt to update a content unit using HTTP PUT.
+
+        This HTTP method is not supported and a HTTP exception is expected.
+        """
+        attrs = _gen_content_unit_attrs(self.artifact)
+        with self.assertRaises(HTTPError):
+            self.client.put(self.content_unit['_href'], attrs)
+
+
+def _gen_content_unit_attrs(artifact):
+    """Generate a dict with content unit attributes.
+
+    :param: artifact: A dict of info about the artifact.
+    :returns: A semi-random dict for use in creating a content unit.
+    """
+    # FIXME: add content specific metadata here
+    return {'artifact': artifact['_href']}
+
+
+@unittest.skip("FIXME: Re-enable once sync support is added")
+class DeleteContentUnitRepoVersionTestCase(unittest.TestCase):
+    """Test whether content unit used by a repo version can be deleted.
+
+    This test targets the following issues:
+
+    * `Pulp #3418 <https://pulp.plan.io/issues/3418>`_
+    * `Pulp Smash #900 <https://github.com/PulpQE/pulp-smash/issues/900>`_
+    """
+
+    def test_all(self):
+        """Test whether content unit used by a repo version can be deleted.
+
+        Do the following:
+
+        1. Sync content to a repository.
+        2. Attempt to delete a content unit present in a repository version.
+           Assert that a HTTP exception was raised.
+        3. Assert that number of content units present on the repository
+           does not change after the attempt to delete one content unit.
+        """
+        cfg = config.get_config()
+        client = api.Client(cfg, api.json_handler)
+
+        body = gen_rpm_remote()
+        remote = client.post(RPM_REMOTE_PATH, body)
+        self.addCleanup(client.delete, remote['_href'])
+
+        repo = client.post(REPO_PATH, gen_repo())
+        self.addCleanup(client.delete, repo['_href'])
+
+        sync(cfg, remote, repo)
+
+        repo = client.get(repo['_href'])
+        content = get_content(repo)
+        with self.assertRaises(HTTPError):
+            client.delete(choice(content)['_href'])
+        self.assertEqual(len(content), len(get_content(repo)))

--- a/pulp_rpm/tests/functional/api/test_crud_publishers.py
+++ b/pulp_rpm/tests/functional/api/test_crud_publishers.py
@@ -1,0 +1,99 @@
+# coding=utf-8
+"""Tests that CRUD content_unit publishers."""
+import unittest
+
+from requests.exceptions import HTTPError
+
+from pulp_smash import api, config
+from pulp_smash.pulp3.constants import REPO_PATH
+from pulp_smash.pulp3.utils import gen_repo
+
+from pulp_rpm.tests.functional.constants import RPM_PUBLISHER_PATH
+from pulp_rpm.tests.functional.utils import gen_rpm_publisher, skip_if
+from pulp_rpm.tests.functional.utils import set_up_module as setUpModule  # noqa:F401
+
+
+class CRUDPublishersTestCase(unittest.TestCase):
+    """CRUD publishers."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create class-wide variables.
+
+        In order to create a publisher a repository has to be created first.
+        """
+        cls.cfg = config.get_config()
+        cls.client = api.Client(cls.cfg, api.json_handler)
+        cls.publisher = {}
+        cls.repo = cls.client.post(REPO_PATH, gen_repo())
+
+    @classmethod
+    def tearDownClass(cls):
+        """Clean class-wide variable."""
+        cls.client.delete(cls.repo['_href'])
+
+    def test_01_create_publisher(self):
+        """Create a publisher."""
+        body = gen_rpm_publisher()
+        type(self).publisher = self.client.post(RPM_PUBLISHER_PATH, body)
+        for key, val in body.items():
+            with self.subTest(key=key):
+                self.assertEqual(self.publisher[key], val)
+
+    @skip_if(bool, 'publisher', False)
+    def test_02_create_same_name(self):
+        """Try to create a second publisher with an identical name.
+
+        See: `Pulp Smash #1055
+        <https://github.com/PulpQE/pulp-smash/issues/1055>`_.
+        """
+        body = gen_rpm_publisher()
+        body['name'] = self.publisher['name']
+        with self.assertRaises(HTTPError):
+            self.client.post(RPM_PUBLISHER_PATH, body)
+
+    @skip_if(bool, 'publisher', False)
+    def test_02_read_publisher(self):
+        """Read a publisher by its href."""
+        publisher = self.client.get(self.publisher['_href'])
+        for key, val in self.publisher.items():
+            with self.subTest(key=key):
+                self.assertEqual(publisher[key], val)
+
+    @skip_if(bool, 'publisher', False)
+    def test_02_read_publishers(self):
+        """Read a publisher by its name."""
+        page = self.client.get(RPM_PUBLISHER_PATH, params={
+            'name': self.publisher['name']
+        })
+        self.assertEqual(len(page['results']), 1)
+        for key, val in self.publisher.items():
+            with self.subTest(key=key):
+                self.assertEqual(page['results'][0][key], val)
+
+    @skip_if(bool, 'publisher', False)
+    def test_03_partially_update(self):
+        """Update a publisher using HTTP PATCH."""
+        body = gen_rpm_publisher()
+        self.client.patch(self.publisher['_href'], body)
+        type(self).publisher = self.client.get(self.publisher['_href'])
+        for key, val in body.items():
+            with self.subTest(key=key):
+                self.assertEqual(self.publisher[key], val)
+
+    @skip_if(bool, 'publisher', False)
+    def test_04_fully_update(self):
+        """Update a publisher using HTTP PUT."""
+        body = gen_rpm_publisher()
+        self.client.put(self.publisher['_href'], body)
+        type(self).publisher = self.client.get(self.publisher['_href'])
+        for key, val in body.items():
+            with self.subTest(key=key):
+                self.assertEqual(self.publisher[key], val)
+
+    @skip_if(bool, 'publisher', False)
+    def test_05_delete(self):
+        """Delete a publisher."""
+        self.client.delete(self.publisher['_href'])
+        with self.assertRaises(HTTPError):
+            self.client.get(self.publisher['_href'])

--- a/pulp_rpm/tests/functional/api/test_crud_remotes.py
+++ b/pulp_rpm/tests/functional/api/test_crud_remotes.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-"""Tests that CRUD remotes."""
+"""Tests that CRUD rpm remotes."""
 from random import choice
 import unittest
 
@@ -7,14 +7,11 @@ from requests.exceptions import HTTPError
 
 from pulp_smash import api, config, utils
 from pulp_smash.pulp3.constants import REPO_PATH
-from pulp_smash.pulp3.utils import gen_remote, gen_repo
+from pulp_smash.pulp3.utils import gen_repo
 
-from pulp_rpm.tests.functional.constants import (
-    RPM_SIGNED_FIXTURE_URL,
-    RPM_REMOTE_PATH
-)
+from pulp_rpm.tests.functional.constants import RPM_REMOTE_PATH
+from pulp_rpm.tests.functional.utils import skip_if, gen_rpm_remote
 from pulp_rpm.tests.functional.utils import set_up_module as setUpModule  # noqa:F401
-from pulp_rpm.tests.functional.utils import skip_if
 
 
 class CRUDRemotesTestCase(unittest.TestCase):
@@ -24,7 +21,7 @@ class CRUDRemotesTestCase(unittest.TestCase):
     def setUpClass(cls):
         """Create class-wide variables.
 
-        In order to create an remote a repository has to be created first.
+        In order to create a remote a repository has to be created first.
         """
         cls.cfg = config.get_config()
         cls.client = api.Client(cls.cfg, api.json_handler)
@@ -53,14 +50,14 @@ class CRUDRemotesTestCase(unittest.TestCase):
         See: `Pulp Smash #1055
         <https://github.com/PulpQE/pulp-smash/issues/1055>`_.
         """
-        body = gen_remote(RPM_SIGNED_FIXTURE_URL)
+        body = gen_rpm_remote()
         body['name'] = self.remote['name']
         with self.assertRaises(HTTPError):
             self.client.post(RPM_REMOTE_PATH, body)
 
     @skip_if(bool, 'remote', False)
     def test_02_read_remote(self):
-        """Read an remote by its href."""
+        """Read a remote by its href."""
         remote = self.client.get(self.remote['_href'])
         for key, val in self.remote.items():
             with self.subTest(key=key):
@@ -68,7 +65,7 @@ class CRUDRemotesTestCase(unittest.TestCase):
 
     @skip_if(bool, 'remote', False)
     def test_02_read_remotes(self):
-        """Read an remote by its name."""
+        """Read a remote by its name."""
         page = self.client.get(RPM_REMOTE_PATH, params={
             'name': self.remote['name']
         })
@@ -79,7 +76,7 @@ class CRUDRemotesTestCase(unittest.TestCase):
 
     @skip_if(bool, 'remote', False)
     def test_03_partially_update(self):
-        """Update an remote using HTTP PATCH."""
+        """Update a remote using HTTP PATCH."""
         body = _gen_verbose_remote()
         self.client.patch(self.remote['_href'], body)
         for key in ('username', 'password'):
@@ -91,7 +88,7 @@ class CRUDRemotesTestCase(unittest.TestCase):
 
     @skip_if(bool, 'remote', False)
     def test_04_fully_update(self):
-        """Update an remote using HTTP PUT."""
+        """Update a remote using HTTP PUT."""
         body = _gen_verbose_remote()
         self.client.put(self.remote['_href'], body)
         for key in ('username', 'password'):
@@ -103,7 +100,7 @@ class CRUDRemotesTestCase(unittest.TestCase):
 
     @skip_if(bool, 'remote', False)
     def test_05_delete(self):
-        """Delete an remote."""
+        """Delete a remote."""
         self.client.delete(self.remote['_href'])
         with self.assertRaises(HTTPError):
             self.client.get(self.remote['_href'])
@@ -120,14 +117,14 @@ class CreateRemoteNoURLTestCase(unittest.TestCase):
         * `Pulp #3395 <https://pulp.plan.io/issues/3395>`_
         * `Pulp Smash #984 <https://github.com/PulpQE/pulp-smash/issues/984>`_
         """
-        body = gen_remote(utils.uuid4())
+        body = gen_rpm_remote()
         del body['url']
         with self.assertRaises(HTTPError):
             api.Client(config.get_config()).post(RPM_REMOTE_PATH, body)
 
 
 def _gen_verbose_remote():
-    """Return a semi-random dict for use in defining an remote.
+    """Return a semi-random dict for use in defining a remote.
 
     For most tests, it's desirable to create remotes with as few attributes
     as possible, so that the tests can specifically target and attempt to break
@@ -136,7 +133,7 @@ def _gen_verbose_remote():
 
     Note that 'username' and 'password' are write-only attributes.
     """
-    attrs = gen_remote(RPM_SIGNED_FIXTURE_URL)
+    attrs = gen_rpm_remote()
     attrs.update({
         'password': utils.uuid4(),
         'username': utils.uuid4(),

--- a/pulp_rpm/tests/functional/api/test_download_content.py
+++ b/pulp_rpm/tests/functional/api/test_download_content.py
@@ -1,0 +1,102 @@
+# coding=utf-8
+"""Tests that verify download of content served by Pulp."""
+import hashlib
+import unittest
+from random import choice
+from urllib.parse import urljoin
+
+from pulp_smash import api, config, utils
+from pulp_smash.pulp3.constants import DISTRIBUTION_PATH, REPO_PATH
+from pulp_smash.pulp3.utils import (
+    gen_distribution,
+    gen_repo,
+    publish,
+    sync,
+)
+
+from pulp_rpm.tests.functional.utils import (
+    gen_rpm_remote,
+    gen_rpm_publisher,
+    get_rpm_content_unit_paths,
+)
+from pulp_rpm.tests.functional.constants import (
+    RPM_FIXTURE_URL,
+    RPM_REMOTE_PATH,
+    RPM_PUBLISHER_PATH,
+)
+from pulp_rpm.tests.functional.utils import set_up_module as setUpModule  # noqa:F401
+
+
+# Define utils.get_rpm_content_unit_paths() before enabling this test
+@unittest.skip("FIXME: plugin writer action required")
+class DownloadContentTestCase(unittest.TestCase):
+    """Verify whether content served by pulp can be downloaded."""
+
+    def test_all(self):
+        """Verify whether content served by pulp can be downloaded.
+
+        The process of publishing content is more involved in Pulp 3 than it
+        was under Pulp 2. Given a repository, the process is as follows:
+
+        1. Create a publication from the repository. (The latest repository
+           version is selected if no version is specified.) A publication is a
+           repository version plus metadata.
+        2. Create a distribution from the publication. The distribution defines
+           at which URLs a publication is available, e.g.
+           ``http://example.com/content/foo/`` and
+           ``http://example.com/content/bar/``.
+
+        Do the following:
+
+        1. Create, populate, publish, and distribute a repository.
+        2. Select a random content unit in the distribution. Download that
+           content unit from Pulp, and verify that the content unit has the
+           same checksum when fetched directly from Pulp-Fixtures.
+
+        This test targets the following issues:
+
+        * `Pulp #2895 <https://pulp.plan.io/issues/2895>`_
+        * `Pulp Smash #872 <https://github.com/PulpQE/pulp-smash/issues/872>`_
+        """
+        cfg = config.get_config()
+        client = api.Client(cfg, api.json_handler)
+
+        repo = client.post(REPO_PATH, gen_repo())
+        self.addCleanup(client.delete, repo['_href'])
+
+        body = gen_rpm_remote()
+        remote = client.post(RPM_REMOTE_PATH, body)
+        self.addCleanup(client.delete, remote['_href'])
+
+        sync(cfg, remote, repo)
+        repo = client.get(repo['_href'])
+
+        # Create a publisher.
+        publisher = client.post(RPM_PUBLISHER_PATH, gen_rpm_publisher())
+        self.addCleanup(client.delete, publisher['_href'])
+
+        # Create a publication.
+        publication = publish(cfg, publisher, repo)
+        self.addCleanup(client.delete, publication['_href'])
+
+        # Create a distribution.
+        body = gen_distribution()
+        body['publication'] = publication['_href']
+        distribution = client.post(DISTRIBUTION_PATH, body)
+        self.addCleanup(client.delete, distribution['_href'])
+
+        # Pick a content unit, and download it from both Pulp Fixtures…
+        unit_path = choice(get_rpm_content_unit_paths(repo))
+        fixtures_hash = hashlib.sha256(
+            utils.http_get(urljoin(RPM_FIXTURE_URL, unit_path))
+        ).hexdigest()
+
+        # …and Pulp.
+        client.response_handler = api.safe_handler
+
+        unit_url = cfg.get_hosts('api')[0].roles['api']['scheme']
+        unit_url += '://' + distribution['base_url'] + '/'
+        unit_url = urljoin(unit_url, unit_path)
+
+        pulp_hash = hashlib.sha256(client.get(unit_url).content).hexdigest()
+        self.assertEqual(fixtures_hash, pulp_hash)

--- a/pulp_rpm/tests/functional/api/test_publish.py
+++ b/pulp_rpm/tests/functional/api/test_publish.py
@@ -1,0 +1,97 @@
+# coding=utf-8
+"""Tests that publish rpm plugin repositories."""
+import unittest
+from random import choice
+from urllib.parse import urljoin
+
+from requests.exceptions import HTTPError
+
+from pulp_smash import api, config
+from pulp_smash.pulp3.constants import REPO_PATH
+from pulp_smash.pulp3.utils import (
+    gen_repo,
+    get_versions,
+    publish,
+    sync,
+)
+
+from pulp_rpm.tests.functional.utils import (
+    gen_rpm_remote,
+    gen_rpm_publisher,
+)
+from pulp_rpm.tests.functional.constants import (
+    RPM_CONTENT_PATH,
+    RPM_REMOTE_PATH,
+    RPM_PUBLISHER_PATH,
+)
+from pulp_rpm.tests.functional.utils import set_up_module as setUpModule  # noqa:F401
+
+
+@unittest.skip("FIXME: Implement publish support")
+class PublishAnyRepoVersionTestCase(unittest.TestCase):
+    """Test whether a particular repository version can be published.
+
+    This test targets the following issues:
+
+    * `Pulp #3324 <https://pulp.plan.io/issues/3324>`_
+    * `Pulp Smash #897 <https://github.com/PulpQE/pulp-smash/issues/897>`_
+    """
+
+    def test_all(self):
+        """Test whether a particular repository version can be published.
+
+        1. Create a repository with at least 2 repository versions.
+        2. Create a publication by supplying the latest ``repository_version``.
+        3. Assert that the publication ``repository_version`` attribute points
+           to the latest repository version.
+        4. Create a publication by supplying the non-latest ``repository_version``.
+        5. Assert that the publication ``repository_version`` attribute points
+           to the supplied repository version.
+        6. Assert that an exception is raised when providing two different
+           repository versions to be published at same time.
+        """
+        cfg = config.get_config()
+        client = api.Client(cfg, api.json_handler)
+
+        body = gen_rpm_remote()
+        remote = client.post(RPM_REMOTE_PATH, body)
+        self.addCleanup(client.delete, remote['_href'])
+
+        repo = client.post(REPO_PATH, gen_repo())
+        self.addCleanup(client.delete, repo['_href'])
+
+        sync(cfg, remote, repo)
+
+        publisher = client.post(RPM_PUBLISHER_PATH, gen_rpm_publisher())
+        self.addCleanup(client.delete, publisher['_href'])
+
+        # Step 1
+        repo = client.post(REPO_PATH, gen_repo())
+        self.addCleanup(client.delete, repo['_href'])
+        for rpm_content in client.get(RPM_CONTENT_PATH)['results']:
+            client.post(
+                repo['_versions_href'],
+                {'add_content_units': [rpm_content['_href']]}
+            )
+        version_hrefs = tuple(ver['_href'] for ver in get_versions(repo))
+        non_latest = choice(version_hrefs[:-1])
+
+        # Step 2
+        publication = publish(cfg, publisher, repo)
+
+        # Step 3
+        self.assertEqual(publication['repository_version'], version_hrefs[-1])
+
+        # Step 4
+        publication = publish(cfg, publisher, repo, non_latest)
+
+        # Step 5
+        self.assertEqual(publication['repository_version'], non_latest)
+
+        # Step 6
+        with self.assertRaises(HTTPError):
+            body = {
+                'repository': repo['_href'],
+                'repository_version': non_latest
+            }
+            client.post(urljoin(publisher['_href'], 'publish/'), body)

--- a/pulp_rpm/tests/functional/api/test_sync.py
+++ b/pulp_rpm/tests/functional/api/test_sync.py
@@ -1,0 +1,74 @@
+# coding=utf-8
+"""Tests that sync rpm plugin repositories."""
+import unittest
+
+from pulp_smash import api, config
+from pulp_smash.pulp3.constants import REPO_PATH
+from pulp_smash.pulp3.utils import (
+    gen_repo,
+    get_content,
+    get_added_content,
+    sync,
+)
+
+from pulp_rpm.tests.functional.constants import (
+    RPM_FIXTURE_COUNT,
+    RPM_REMOTE_PATH
+)
+from pulp_rpm.tests.functional.utils import gen_rpm_remote
+from pulp_rpm.tests.functional.utils import set_up_module as setUpModule  # noqa:F401
+
+
+@unittest.skip("FIXME: Enable after adding sync support")
+class BasicSyncRpmRepoTestCase(unittest.TestCase):
+    """Sync repositories with the rpm plugin."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create class-wide variables."""
+        cls.cfg = config.get_config()
+
+    def test_sync(self):
+        """Sync repositories with the rpm plugin.
+
+        In order to sync a repository a remote has to be associated within
+        this repository. When a repository is created this version field is set
+        as None. After a sync the repository version is updated.
+
+        Do the following:
+
+        1. Create a repository, and a remote.
+        2. Assert that repository version is None.
+        3. Sync the remote.
+        4. Assert that repository version is not None.
+        5. Assert that the correct number of units were added and are present in the repo.
+        6. Sync the remote one more time.
+        7. Assert that repository version is different from the previous one.
+        8. Assert that the same number of are present and that no units were added.
+        """
+        client = api.Client(self.cfg, api.json_handler)
+
+        repo = client.post(REPO_PATH, gen_repo())
+        self.addCleanup(client.delete, repo['_href'])
+
+        body = gen_rpm_remote()
+        remote = client.post(RPM_REMOTE_PATH, body)
+        self.addCleanup(client.delete, remote['_href'])
+
+        # Sync the repository.
+        self.assertIsNone(repo['_latest_version_href'])
+        sync(self.cfg, remote, repo)
+        repo = client.get(repo['_href'])
+
+        self.assertIsNotNone(repo['_latest_version_href'])
+        self.assertEqual(len(get_content(repo)), RPM_FIXTURE_COUNT)
+        self.assertEqual(len(get_added_content(repo)), RPM_FIXTURE_COUNT)
+
+        # Sync the repository again.
+        latest_version_href = repo['_latest_version_href']
+        sync(self.cfg, remote, repo)
+        repo = client.get(repo['_href'])
+
+        self.assertNotEqual(latest_version_href, repo['_latest_version_href'])
+        self.assertEqual(len(get_content(repo)), RPM_FIXTURE_COUNT)
+        self.assertEqual(len(get_added_content(repo)), 0)

--- a/pulp_rpm/tests/functional/constants.py
+++ b/pulp_rpm/tests/functional/constants.py
@@ -2,19 +2,28 @@
 from types import MappingProxyType
 from urllib.parse import urljoin
 
-from pulp_smash.constants import PULP_FIXTURES_BASE_URL  # noqa:F401
+from pulp_smash.constants import PULP_FIXTURES_BASE_URL
 from pulp_smash.pulp3.constants import (
     BASE_PUBLISHER_PATH,
     BASE_REMOTE_PATH,
     CONTENT_PATH
 )
 
+
 RPM_CONTENT_PATH = urljoin(CONTENT_PATH, 'rpm/rpms/')
+SRPM_CONTENT_PATH = urljoin(CONTENT_PATH, 'rpm/srpms/')
 
 RPM_REMOTE_PATH = urljoin(BASE_REMOTE_PATH, 'rpm/')
-
 RPM_PUBLISHER_PATH = urljoin(BASE_PUBLISHER_PATH, 'rpm/')
 
+
+RPM_FIXTURE_URL = urljoin(PULP_FIXTURES_BASE_URL, 'rpm/')
+RPM_FIXTURE_COUNT = 35
+RPM_URL = urljoin(RPM_FIXTURE_URL, 'bear-4.1-1.noarch.rpm')
+
+SRPM_FIXTURE_URL = urljoin(PULP_FIXTURES_BASE_URL, 'srpm/')
+SRPM_FIXTURE_COUNT = 3
+SRPM_URL = urljoin(RPM_FIXTURE_URL, 'test-srpm01-1.0-1.src.rpm')
 
 RPM_DATA = MappingProxyType({
     'name': 'bear',

--- a/pulp_rpm/tests/functional/utils.py
+++ b/pulp_rpm/tests/functional/utils.py
@@ -1,12 +1,26 @@
 # coding=utf-8
-"""Utilities for tests for the file plugin."""
+"""Utilities for tests for the rpm plugin."""
 from functools import partial
 from unittest import SkipTest
 
-from pulp_smash import selectors
+from pulp_smash import api, selectors
+from pulp_smash.pulp3.constants import (
+    REPO_PATH
+)
 from pulp_smash.pulp3.utils import (
+    gen_remote,
+    gen_repo,
+    gen_publisher,
+    get_content,
     require_pulp_3,
     require_pulp_plugins,
+    sync
+)
+
+from pulp_rpm.tests.functional.constants import (
+    RPM_CONTENT_PATH,
+    RPM_FIXTURE_URL,
+    RPM_REMOTE_PATH,
 )
 
 
@@ -14,6 +28,66 @@ def set_up_module():
     """Skip tests Pulp 3 isn't under test or if pulp_rpm isn't installed."""
     require_pulp_3(SkipTest)
     require_pulp_plugins({'pulp_rpm'}, SkipTest)
+
+
+def populate_pulp(cfg, url=RPM_FIXTURE_URL):
+    """Add rpm contents to Pulp.
+
+    :param pulp_smash.config.PulpSmashConfig: Information about a Pulp application.
+    :param url: The rpm repository URL. Defaults to
+        :data:`pulp_smash.constants.RPM_FIXTURE_URL`
+    :returns: A list of dicts, where each dict describes one file content in Pulp.
+    """
+    client = api.Client(cfg, api.json_handler)
+    remote = {}
+    repo = {}
+    try:
+        remote.update(client.post(RPM_REMOTE_PATH, gen_rpm_remote(url)))
+        repo.update(client.post(REPO_PATH, gen_repo()))
+        sync(cfg, remote, repo)
+    finally:
+        if remote:
+            client.delete(remote['_href'])
+        if repo:
+            client.delete(repo['_href'])
+    return client.get(RPM_CONTENT_PATH)['results']
+
+
+def gen_rpm_remote(**kwargs):
+    """Return a semi-random dict for use in creating a rpm Remote.
+
+    :param url: The URL of an external content source.
+    """
+    remote = gen_remote(RPM_FIXTURE_URL)
+    rpm_extra_fields = {
+        **kwargs
+    }
+    remote.update(rpm_extra_fields)
+    return remote
+
+
+def gen_rpm_publisher(**kwargs):
+    """Return a semi-random dict for use in creating a Remote.
+
+    :param url: The URL of an external content source.
+    """
+    publisher = gen_publisher()
+    rpm_extra_fields = {
+        **kwargs
+    }
+    publisher.update(rpm_extra_fields)
+    return publisher
+
+
+# FIXME: replace this boilerplate with a real implementation
+def get_rpm_content_unit_paths(repo):
+    """Return the relative path of content units present in a rpm repository.
+
+    :param repo: A dict of information about the repository.
+    :returns: A list with the paths of units present in a given repository.
+    """
+    # The "relative_path" is actually a file path and name
+    return [content_unit['relative_path'] for content_unit in get_content(repo)]
 
 
 skip_if = partial(selectors.skip_if, exc=SkipTest)


### PR DESCRIPTION
Add boilerplate for all the smash tests but leave them disabled for now.
CRUD smash tests are enabled but not the sync/publish/content download ones.