### PR TITLE
Add upload support, enable CRUD PackageContent tests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -160,7 +160,7 @@ Upload ``foo.rpm`` to Pulp
 
 Create an Artifact by uploading the file to Pulp.
 
-``$ http --form POST http://localhost:8000/pulp/api/v3/artifacts/ file@./foo.rpm``
+``$ http --form POST http://localhost:8000/pulp/api/v3/artifacts/ file@./foo-4.1-1.noarch.rpm``
 
 .. code:: json
 
@@ -174,7 +174,7 @@ Create ``rpm`` content from an Artifact
 
 Create a content unit and point it to your artifact
 
-``$ http POST http://localhost:8000/pulp/api/v3/content/rpm/packages/ relative_path=foo.rpm artifact="/pulp/api/v3/artifacts/1/"``
+``$ http POST http://localhost:8000/pulp/api/v3/content/rpm/packages/ relative_path=foo.rpm artifact="/pulp/api/v3/artifacts/1/" filename=foo-4.1-1.noarch.rpm``
 
 .. code:: json
 

--- a/pulp_rpm/tests/functional/api/test_download_content.py
+++ b/pulp_rpm/tests/functional/api/test_download_content.py
@@ -17,7 +17,7 @@ from pulp_smash.pulp3.utils import (
 from pulp_rpm.tests.functional.utils import (
     gen_rpm_publisher,
     gen_rpm_remote,
-    get_rpm_content_unit_paths,
+    get_rpm_package_paths,
 )
 from pulp_rpm.tests.functional.constants import (
     RPM_PUBLISHER_PATH,
@@ -86,7 +86,7 @@ class DownloadContentTestCase(unittest.TestCase):
         self.addCleanup(client.delete, distribution['_href'])
 
         # Pick a content unit, and download it from both Pulp Fixtures…
-        unit_path = choice(get_rpm_content_unit_paths(repo))
+        unit_path = choice(get_rpm_package_paths(repo))
         fixtures_hash = hashlib.sha256(
             utils.http_get(urljoin(RPM_SIGNED_FIXTURE_URL, unit_path))
         ).hexdigest()

--- a/pulp_rpm/tests/functional/constants.py
+++ b/pulp_rpm/tests/functional/constants.py
@@ -36,14 +36,34 @@ repositories, i.e. :data:`RPM_SIGNED_FIXTURE_URL` and :data:`RPM_UNSIGNED_FIXTUR
 This matches the format output by the "content_summary" field on "../repositories/../versions/../".
 """
 
-RPM_SIGNED_URL = urljoin(RPM_SIGNED_FIXTURE_URL, 'bear-4.1-1.noarch.rpm')
-"""The path to a single signed RPM package."""
-
-RPM_UNSIGNED_URL = urljoin(RPM_UNSIGNED_FIXTURE_URL, 'bear-4.1-1.noarch.rpm')
-"""The path to a single unsigned RPM package."""
 
 RPM_PACKAGE_NAME = 'bear'
 """The name of one RPM package."""
+
+RPM_PACKAGE_FILENAME = 'bear-4.1-1.noarch.rpm'
+"""The filename of one RPM package."""
+
+RPM_PACKAGE_DATA = {
+    'name': 'bear',
+    'epoch': '0',
+    'version': '4.1',
+    'release': '1',
+    'arch': 'noarch',
+    'description': 'A dummy package of bear',
+    'summary': 'A dummy package of bear',
+    'rpm_license': 'GPLv2',
+    'rpm_group': 'Internet/Applications',
+    'rpm_vendor': "",
+    # TODO: Complete this information once we figure out how to serialize everything nicely
+}
+"""The metadata for one RPM package."""
+
+RPM_SIGNED_URL = urljoin(RPM_SIGNED_FIXTURE_URL, RPM_PACKAGE_FILENAME)
+"""The path to a single signed RPM package."""
+
+RPM_UNSIGNED_URL = urljoin(RPM_UNSIGNED_FIXTURE_URL, RPM_PACKAGE_FILENAME)
+"""The path to a single unsigned RPM package."""
+
 
 RPM_UPDATED_UPDATEINFO_FIXTURE_URL = urljoin(
     PULP_FIXTURES_BASE_URL, 'rpm-updated-updateinfo/')


### PR DESCRIPTION
Implement upload support.  Content units are now created by providing the artifact href and a filename -- all additional information is parsed directly from the RPM file instead of being user-provided.

Implement some content-specific bits of the smash test boilerplate for
RPM Packages, and enable CRUD content tests for PackageContent.
