### PR TITLE
Mark modular RPMs during sync and upload

### DIFF
--- a/plugins/pulp_rpm/plugins/db/models.py
+++ b/plugins/pulp_rpm/plugins/db/models.py
@@ -1077,6 +1077,8 @@ class RPM(RpmBase):
     unit_description = 'RPM'
     unit_referenced_types = ['erratum']
 
+    is_modular = mongoengine.BooleanField(default=False)
+
     meta = {'collection': 'units_rpm',
             'allow_inheritance': False}
 

--- a/plugins/pulp_rpm/plugins/importers/yum/parse/rpm.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/parse/rpm.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 import logging
 import os
+import re
 from gettext import gettext as _
 
 import deltarpm
@@ -84,7 +85,6 @@ def package_headers(filename):
     :return: package header
     :rtype: rpm.hdr
     """
-
     # Read the RPM header attributes for use later
     ts = rpm_module.TransactionSet()
     ts.setVSFlags(rpm_module._RPMVSF_NOSIGNATURES)
@@ -323,3 +323,21 @@ def evr_to_str(epoch, version, release):
         return "%s-%s" % (version, release)
     else:
         return "%s:%s-%s" % (epoch, version, release)
+
+
+def get_package_modular_flag(headers):
+    """
+    Look at package headers and decide if a package is modular or not.
+
+    DISTTAG tag should contain 'module(...)' substring for package to be a modular one.
+
+    :param headers: package headers
+    :type  headers: rpm.hdr
+
+    :return: True, if package is a modular one
+    :rtype: boolean
+    """
+    modular_flag = headers.get(rpm_module.RPMTAG_DISTTAG)
+    if modular_flag is None:
+        return False
+    return bool(re.match(r'module\(.*?\)', modular_flag))

--- a/plugins/pulp_rpm/plugins/importers/yum/upload.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/upload.py
@@ -383,6 +383,10 @@ def _handle_package(repo, type_id, unit_key, metadata, file_path, conduit, confi
             package_xml = (utils.fake_xml_element(repodata['primary'], constants.COMMON_NAMESPACE)
                                 .find(primary.PACKAGE_TAG))
             unit = primary.process_package_element(package_xml)
+
+            package_headers = rpm_parse.package_headers(file_path)
+            unit.is_modular = rpm_parse.get_package_modular_flag(package_headers)
+
     except Exception:
         raise PulpCodedException(error_codes.RPM1016)
 

--- a/plugins/pulp_rpm/plugins/migrations/0046_add_is_modular_field.py
+++ b/plugins/pulp_rpm/plugins/migrations/0046_add_is_modular_field.py
@@ -1,0 +1,127 @@
+import logging
+
+from gettext import gettext as _
+
+from pulp.server.db.connection import get_collection
+from pulp.server.db.migrations.lib import utils
+
+_LOGGER = logging.getLogger('pulp_rpm.plugins.migrations.0046')
+
+units_rpm_collection = get_collection('units_rpm')
+units_modulemd_collection = get_collection('units_modulemd')
+
+NEW_FIELD = 'is_modular'
+
+
+def nevra(name):
+    """Parse NEVRA.
+
+    inspired by:
+    https://github.com/rpm-software-management/hawkey/blob/d61bf52871fcc8e41c92921c8cd92abaa4dfaed5/src/util.c#L157. # NOQA
+    We don't use hawkey because it is not available on all platforms we support.
+
+    :param name: NEVRA (jay-3:3.10-4.fc3.x86_64)
+    :type  name: str
+
+    :return: parsed NEVRA (name, epoch, version, release, architecture)
+                           str    int     str      str         str
+    :rtype: tuple
+    """
+    if name.count(".") < 1:
+        msg = _("failed to parse nevra '%s' not a valid nevra") % name
+        _LOGGER.exception(msg)
+        raise ValueError(msg)
+
+    arch_dot_pos = name.rfind(".")
+    arch = name[arch_dot_pos + 1:]
+
+    return nevr(name[:arch_dot_pos]) + (arch, )
+
+
+def nevr(name):
+    """
+    Parse NEVR.
+
+    inspired by:
+    https://github.com/rpm-software-management/hawkey/blob/d61bf52871fcc8e41c92921c8cd92abaa4dfaed5/src/util.c#L157. # NOQA
+
+    :param name: NEVR "jay-test-3:3.10-4.fc3"
+    :type  name: str
+
+    :return: parsed NEVR (name, epoch, version, release)
+                          str    int     str      str
+    :rtype: tuple
+    """
+    if name.count("-") < 2:  # release or name is missing
+        msg = _("failed to parse nevr '%s' not a valid nevr") % name
+        _LOGGER.exception(msg)
+        raise ValueError(msg)
+
+    release_dash_pos = name.rfind("-")
+    release = name[release_dash_pos + 1:]
+    name_epoch_version = name[:release_dash_pos]
+    name_dash_pos = name_epoch_version.rfind("-")
+    package_name = name_epoch_version[:name_dash_pos]
+
+    epoch_version = name_epoch_version[name_dash_pos + 1:].split(":")
+    if len(epoch_version) == 1:
+        epoch = 0
+        version = epoch_version[0]
+    elif len(epoch_version) == 2:
+        epoch = int(epoch_version[0])
+        version = epoch_version[1]
+    else:
+        # more than one ':'
+        msg = _("failed to parse nevr '%s' not a valid nevr") % name
+        _LOGGER.exception(msg)
+        raise ValueError(msg)
+
+    return package_name, epoch, version, release
+
+
+def migrate_modulemd_artifacts(modulemd):
+    """
+    Set is_modular flag to True for modulemd's artifacts.
+
+    :param modulemd: module for which artifacts should be updated
+    :type  modulemd: pulp_rpm.plugins.db.models.Modulemd
+    """
+    delta = {'is_modular': True}
+    for artifact in modulemd.get('artifacts'):
+        pkg_nevra = nevra(artifact)
+        search_criteria = {'name': pkg_nevra[0],
+                           'epoch': unicode(pkg_nevra[1]),
+                           'version': pkg_nevra[2],
+                           'release': pkg_nevra[3],
+                           'arch': pkg_nevra[4],
+                           NEW_FIELD: {'$exists': False}}
+
+        for rpm in units_rpm_collection.find(search_criteria, ['_id']):
+            units_rpm_collection.update_one({'_id': rpm['_id']}, {'$set': delta})
+
+
+def migrate(*args, **kwargs):
+    """
+    Add `is_modular` field to RPM collection.
+
+    Set this field appropriately for RPM collection based on available info in modulemd units.
+
+    :param args:   unused
+    :type  args:   list
+    :param kwargs: unused
+    :type  kwargs: dict
+    """
+    total_modulemd_units = units_modulemd_collection.count()
+
+    with utils.MigrationProgressLog('Modulemd artifacts', total_modulemd_units) as migration_log:
+        for modulemd in units_modulemd_collection.find({}, ['artifacts']).batch_size(100):
+            migrate_modulemd_artifacts(modulemd)
+            migration_log.progress()
+
+    total_rpm_units = units_rpm_collection.count({NEW_FIELD: {'$exists': False}})
+
+    if total_rpm_units:
+        with utils.MigrationProgressLog('RPM', total_rpm_units) as migration_log:
+            units_rpm_collection.update_many({NEW_FIELD: {'$exists': False}},
+                                             {'$set': {NEW_FIELD: False}})
+            migration_log.progress(migrated_units=total_rpm_units)


### PR DESCRIPTION
* Add new field `is_modular` for Rpm model
* Inspect headers to mark RPMs as modular during upload
* Mark RPMs as modular during sync based on artifacts info in modules.yaml
* Inspect headers to mark RPMs as modular ones upon successful download
* Migrate all RPMs, set `is_modular` to True based on data in Modulemd units

closes #4049
https://pulp.plan.io/issues/4049