### PR TITLE
Add a new smash test for duplicate NEVRA removal

### DIFF
--- a/pulp_rpm/tests/functional/api/test_sync.py
+++ b/pulp_rpm/tests/functional/api/test_sync.py
@@ -16,6 +16,8 @@ from pulp_rpm.tests.functional.constants import (
     RPM_FIXTURE_COUNT,
     RPM_FIXTURE_CONTENT_SUMMARY,
     RPM_REMOTE_PATH,
+    RPM_SIGNED_FIXTURE_URL,
+    RPM_PACKAGE_NAME,
     RPM_UNSIGNED_FIXTURE_URL,
     RPM_UPDATED_UPDATEINFO_FIXTURE_URL,
     RPM_UPDATERECORD_ID,
@@ -24,7 +26,7 @@ from pulp_rpm.tests.functional.utils import gen_rpm_remote
 from pulp_rpm.tests.functional.utils import set_up_module as setUpModule  # noqa:F401
 
 
-class BasicSyncRpmRepoTestCase(unittest.TestCase):
+class BasicSyncTestCase(unittest.TestCase):
     """Sync repositories with the rpm plugin."""
 
     @classmethod
@@ -81,7 +83,75 @@ class BasicSyncRpmRepoTestCase(unittest.TestCase):
         self.assertEqual(len(get_added_content(repo)), 0)
 
 
-@unittest.skip("FIXME: Enable this test after we can throw out duplicate Errata")
+@unittest.skip("FIXME: Enable this test after we can throw out duplicate Packages")
+class SyncMutatedPackagesTestCase(unittest.TestCase):
+    """Sync different packages with the same NEVRA as existing packages."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create class-wide variables."""
+        cls.cfg = config.get_config()
+
+    def test_all(self):
+        """Sync two copies of the same packages, make sure we end up with only one copy.
+
+        Do the following:
+
+        1. Create a repository and a remote.
+        2. Sync the remote.
+        3. Assert that the content summary matches what is expected.
+        4. Create a new remote w/ using fixture containing updated errata (packages with the same
+           NEVRA as the existing package content, but different pkgId)
+        5. Sync the remote again.
+        6. Assert that repository version is different from the previous one but has the same
+           content summary.
+        7. Assert that the packages have changed since the last sync.
+        """
+        client = api.Client(self.cfg, api.json_handler)
+
+        repo = client.post(REPO_PATH, gen_repo())
+        self.addCleanup(client.delete, repo['_href'])
+
+        # Create a remote with the unsigned RPM fixture url.
+        body = gen_rpm_remote(url=RPM_UNSIGNED_FIXTURE_URL)
+        remote = client.post(RPM_REMOTE_PATH, body)
+        self.addCleanup(client.delete, remote['_href'])
+
+        # Sync the repository.
+        self.assertIsNone(repo['_latest_version_href'])
+        sync(self.cfg, remote, repo)
+        repo = client.get(repo['_href'])
+        self.assertDictEqual(get_content_summary(repo), RPM_FIXTURE_CONTENT_SUMMARY)
+
+        # Save a copy of the original packages.
+        original_packages = {
+            content['errata_id']: content for content in get_content(repo)
+            if content['type'] == 'packages'
+        }
+
+        # Create a remote with a different test fixture with the same NEVRA but different digests.
+        body = gen_rpm_remote(url=RPM_SIGNED_FIXTURE_URL)
+        remote = client.post(RPM_REMOTE_PATH, body)
+        self.addCleanup(client.delete, remote['_href'])
+
+        # Sync the repository again.
+        sync(self.cfg, remote, repo)
+        repo = client.get(repo['_href'])
+        self.assertDictEqual(get_content_summary(repo), RPM_FIXTURE_CONTENT_SUMMARY)
+        self.assertEqual(len(get_added_content(repo)), 0)
+
+        # Test that the packages have been modified.
+        mutated_packages = {
+            content['errata_id']: content for content in get_content(repo)
+            if content['type'] == 'update'
+        }
+
+        self.assertNotEqual(mutated_packages, original_packages)
+        self.assertNotEqual(mutated_packages[RPM_PACKAGE_NAME]['pkgId'],
+                            original_packages[RPM_PACKAGE_NAME]['pkgId'])
+
+
+@unittest.skip("FIXME: Enable this test after we can throw out duplicate UpdateRecords")
 class SyncMutatedUpdateRecordTestCase(unittest.TestCase):
     """Sync a new Erratum with the same ID."""
 
@@ -91,11 +161,7 @@ class SyncMutatedUpdateRecordTestCase(unittest.TestCase):
         cls.cfg = config.get_config()
 
     def test_all(self):
-        """Sync repositories with the rpm plugin.
-
-        In order to sync a repository a remote has to be associated within
-        this repository. When a repository is created this version field is set
-        as None. After a sync the repository version is updated.
+        """Sync two copies of the same UpdateRecords, make sure we end up with only one copy.
 
         Do the following:
 

--- a/pulp_rpm/tests/functional/constants.py
+++ b/pulp_rpm/tests/functional/constants.py
@@ -41,6 +41,9 @@ RPM_SIGNED_URL = urljoin(RPM_SIGNED_FIXTURE_URL, 'bear-4.1-1.noarch.rpm')
 RPM_UNSIGNED_URL = urljoin(RPM_UNSIGNED_FIXTURE_URL, 'bear-4.1-1.noarch.rpm')
 """The path to a single unsigned RPM package."""
 
+RPM_PACKAGE_NAME = 'bear'
+"""The name of one RPM package."""
+
 
 RPM_UPDATED_UPDATEINFO_FIXTURE_URL = urljoin(
     PULP_FIXTURES_BASE_URL, 'rpm-updated-updateinfo/')


### PR DESCRIPTION
Test that when packages with the same NEVRA but different pkgId are
synced into the repository, we end up with only one copy of them in the
final repository version.