### PR TITLE
Get Sync Working with Erratum!

### DIFF
--- a/pulp_rpm/app/models.py
+++ b/pulp_rpm/app/models.py
@@ -327,9 +327,11 @@ class UpdateRecord(Content):
     digest = models.TextField()
 
     class Meta:
-        unique_together = ()
-        # TODO: Find some way to enforce uniqueness per-repository
-        # make a hash of the natural key, store the hash?
+        unique_together = (
+            'errata_id', 'updated_date', 'description', 'issued_date', 'fromstr', 'status', 'title',
+            'summary', 'version', 'update_type', 'severity', 'solution', 'release', 'rights',
+            'pushcount', 'digest'
+        )
 
     @classmethod
     def createrepo_to_dict(cls, update):
@@ -345,9 +347,9 @@ class UpdateRecord(Content):
         """
         return {
             'errata_id': getattr(update, CREATEREPO_UPDATE_RECORD_ATTRS.ID),
-            'updated_date': getattr(update, CREATEREPO_UPDATE_RECORD_ATTRS.UPDATED_DATE) or '',
+            'updated_date': str(getattr(update, CREATEREPO_UPDATE_RECORD_ATTRS.UPDATED_DATE)),
             'description': getattr(update, CREATEREPO_UPDATE_RECORD_ATTRS.DESCRIPTION) or '',
-            'issued_date': getattr(update, CREATEREPO_UPDATE_RECORD_ATTRS.ISSUED_DATE) or '',
+            'issued_date': str(getattr(update, CREATEREPO_UPDATE_RECORD_ATTRS.ISSUED_DATE)) or '',
             'fromstr': getattr(update, CREATEREPO_UPDATE_RECORD_ATTRS.FROMSTR) or '',
             'status': getattr(update, CREATEREPO_UPDATE_RECORD_ATTRS.STATUS) or '',
             'title': getattr(update, CREATEREPO_UPDATE_RECORD_ATTRS.TITLE) or '',
@@ -447,7 +449,7 @@ class UpdateCollectionPackage(models.Model):
     epoch = models.TextField(blank=True)
     filename = models.TextField(blank=True)
     name = models.TextField(blank=True)
-    reboot_suggested = models.BooleanField(blank=True)
+    reboot_suggested = models.BooleanField(default=False)
     release = models.TextField(blank=True)
     src = models.TextField(blank=True)
     sum = models.TextField(blank=True)
@@ -474,7 +476,7 @@ class UpdateCollectionPackage(models.Model):
             'epoch': getattr(package, CREATEREPO_UPDATE_COLLECTION_PACKAGE_ATTRS.EPOCH) or '0',
             'filename': getattr(package, CREATEREPO_UPDATE_COLLECTION_PACKAGE_ATTRS.FILENAME) or '',
             'name': getattr(package, CREATEREPO_UPDATE_COLLECTION_PACKAGE_ATTRS.NAME) or '',
-            'reboot_suggested': getattr(package, CREATEREPO_UPDATE_COLLECTION_PACKAGE_ATTRS.REBOOT_SUGGESTED) or '',  # noqa
+            'reboot_suggested': getattr(package, CREATEREPO_UPDATE_COLLECTION_PACKAGE_ATTRS.REBOOT_SUGGESTED),  # noqa
             'release': getattr(package, CREATEREPO_UPDATE_COLLECTION_PACKAGE_ATTRS.RELEASE) or '',
             'src': getattr(package, CREATEREPO_UPDATE_COLLECTION_PACKAGE_ATTRS.SRC) or '',
             'sum': getattr(package, CREATEREPO_UPDATE_COLLECTION_PACKAGE_ATTRS.SUM) or '',

--- a/pulp_rpm/app/serializers.py
+++ b/pulp_rpm/app/serializers.py
@@ -1,6 +1,6 @@
 from pulpcore.plugin.serializers import ContentSerializer, RemoteSerializer, PublisherSerializer
 
-from pulp_rpm.app.models import Package, RpmRemote, RpmPublisher
+from pulp_rpm.app.models import Package, RpmRemote, RpmPublisher, UpdateRecord
 
 
 class PackageSerializer(ContentSerializer):
@@ -9,16 +9,6 @@ class PackageSerializer(ContentSerializer):
 
     Add serializers for the new fields defined in Package and add those fields to the Meta class
     keeping fields from the parent class as well. Provide help_text.
-
-    For example::
-
-    field1 = serializers.TextField(help_text="field1 description")
-    field2 = serializers.IntegerField(help_text="field2 description")
-    field3 = serializers.CharField(help_text="field3 description")
-
-    class Meta:
-        fields = ContentSerializer.Meta.fields + ('field1', 'field2', 'field3')
-        model = Package
     """
 
     class Meta:
@@ -62,3 +52,16 @@ class RpmPublisherSerializer(PublisherSerializer):
     class Meta:
         fields = PublisherSerializer.Meta.fields
         model = RpmPublisher
+
+
+class UpdateRecordSerializer(ContentSerializer):
+    """
+    A Serializer for UpdateRecord.
+
+    Add serializers for the new fields defined in UpdateRecord and add those fields to the Meta
+    class keeping fields from the parent class as well. Provide help_text.
+    """
+
+    class Meta:
+        fields = ContentSerializer.Meta.fields
+        model = UpdateRecord

--- a/pulp_rpm/app/viewsets.py
+++ b/pulp_rpm/app/viewsets.py
@@ -18,11 +18,12 @@ from pulpcore.plugin.viewsets import (
 )
 
 from pulp_rpm.app import tasks
-from pulp_rpm.app.models import Package, RpmRemote, RpmPublisher
+from pulp_rpm.app.models import Package, RpmRemote, RpmPublisher, UpdateRecord
 from pulp_rpm.app.serializers import (
     PackageSerializer,
     RpmRemoteSerializer,
-    RpmPublisherSerializer
+    RpmPublisherSerializer,
+    UpdateRecordSerializer
 )
 
 
@@ -119,3 +120,19 @@ class RpmPublisherViewSet(PublisherViewSet):
             }
         )
         return OperationPostponedResponse(result, request)
+
+
+class UpdateRecordViewSet(ContentViewSet):
+    """
+    A ViewSet for UpdateRecord.
+
+    Define endpoint name which will appear in the API endpoint for this content type.
+    For example::
+        http://pulp.example.com/pulp/api/v3/content/rpm/errata/
+
+    Also specify queryset and serializer for UpdateRecord.
+    """
+
+    endpoint_name = 'rpm/errata'
+    queryset = UpdateRecord.objects.all()
+    serializer_class = UpdateRecordSerializer

--- a/pulp_rpm/tests/functional/constants.py
+++ b/pulp_rpm/tests/functional/constants.py
@@ -18,7 +18,7 @@ RPM_PUBLISHER_PATH = urljoin(BASE_PUBLISHER_PATH, 'rpm/')
 
 
 RPM_FIXTURE_URL = urljoin(PULP_FIXTURES_BASE_URL, 'rpm/')
-RPM_FIXTURE_COUNT = 35
+RPM_FIXTURE_COUNT = 39  # 35 Packages + 4 UpdateRecord units
 RPM_URL = urljoin(RPM_FIXTURE_URL, 'bear-4.1-1.noarch.rpm')
 
 SRPM_FIXTURE_URL = urljoin(PULP_FIXTURES_BASE_URL, 'srpm/')


### PR DESCRIPTION
- Adds a new custom stage that saves UpdateCollection and
  UpdateCollectionPackage objects in bulk
- Uses a new custom pipeline instead of DeclarativeVersion. This is
  temporary until a new feature is added to DeclarativeVersion to
  allow for stage injection.
- Adds a viewset and serializer for Erratum. It required one or it would
  raise an exception that it couldn't serialize the output.
- updates the smash count since 4 Erratum units are now being correctly
  included
- refactors closure style coroutines in favor of classmethods

https://pulp.plan.io/issues/3933
closes #3933