### PR TITLE
Add test to package manager consume content from Pulp

### DIFF
--- a/pulp_rpm/tests/functional/api/test_consume_content.py
+++ b/pulp_rpm/tests/functional/api/test_consume_content.py
@@ -1,0 +1,81 @@
+# coding=utf-8
+"""Verify whether package manager, yum/dnf, can consume content from Pulp."""
+import unittest
+from urllib.parse import urljoin
+
+from pulp_smash import api, cli, config
+from pulp_smash.exceptions import NoKnownPackageManagerError
+from pulp_smash.pulp3.constants import DISTRIBUTION_PATH, REPO_PATH
+from pulp_smash.pulp3.utils import (
+    gen_distribution,
+    gen_repo,
+    publish,
+    sync,
+)
+
+from pulp_rpm.tests.functional.utils import (
+    gen_rpm_publisher,
+    gen_rpm_remote,
+)
+from pulp_rpm.tests.functional.constants import (
+    RPM_PUBLISHER_PATH,
+    RPM_REMOTE_PATH,
+)
+from pulp_rpm.tests.functional.utils import set_up_module as setUpModule  # noqa:F401
+from pulp_rpm.tests.functional.utils import gen_yum_config_file
+
+
+class PackageManagerConsumeTestCase(unittest.TestCase):
+    """Verify whether package manager can consume content from Pulp."""
+
+    def test_all(self):
+        """Verify whether package manager can consume content from Pulp.
+
+        This test targets the following issue:
+
+        `Pulp #3204 <https://pulp.plan.io/issues/3204>`_
+        """
+        cfg = config.get_config()
+        try:
+            cli.PackageManager._get_package_manager(cfg)  # pylint:disable=protected-access
+        except NoKnownPackageManagerError:
+            raise unittest.SkipTest('This test requires dnf or yum.')
+        client = api.Client(cfg, api.json_handler)
+        body = gen_rpm_remote()
+        remote = client.post(RPM_REMOTE_PATH, body)
+        self.addCleanup(client.delete, remote['_href'])
+
+        repo = client.post(REPO_PATH, gen_repo())
+        self.addCleanup(client.delete, repo['_href'])
+
+        sync(cfg, remote, repo)
+
+        publisher = client.post(RPM_PUBLISHER_PATH, gen_rpm_publisher())
+        self.addCleanup(client.delete, publisher['_href'])
+
+        publication = publish(cfg, publisher, repo)
+        self.addCleanup(client.delete, publication['_href'])
+
+        body = gen_distribution()
+        body['publication'] = publication['_href']
+        distribution = client.post(DISTRIBUTION_PATH, body)
+        self.addCleanup(client.delete, distribution['_href'])
+
+        repo_path = gen_yum_config_file(
+            cfg,
+            baseurl=urljoin(cfg.get_base_url(), urljoin(
+                'pulp/content/',
+                distribution['base_path']
+            )),
+            name=repo['name'],
+            repositoryid=repo['name']
+        )
+
+        cli_client = cli.Client(cfg)
+        self.addCleanup(cli_client.run, ('rm', repo_path), sudo=True)
+        rpm_name = 'walrus'
+        pkg_mgr = cli.PackageManager(cfg)
+        pkg_mgr.install(rpm_name)
+        self.addCleanup(pkg_mgr.uninstall, rpm_name)
+        rpm = cli_client.run(('rpm', '-q', rpm_name)).stdout.strip().split('-')
+        self.assertEqual(rpm_name, rpm[0])

--- a/pulp_rpm/tests/functional/api/test_publish.py
+++ b/pulp_rpm/tests/functional/api/test_publish.py
@@ -43,7 +43,8 @@ class PublishAnyRepoVersionTestCase(unittest.TestCase):
         2. Create a publication by supplying the latest ``repository_version``.
         3. Assert that the publication ``repository_version`` attribute points
            to the latest repository version.
-        4. Create a publication by supplying the non-latest ``repository_version``.
+        4. Create a publication by supplying the non-latest
+        ``repository_version``.
         5. Assert that the publication ``repository_version`` attribute points
            to the supplied repository version.
         6. Assert that an exception is raised when providing two different

--- a/pulp_rpm/tests/functional/utils.py
+++ b/pulp_rpm/tests/functional/utils.py
@@ -1,16 +1,18 @@
 # coding=utf-8
 """Utilities for tests for the rpm plugin."""
+import os
 from functools import partial
+from io import StringIO
 from unittest import SkipTest
 
-from pulp_smash import api, selectors
+from pulp_smash import api, cli, selectors
 from pulp_smash.pulp3.constants import (
     REPO_PATH
 )
 from pulp_smash.pulp3.utils import (
+    gen_publisher,
     gen_remote,
     gen_repo,
-    gen_publisher,
     get_content,
     require_pulp_3,
     require_pulp_plugins,
@@ -19,8 +21,9 @@ from pulp_smash.pulp3.utils import (
 
 from pulp_rpm.tests.functional.constants import (
     RPM_CONTENT_PATH,
-    RPM_SIGNED_FIXTURE_URL,
     RPM_REMOTE_PATH,
+    RPM_SIGNED_FIXTURE_URL,
+    RPM_UNSIGNED_FIXTURE_URL,
 )
 
 
@@ -33,10 +36,12 @@ def set_up_module():
 def populate_pulp(cfg, url=RPM_SIGNED_FIXTURE_URL):
     """Add rpm contents to Pulp.
 
-    :param pulp_smash.config.PulpSmashConfig: Information about a Pulp application.
+    :param pulp_smash.config.PulpSmashConfig: Information about a Pulp
+    application.
     :param url: The rpm repository URL. Defaults to
         :data:`pulp_smash.constants.RPM_FIXTURE_URL`
-    :returns: A list of dicts, where each dict describes one file content in Pulp.
+    :returns: A list of dicts, where each dict describes one file content in
+    Pulp.
     """
     client = api.Client(cfg, api.json_handler)
     remote = {}
@@ -58,7 +63,7 @@ def gen_rpm_remote(**kwargs):
 
     :param url: The URL of an external content source.
     """
-    remote = gen_remote(RPM_SIGNED_FIXTURE_URL)
+    remote = gen_remote(RPM_UNSIGNED_FIXTURE_URL)
     rpm_extra_fields = {
         **kwargs
     }
@@ -88,6 +93,54 @@ def get_rpm_content_unit_paths(repo):
     """
     # The "relative_path" is actually a file path and name
     return [content_unit['relative_path'] for content_unit in get_content(repo)]
+
+
+def gen_yum_config_file(cfg, repositoryid, baseurl, name, **kwargs):
+    """Generate a yum configuration file and write it to ``/etc/yum.repos.d/``.
+
+    Generate a yum configuration file containing a single repository section,
+    and write it to ``/etc/yum.repos.d/{repositoryid}.repo``.
+
+    :param cfg: The system on which to create
+        a yum configuration file.
+    :param repositoryid: The section's ``repositoryid``. Used when naming the
+        configuration file and populating the brackets at the head of the file.
+        For details, see yum.conf(5).
+    :param baseurl: The required option ``baseurl`` specifying the url of repo.
+        For details, see yum.conf(5)
+    :param name: The required option ``name`` specifying the name of repo.
+        For details, see yum.conf(5).
+    :param kwargs: Section options. Each kwarg corresponds to one option. For
+        details, see yum.conf(5).
+    :returns: The path to the yum configuration file.
+    """
+    # required repo options
+    kwargs.setdefault('name', name)
+    kwargs.setdefault('baseurl', baseurl)
+    # assume some common used defaults
+    kwargs.setdefault('enabled', 1)
+    kwargs.setdefault('gpgcheck', 0)
+    kwargs.setdefault('metadata_expire', 0)  # force metadata load every time
+    # if sslverify is not provided in kwargs it is inferred from cfg
+    kwargs.setdefault(
+        'sslverify',
+        'yes' if cfg.get_hosts('api')[0].roles['api'].get('verify') else 'no'
+    )
+
+    path = os.path.join('/etc/yum.repos.d/', repositoryid + '.repo')
+    with StringIO() as section:
+        section.write('[{}]\n'.format(repositoryid))
+        for key, value in kwargs.items():
+            section.write('{}: {}\n'.format(key, value))
+        # machine.session is used here to keep SSH session open
+        cli.Client(cfg).machine.session().run(
+            'echo "{}" | {}tee {} > /dev/null'.format(
+                section.getvalue(),
+                '' if cli.is_root(cfg) else 'sudo ',
+                path
+            )
+        )
+    return path
 
 
 skip_if = partial(selectors.skip_if, exc=SkipTest)


### PR DESCRIPTION
Add a test to verify whether package manger, dnf/yum, can consume content from pulp.

Add an utils function `gen_yum_config_file`.

See: https://pulp.plan.io/issues/3204