### PR TITLE
Only show checksum if it's not blank

### DIFF
--- a/pulp_rpm/app/tasks/publishing.py
+++ b/pulp_rpm/app/tasks/publishing.py
@@ -62,9 +62,10 @@ def update_record_xml(update_record):
             pkg.arch = package.arch
             pkg.src = package.src
             pkg.filename = package.filename
-            pkg.sum = package.sum
-            pkg.sum_type = int(package.sum_type or 0)
             pkg.reboot_suggested = package.reboot_suggested
+            if package.sum:
+                pkg.sum = package.sum
+                pkg.sum_type = int(package.sum_type or 0)
             col.append(pkg)
 
         rec.append_collection(col)


### PR DESCRIPTION
We could still end up with "Unknown checksum" values but I think that's ok and it should be less likely that checksum is set but sum_type is not.

fixes #4033
https://pulp.plan.io/issues/4033