### PR TITLE
Enable test download content

### DIFF
--- a/pulp_rpm/tests/functional/api/test_download_content.py
+++ b/pulp_rpm/tests/functional/api/test_download_content.py
@@ -22,13 +22,11 @@ from pulp_rpm.tests.functional.utils import (
 from pulp_rpm.tests.functional.constants import (
     RPM_PUBLISHER_PATH,
     RPM_REMOTE_PATH,
-    RPM_SIGNED_FIXTURE_URL,
+    RPM_UNSIGNED_FIXTURE_URL,
 )
 from pulp_rpm.tests.functional.utils import set_up_module as setUpModule  # noqa:F401
 
 
-# Define utils.get_rpm_content_unit_paths() before enabling this test
-@unittest.skip('FIXME: plugin writer action required')
 class DownloadContentTestCase(unittest.TestCase):
     """Verify whether content served by pulp can be downloaded."""
 
@@ -88,7 +86,7 @@ class DownloadContentTestCase(unittest.TestCase):
         # Pick a content unit, and download it from both Pulp Fixtures…
         unit_path = choice(get_rpm_package_paths(repo))
         fixtures_hash = hashlib.sha256(
-            utils.http_get(urljoin(RPM_SIGNED_FIXTURE_URL, unit_path))
+            utils.http_get(urljoin(RPM_UNSIGNED_FIXTURE_URL, unit_path))
         ).hexdigest()
 
         # …and Pulp.

--- a/pulp_rpm/tests/functional/utils.py
+++ b/pulp_rpm/tests/functional/utils.py
@@ -16,7 +16,7 @@ from pulp_smash.pulp3.utils import (
     get_content,
     require_pulp_3,
     require_pulp_plugins,
-    sync
+    sync,
 )
 
 from pulp_rpm.tests.functional.constants import (
@@ -64,30 +64,10 @@ def get_rpm_package_paths(repo):
     :returns: A list with the paths of units present in a given repository.
     """
     return [
-        gen_rpm_filename(content_unit) for content_unit in get_content(repo)
+        content_unit['location_href']
+        for content_unit in get_content(repo)
+        if 'location_href' in content_unit
     ]
-
-
-def gen_rpm_filename(package):
-    """Create a filename for a RPM based upon its NEVRA information.
-
-    :param package: Information about the content unit.
-    :type package: dict
-    :returns: The filename of the package.
-    :rtype: str
-    """
-    format_string = (
-        '{n}-{e}:{v}-{r}.{a}.rpm'
-        if package['epoch'] else '{n}-{v}-{r}.{a}.rpm'
-    )
-
-    return format_string.format(
-        n=package['name'],
-        e=package['epoch'],
-        v=package['version'],
-        r=package['release'],
-        a=package['arch']
-    )
 
 
 def populate_pulp(cfg, url=RPM_SIGNED_FIXTURE_URL):


### PR DESCRIPTION
Enable test download content, and modify the function `get_rpm_package_paths`.
This function will return just RPM packages names with this change.

Remove function `gen_rpm_filename`.

'[noissue]'