### PR TITLE
Add test to sync/publish update references

### DIFF
--- a/pulp_rpm/tests/functional/api/test_sync.py
+++ b/pulp_rpm/tests/functional/api/test_sync.py
@@ -84,7 +84,7 @@ class BasicSyncTestCase(unittest.TestCase):
         self.assertEqual(len(get_added_content(repo)), 0)
 
 
-@unittest.skip("FIXME: Enable this test after we can throw out duplicate Packages")
+@unittest.skip('FIXME: Enable this test after we can throw out duplicate Packages')
 class SyncMutatedPackagesTestCase(unittest.TestCase):
     """Sync different packages with the same NEVRA as existing packages."""
 
@@ -152,7 +152,7 @@ class SyncMutatedPackagesTestCase(unittest.TestCase):
                             original_packages[RPM_PACKAGE_NAME]['pkgId'])
 
 
-@unittest.skip("FIXME: Enable this test after we can throw out duplicate UpdateRecords")
+@unittest.skip('FIXME: Enable this test after we can throw out duplicate UpdateRecords')
 class SyncMutatedUpdateRecordTestCase(unittest.TestCase):
     """Sync a new Erratum with the same ID."""
 
@@ -229,6 +229,6 @@ class SyncMutatedUpdateRecordTestCase(unittest.TestCase):
         self.assertNotEqual(mutated_updaterecords, original_updaterecords)
         self.assertEqual(
             mutated_updaterecords[RPM_UPDATERECORD_ID]['description'],
-            "Updated Gorilla_Erratum and the updated date contains timezone",
+            'Updated Gorilla_Erratum and the updated date contains timezone',
             mutated_updaterecords[RPM_UPDATERECORD_ID]
         )

--- a/pulp_rpm/tests/functional/constants.py
+++ b/pulp_rpm/tests/functional/constants.py
@@ -6,14 +6,11 @@ from pulp_smash.constants import PULP_FIXTURES_BASE_URL
 from pulp_smash.pulp3.constants import (
     BASE_PUBLISHER_PATH,
     BASE_REMOTE_PATH,
-    CONTENT_PATH
+    CONTENT_PATH,
 )
 
 RPM_CONTENT_PATH = urljoin(CONTENT_PATH, 'rpm/packages/')
 """The location of RPM packages on the content endpoint."""
-
-UPDATERECORD_CONTENT_PATH = urljoin(CONTENT_PATH, 'rpm/updates/')
-"""The location of RPM UpdateRecords on the content endpoint."""
 
 RPM_REMOTE_PATH = urljoin(BASE_REMOTE_PATH, 'rpm/')
 
@@ -31,11 +28,11 @@ RPM_FIXTURE_COUNT = 39  # 35 Packages + 4 UpdateRecord units
 """
 
 RPM_FIXTURE_CONTENT_SUMMARY = {'package': 35, 'update': 4}
-"""The breakdown of how many of each type of content unit are present in the standard
-repositories, i.e. :data:`RPM_SIGNED_FIXTURE_URL` and :data:`RPM_UNSIGNED_FIXTURE_URL`.
-This matches the format output by the "content_summary" field on "../repositories/../versions/../".
+"""The breakdown of how many of each type of content unit are present in the
+standard repositories, i.e. :data:`RPM_SIGNED_FIXTURE_URL` and
+:data:`RPM_UNSIGNED_FIXTURE_URL`.  This matches the format output by the
+"content_summary" field on "../repositories/../versions/../".
 """
-
 
 RPM_PACKAGE_NAME = 'bear'
 """The name of one RPM package."""
@@ -53,10 +50,20 @@ RPM_PACKAGE_DATA = {
     'summary': 'A dummy package of bear',
     'rpm_license': 'GPLv2',
     'rpm_group': 'Internet/Applications',
-    'rpm_vendor': "",
+    'rpm_vendor': '',
     # TODO: Complete this information once we figure out how to serialize everything nicely
 }
 """The metadata for one RPM package."""
+
+RPM_REFERENCES_UPDATEINFO_URL = urljoin(
+    PULP_FIXTURES_BASE_URL,
+    'rpm-references-updateinfo/'
+)
+"""The URL to a repository with ``updateinfo.xml`` containing references.
+
+This repository includes errata with reference element (0, 1 or 2 references)
+and without it.
+"""
 
 RPM_SIGNED_URL = urljoin(RPM_SIGNED_FIXTURE_URL, RPM_PACKAGE_FILENAME)
 """The path to a single signed RPM package."""
@@ -67,8 +74,8 @@ RPM_UNSIGNED_URL = urljoin(RPM_UNSIGNED_FIXTURE_URL, RPM_PACKAGE_FILENAME)
 
 RPM_UPDATED_UPDATEINFO_FIXTURE_URL = urljoin(
     PULP_FIXTURES_BASE_URL, 'rpm-updated-updateinfo/')
-"""The URL to a repository containing UpdateRecords (Errata) with the same IDs as the ones
-in the standard repositories, but with different metadata.
+"""The URL to a repository containing UpdateRecords (Errata) with the same IDs
+as the ones in the standard repositories, but with different metadata.
 
 Note: This repository uses unsigned RPMs.
 """
@@ -76,10 +83,14 @@ Note: This repository uses unsigned RPMs.
 RPM_UPDATERECORD_ID = 'RHEA-2012:0058'
 """The ID of an UpdateRecord (erratum).
 
-The package contained on this erratum is defined by :data:`RPM_UPDATERECORD_RPM_NAME` and
-the erratum is present in the standard repositories, i.e. :data:`RPM_SIGNED_FIXTURE_URL`
-and :data:`RPM_UNSIGNED_FIXTURE_URL`.
+The package contained on this erratum is defined by
+:data:`RPM_UPDATERECORD_RPM_NAME` and the erratum is present in the standard
+repositories, i.e. :data:`RPM_SIGNED_FIXTURE_URL` and
+:data:`RPM_UNSIGNED_FIXTURE_URL`.
 """
 
 RPM_UPDATERECORD_RPM_NAME = 'gorilla'
 """The name of the RPM named by :data:`RPM_UPDATERECORD_ID`."""
+
+UPDATERECORD_CONTENT_PATH = urljoin(CONTENT_PATH, 'rpm/updates/')
+"""The location of RPM UpdateRecords on the content endpoint."""

--- a/pulp_rpm/tests/functional/utils.py
+++ b/pulp_rpm/tests/functional/utils.py
@@ -23,6 +23,7 @@ from pulp_rpm.tests.functional.constants import (
     RPM_CONTENT_PATH,
     RPM_REMOTE_PATH,
     RPM_SIGNED_FIXTURE_URL,
+    RPM_UNSIGNED_FIXTURE_URL,
 )
 
 
@@ -32,17 +33,15 @@ def set_up_module():
     require_pulp_plugins({'pulp_rpm'}, SkipTest)
 
 
-def gen_rpm_remote(**kwargs):
-    """Return a semi-random dict for use in creating a rpm Remote.
+def gen_rpm_remote(url=None, **kwargs):
+    """Return a semi-random dict for use in creating a RPM remote.
 
     :param url: The URL of an external content source.
     """
-    remote = gen_remote(RPM_SIGNED_FIXTURE_URL)
-    rpm_extra_fields = {
-        **kwargs
-    }
-    remote.update(rpm_extra_fields)
-    return remote
+    if url is None:
+        url = RPM_UNSIGNED_FIXTURE_URL
+
+    return gen_remote(url, **kwargs)
 
 
 def gen_rpm_publisher(**kwargs):
@@ -59,12 +58,14 @@ def gen_rpm_publisher(**kwargs):
 
 
 def get_rpm_package_paths(repo):
-    """Return the relative path of content units present in a rpm repository.
+    """Return the relative path of content units present in a RPM repository.
 
     :param repo: A dict of information about the repository.
     :returns: A list with the paths of units present in a given repository.
     """
-    return [gen_rpm_filename(content_unit) for content_unit in get_content(repo)]
+    return [
+        gen_rpm_filename(content_unit) for content_unit in get_content(repo)
+    ]
 
 
 def gen_rpm_filename(package):
@@ -75,7 +76,10 @@ def gen_rpm_filename(package):
     :returns: The filename of the package.
     :rtype: str
     """
-    format_string = "{n}-{e}:{v}-{r}.{a}.rpm" if package['epoch'] else "{n}-{v}-{r}.{a}.rpm"
+    format_string = (
+        '{n}-{e}:{v}-{r}.{a}.rpm'
+        if package['epoch'] else '{n}-{v}-{r}.{a}.rpm'
+    )
 
     return format_string.format(
         n=package['name'],


### PR DESCRIPTION
Add test to sync/publish a RPM repository with `updateinfo.xml` with
references.

Introduce new constant RPM_REFERENCES_UPDATEINFO_URL

See: https://repos.fedorapeople.org/pulp/pulp/fixtures/rpm-references-updateinfo/