### PR TITLE
Store UpdateReference

### DIFF
--- a/pulp_rpm/app/constants.py
+++ b/pulp_rpm/app/constants.py
@@ -99,3 +99,10 @@ CREATEREPO_UPDATE_COLLECTION_PACKAGE_ATTRS = SimpleNamespace(
     SUM_TYPE='sum_type',
     VERSION='version'
 )
+
+CREATEREPO_UPDATE_REFERENCE_ATTRS = SimpleNamespace(
+    HREF='href',
+    ID='id',
+    TITLE='title',
+    TYPE='type'
+)


### PR DESCRIPTION
- Create an UpdateReference model to store reference info for errata.
- Store it during sync

re #3998
https://pulp.plan.io/issues/3998