### PR TITLE
Add a test for mutated errata

### DIFF
--- a/pulp_rpm/tests/functional/api/test_crud_content_unit.py
+++ b/pulp_rpm/tests/functional/api/test_crud_content_unit.py
@@ -15,7 +15,7 @@ from pulp_smash.pulp3.utils import (
 )
 
 from pulp_rpm.tests.functional.constants import (
-    RPM_URL,
+    RPM_SIGNED_URL,
     RPM_CONTENT_PATH,
     RPM_REMOTE_PATH,
 )
@@ -41,7 +41,7 @@ class ContentUnitTestCase(unittest.TestCase):
         delete_orphans(cls.cfg)
         cls.content_unit = {}
         cls.client = api.Client(cls.cfg, api.json_handler)
-        files = {'file': utils.http_get(RPM_URL)}
+        files = {'file': utils.http_get(RPM_SIGNED_URL)}
         cls.artifact = cls.client.post(ARTIFACTS_PATH, files=files)
 
     @classmethod

--- a/pulp_rpm/tests/functional/api/test_crud_remotes.py
+++ b/pulp_rpm/tests/functional/api/test_crud_remotes.py
@@ -10,7 +10,7 @@ from pulp_smash.pulp3.constants import REPO_PATH
 from pulp_smash.pulp3.utils import gen_repo
 
 from pulp_rpm.tests.functional.constants import RPM_REMOTE_PATH
-from pulp_rpm.tests.functional.utils import skip_if, gen_rpm_remote
+from pulp_rpm.tests.functional.utils import gen_rpm_remote, skip_if
 from pulp_rpm.tests.functional.utils import set_up_module as setUpModule  # noqa:F401
 
 

--- a/pulp_rpm/tests/functional/api/test_download_content.py
+++ b/pulp_rpm/tests/functional/api/test_download_content.py
@@ -20,7 +20,7 @@ from pulp_rpm.tests.functional.utils import (
     get_rpm_content_unit_paths,
 )
 from pulp_rpm.tests.functional.constants import (
-    RPM_FIXTURE_URL,
+    RPM_SIGNED_FIXTURE_URL,
     RPM_REMOTE_PATH,
     RPM_PUBLISHER_PATH,
 )
@@ -88,7 +88,7 @@ class DownloadContentTestCase(unittest.TestCase):
         # Pick a content unit, and download it from both Pulp Fixtures…
         unit_path = choice(get_rpm_content_unit_paths(repo))
         fixtures_hash = hashlib.sha256(
-            utils.http_get(urljoin(RPM_FIXTURE_URL, unit_path))
+            utils.http_get(urljoin(RPM_SIGNED_FIXTURE_URL, unit_path))
         ).hexdigest()
 
         # …and Pulp.

--- a/pulp_rpm/tests/functional/api/test_sync.py
+++ b/pulp_rpm/tests/functional/api/test_sync.py
@@ -6,14 +6,19 @@ from pulp_smash import api, config
 from pulp_smash.pulp3.constants import REPO_PATH
 from pulp_smash.pulp3.utils import (
     gen_repo,
-    get_content,
     get_added_content,
+    get_content,
+    get_content_summary,
     sync,
 )
 
 from pulp_rpm.tests.functional.constants import (
     RPM_FIXTURE_COUNT,
-    RPM_REMOTE_PATH
+    RPM_FIXTURE_CONTENT_SUMMARY,
+    RPM_REMOTE_PATH,
+    RPM_UNSIGNED_FIXTURE_URL,
+    RPM_UPDATED_UPDATEINFO_FIXTURE_URL,
+    RPM_UPDATERECORD_ID,
 )
 from pulp_rpm.tests.functional.utils import gen_rpm_remote
 from pulp_rpm.tests.functional.utils import set_up_module as setUpModule  # noqa:F401
@@ -36,7 +41,7 @@ class BasicSyncRpmRepoTestCase(unittest.TestCase):
 
         Do the following:
 
-        1. Create a repository, and a remote.
+        1. Create a repository and a remote.
         2. Assert that repository version is None.
         3. Sync the remote.
         4. Assert that repository version is not None.
@@ -50,6 +55,7 @@ class BasicSyncRpmRepoTestCase(unittest.TestCase):
         repo = client.post(REPO_PATH, gen_repo())
         self.addCleanup(client.delete, repo['_href'])
 
+        # Create a remote with the standard test fixture url.
         body = gen_rpm_remote()
         remote = client.post(RPM_REMOTE_PATH, body)
         self.addCleanup(client.delete, remote['_href'])
@@ -59,8 +65,9 @@ class BasicSyncRpmRepoTestCase(unittest.TestCase):
         sync(self.cfg, remote, repo)
         repo = client.get(repo['_href'])
 
+        # Check that we have the correct content counts.
         self.assertIsNotNone(repo['_latest_version_href'])
-        self.assertEqual(len(get_content(repo)), RPM_FIXTURE_COUNT)
+        self.assertDictEqual(get_content_summary(repo), RPM_FIXTURE_CONTENT_SUMMARY)
         self.assertEqual(len(get_added_content(repo)), RPM_FIXTURE_COUNT)
 
         # Sync the repository again.
@@ -68,6 +75,81 @@ class BasicSyncRpmRepoTestCase(unittest.TestCase):
         sync(self.cfg, remote, repo)
         repo = client.get(repo['_href'])
 
+        # Check that nothing has changed since the last sync.
         self.assertNotEqual(latest_version_href, repo['_latest_version_href'])
-        self.assertEqual(len(get_content(repo)), RPM_FIXTURE_COUNT)
+        self.assertDictEqual(get_content_summary(repo), RPM_FIXTURE_CONTENT_SUMMARY)
         self.assertEqual(len(get_added_content(repo)), 0)
+
+
+@unittest.skip("FIXME: Enable this test after we can throw out duplicate Errata")
+class SyncMutatedUpdateRecordTestCase(unittest.TestCase):
+    """Sync a new Erratum with the same ID."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create class-wide variables."""
+        cls.cfg = config.get_config()
+
+    def test_all(self):
+        """Sync repositories with the rpm plugin.
+
+        In order to sync a repository a remote has to be associated within
+        this repository. When a repository is created this version field is set
+        as None. After a sync the repository version is updated.
+
+        Do the following:
+
+        1. Create a repository and a remote.
+        2. Sync the remote.
+        3. Assert that the content summary matches what is expected.
+        4. Create a new remote w/ using fixture containing updated errata (updaterecords with the
+           ID as the existing updaterecord content, but different metadata)
+        5. Sync the remote again.
+        6. Assert that repository version is different from the previous one but has the same
+           content summary.
+        7. Assert that the updaterecords have changed since the last sync.
+        """
+        client = api.Client(self.cfg, api.json_handler)
+
+        repo = client.post(REPO_PATH, gen_repo())
+        self.addCleanup(client.delete, repo['_href'])
+
+        # Create a remote with the unsigned RPM fixture url.
+        # We need to use the unsigned fixture because the one used down below has unsigned RPMs.
+        # Signed and unsigned units have different hashes, so they're seen as different units.
+        body = gen_rpm_remote(url=RPM_UNSIGNED_FIXTURE_URL)
+        remote = client.post(RPM_REMOTE_PATH, body)
+        self.addCleanup(client.delete, remote['_href'])
+
+        # Sync the repository.
+        self.assertIsNone(repo['_latest_version_href'])
+        sync(self.cfg, remote, repo)
+        repo = client.get(repo['_href'])
+        self.assertDictEqual(get_content_summary(repo), RPM_FIXTURE_CONTENT_SUMMARY)
+
+        # Save a copy of the original updateinfo
+        original_updaterecords = {
+            content['errata_id']: content for content in get_content(repo)
+            if content['type'] == 'update'
+        }
+
+        # Create a remote with a different test fixture, one containing mutated updateinfo.
+        body = gen_rpm_remote(url=RPM_UPDATED_UPDATEINFO_FIXTURE_URL)
+        remote = client.post(RPM_REMOTE_PATH, body)
+        self.addCleanup(client.delete, remote['_href'])
+
+        # Sync the repository again.
+        sync(self.cfg, remote, repo)
+        repo = client.get(repo['_href'])
+        self.assertDictEqual(get_content_summary(repo), RPM_FIXTURE_CONTENT_SUMMARY)
+        self.assertEqual(len(get_added_content(repo)), 0)
+
+        # Test that the updateinfo have been modified.
+        mutated_updaterecords = {
+            content['errata_id']: content for content in get_content(repo)
+            if content['type'] == 'update'
+        }
+
+        self.assertNotEqual(mutated_updaterecords, original_updaterecords)
+        self.assertEqual(mutated_updaterecords[RPM_UPDATERECORD_ID]['description'],
+                         "Updated Gorilla_Erratum and the updated date contains timezone")

--- a/pulp_rpm/tests/functional/constants.py
+++ b/pulp_rpm/tests/functional/constants.py
@@ -1,5 +1,4 @@
 # coding=utf-8
-from types import MappingProxyType
 from urllib.parse import urljoin
 
 from pulp_smash.constants import PULP_FIXTURES_BASE_URL
@@ -10,75 +9,54 @@ from pulp_smash.pulp3.constants import (
 )
 
 
-RPM_CONTENT_PATH = urljoin(CONTENT_PATH, 'rpm/rpms/')
-SRPM_CONTENT_PATH = urljoin(CONTENT_PATH, 'rpm/srpms/')
+RPM_CONTENT_PATH = urljoin(CONTENT_PATH, 'rpm/packages/')
+"""The location of RPM packages on the content endpoint."""
+UPDATERECORD_CONTENT_PATH = urljoin(CONTENT_PATH, 'rpm/updates/')
+"""The location of RPM UpdateRecords on the content endpoint."""
 
 RPM_REMOTE_PATH = urljoin(BASE_REMOTE_PATH, 'rpm/')
 RPM_PUBLISHER_PATH = urljoin(BASE_PUBLISHER_PATH, 'rpm/')
 
 
-RPM_FIXTURE_URL = urljoin(PULP_FIXTURES_BASE_URL, 'rpm/')
-RPM_FIXTURE_COUNT = 39  # 35 Packages + 4 UpdateRecord units
-RPM_URL = urljoin(RPM_FIXTURE_URL, 'bear-4.1-1.noarch.rpm')
-
-SRPM_FIXTURE_URL = urljoin(PULP_FIXTURES_BASE_URL, 'srpm/')
-SRPM_FIXTURE_COUNT = 3
-SRPM_URL = urljoin(RPM_FIXTURE_URL, 'test-srpm01-1.0-1.src.rpm')
-
-RPM_DATA = MappingProxyType({
-    'name': 'bear',
-    'epoch': '0',
-    'version': '4.1',
-    'release': '1',
-    'arch': 'noarch',
-    'metadata': {
-        'release': '1',
-        'license': 'GPLv2',
-        'description': 'A dummy package of bear',
-        'files': {'dir': [], 'file': ['/tmp/bear.txt']},
-        'group': 'Internet/Applications',
-        'size': {'installed': 42, 'package': 1846},
-        'sourcerpm': 'bear-4.1-1.src.rpm',
-        'summary': 'A dummy package of bear',
-        'vendor': None,
-    },
-})
-"""Metadata for an RPM with an associated erratum.
-The metadata tags that may be present in an RPM may be printed with:
-.. code-block:: sh
-    rpm --querytags
-Metadata for an RPM can be printed with a command like the following:
-.. code-block:: sh
-    for tag in name epoch version release arch vendor; do
-        echo "$(rpm -qp bear-4.1-1.noarch.rpm --qf "%{$tag}")"
-    done
-There are three ways to measure the size of an RPM:
-installed size
-    The size of all the regular files in the payload.
-archive size
-    The uncompressed size of the payload, including necessary CPIO headers.
-package size
-    The actual size of an RPM file, as returned by ``stat --format='%s' …``.
-For more information, see the Fedora documentation on `RPM headers
-<https://docs.fedoraproject.org/en-US/Fedora_Draft_Documentation/0.1/html/RPM_Guide/ch-package-structure.html#id623000>`_.
-"""
-
-RPM = '{}-{}{}-{}.{}.rpm'.format(
-    RPM_DATA['name'],
-    RPM_DATA['epoch'] + '!' if RPM_DATA['epoch'] != '0' else '',
-    RPM_DATA['version'],
-    RPM_DATA['release'],
-    RPM_DATA['arch'],
-)
-"""The name of an RPM file. See :data:`pulp_smash.constants.RPM_SIGNED_URL`."""
-
-RPM_SIGNED_FIXTURE_COUNT = 32
-"""The number of packages available at :data:`RPM_SIGNED_FIXTURE_URL`."""
-
 RPM_SIGNED_FIXTURE_URL = urljoin(PULP_FIXTURES_BASE_URL, 'rpm-signed/')
-"""The URL to a signed RPM repository. See :data:`RPM_SIGNED_URL`."""
+"""The URL to a repository with signed RPM packages."""
 
-RPM_SIGNED_URL = urljoin(RPM_SIGNED_FIXTURE_URL, RPM)
-"""The URL to an RPM file.
-Built from :data:`RPM_SIGNED_FIXTURE_URL` and :data:`RPM`.
+RPM_UNSIGNED_FIXTURE_URL = urljoin(PULP_FIXTURES_BASE_URL, 'rpm-unsigned/')
+"""The URL to a repository with unsigned RPM packages."""
+
+RPM_FIXTURE_COUNT = 39  # 35 Packages + 4 UpdateRecord units
+"""The total number of content units present in the standard repositories, i.e.
+:data:`RPM_SIGNED_FIXTURE_URL` and :data:`RPM_UNSIGNED_FIXTURE_URL`.
 """
+
+RPM_FIXTURE_CONTENT_SUMMARY = {'package': 35, 'update': 4}
+"""The breakdown of how many of each type of content unit are present in the standard
+repositories, i.e. :data:`RPM_SIGNED_FIXTURE_URL` and :data:`RPM_UNSIGNED_FIXTURE_URL`.
+This matches the format output by the "content_summary" field on "../repositories/../versions/../".
+"""
+
+RPM_SIGNED_URL = urljoin(RPM_SIGNED_FIXTURE_URL, 'bear-4.1-1.noarch.rpm')
+"""The path to a single signed RPM package."""
+
+RPM_UNSIGNED_URL = urljoin(RPM_UNSIGNED_FIXTURE_URL, 'bear-4.1-1.noarch.rpm')
+"""The path to a single unsigned RPM package."""
+
+
+RPM_UPDATED_UPDATEINFO_FIXTURE_URL = urljoin(
+    PULP_FIXTURES_BASE_URL, 'rpm-updated-updateinfo/')
+"""The URL to a repository containing UpdateRecords (Errata) with the same IDs as the ones
+in the standard repositories, but with different metadata.
+
+Note: This repository uses unsigned RPMs.
+"""
+
+RPM_UPDATERECORD_ID = 'RHEA-2012:0058'
+"""The ID of an UpdateRecord (erratum).
+
+The package contained on this erratum is defined by :data:`RPM_UPDATERECORD_RPM_NAME` and
+the erratum is present in the standard repositories, i.e. :data:`RPM_SIGNED_FIXTURE_URL`
+and :data:`RPM_UNSIGNED_FIXTURE_URL`.
+"""
+
+RPM_UPDATERECORD_RPM_NAME = 'gorilla'
+"""The name of the RPM named by :data:`RPM_UPDATERECORD_ID`."""

--- a/pulp_rpm/tests/functional/utils.py
+++ b/pulp_rpm/tests/functional/utils.py
@@ -19,7 +19,7 @@ from pulp_smash.pulp3.utils import (
 
 from pulp_rpm.tests.functional.constants import (
     RPM_CONTENT_PATH,
-    RPM_FIXTURE_URL,
+    RPM_SIGNED_FIXTURE_URL,
     RPM_REMOTE_PATH,
 )
 
@@ -30,7 +30,7 @@ def set_up_module():
     require_pulp_plugins({'pulp_rpm'}, SkipTest)
 
 
-def populate_pulp(cfg, url=RPM_FIXTURE_URL):
+def populate_pulp(cfg, url=RPM_SIGNED_FIXTURE_URL):
     """Add rpm contents to Pulp.
 
     :param pulp_smash.config.PulpSmashConfig: Information about a Pulp application.
@@ -58,7 +58,7 @@ def gen_rpm_remote(**kwargs):
 
     :param url: The URL of an external content source.
     """
-    remote = gen_remote(RPM_FIXTURE_URL)
+    remote = gen_remote(RPM_SIGNED_FIXTURE_URL)
     rpm_extra_fields = {
         **kwargs
     }


### PR DESCRIPTION
Add a new smash test which checks that UpdateRecords (Errata) are updated,
not duplicated, when syncing in new UpdateRecord with the same ID but
different metadata.

This test is currently disabled, because it will fail until this is fixed in Pulp.

Also:

* Remove fixture data we aren't using yet
* Replace usages of RPM_FIXTURE_URL with RPM_SIGNED_FIXTURE_URL
* Compare content summaries instead of taking the len() of get_content()
    * RPM has multiple content types which get mixed together otherwise