### PR TITLE
Add test to sync/publish different types of RPMs

### DIFF
--- a/pulp_rpm/tests/functional/api/test_crud_content_unit.py
+++ b/pulp_rpm/tests/functional/api/test_crud_content_unit.py
@@ -53,10 +53,10 @@ class ContentUnitTestCase(unittest.TestCase):
     def test_01_create_content_unit(self):
         """Create content unit."""
         self.content_unit.update(
-            self.client.post(
-                RPM_CONTENT_PATH,
-                {'artifact': self.artifact['_href'], 'filename': RPM_PACKAGE_FILENAME}
-            )
+            self.client.post(RPM_CONTENT_PATH, {
+                'artifact': self.artifact['_href'],
+                'filename': RPM_PACKAGE_FILENAME
+            })
         )
         for key, val in RPM_PACKAGE_DATA.items():
             with self.subTest(key=key):

--- a/pulp_rpm/tests/functional/api/test_publish.py
+++ b/pulp_rpm/tests/functional/api/test_publish.py
@@ -21,11 +21,15 @@ from pulp_rpm.tests.functional.utils import (
     gen_rpm_remote,
 )
 from pulp_rpm.tests.functional.constants import (
+    RPM_ALT_LAYOUT_FIXTURE_URL,
     RPM_CONTENT_PATH,
     RPM_FIXTURE_CONTENT_SUMMARY,
+    RPM_LONG_UPDATEINFO_FIXTURE_URL,
     RPM_PUBLISHER_PATH,
     RPM_REFERENCES_UPDATEINFO_URL,
     RPM_REMOTE_PATH,
+    RPM_RICH_WEAK_FIXTURE_URL,
+    RPM_SHA512_FIXTURE_URL,
 )
 from pulp_rpm.tests.functional.utils import set_up_module as setUpModule  # noqa:F401
 
@@ -137,3 +141,53 @@ class SyncPublishReferencesUpdateTestCase(unittest.TestCase):
 
         publication = publish(cfg, publisher, repo)
         self.addCleanup(client.delete, publication['_href'])
+
+
+class SyncPublishTestCase(unittest.TestCase):
+    """Test sync and publish for different RPM repositories.
+
+    This test targets the following issue:
+
+    `Pulp #4134 <https://pulp.plan.io/issues/4134>`_.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Create class-wide variables."""
+        cls.cfg = config.get_config()
+        cls.client = api.Client(cls.cfg, api.page_handler)
+
+    def test_rpm_rich_weak(self):
+        """Sync and publish an RPM repository. See :meth: `do_test`."""
+        self.do_test(RPM_RICH_WEAK_FIXTURE_URL)
+
+    def test_rpm_long_updateinfo(self):
+        """Sync and publish an RPM repository. See :meth: `do_test`."""
+        self.do_test(RPM_LONG_UPDATEINFO_FIXTURE_URL)
+
+    def test_rpm_alt_layout(self):
+        """Sync and publish an RPM repository. See :meth: `do_test`."""
+        self.do_test(RPM_ALT_LAYOUT_FIXTURE_URL)
+
+    def test_rpm_sha512(self):
+        """Sync and publish an RPM repository. See :meth: `do_test`."""
+        self.do_test(RPM_SHA512_FIXTURE_URL)
+
+    def do_test(self, url):
+        """Sync and publish an RPM repository given a feed URL."""
+        repo = self.client.post(REPO_PATH, gen_repo())
+        self.addCleanup(self.client.delete, repo['_href'])
+
+        remote = self.client.post(RPM_REMOTE_PATH, gen_rpm_remote(url=url))
+        self.addCleanup(self.client.delete, remote['_href'])
+
+        sync(self.cfg, remote, repo)
+        repo = self.client.get(repo['_href'])
+
+        self.assertIsNotNone(repo['_latest_version_href'])
+
+        publisher = self.client.post(RPM_PUBLISHER_PATH, gen_rpm_publisher())
+        self.addCleanup(self.client.delete, publisher['_href'])
+
+        publication = publish(self.cfg, publisher, repo)
+        self.addCleanup(self.client.delete, publication['_href'])

--- a/pulp_rpm/tests/functional/api/test_sync.py
+++ b/pulp_rpm/tests/functional/api/test_sync.py
@@ -48,10 +48,11 @@ class BasicSyncTestCase(unittest.TestCase):
         3. Sync the remote.
         4. Assert that repository version is not None.
         5. Assert that the correct number of units were added and are present
-        in the repo.
+           in the repo.
         6. Sync the remote one more time.
         7. Assert that repository version is different from the previous one.
-        8. Assert that the same number of are present and that no units were added.
+        8. Assert that the same number of are present and that no units were
+           added.
         """
         client = api.Client(self.cfg, api.json_handler)
 
@@ -70,7 +71,10 @@ class BasicSyncTestCase(unittest.TestCase):
 
         # Check that we have the correct content counts.
         self.assertIsNotNone(repo['_latest_version_href'])
-        self.assertDictEqual(get_content_summary(repo), RPM_FIXTURE_CONTENT_SUMMARY)
+        self.assertDictEqual(
+            get_content_summary(repo),
+            RPM_FIXTURE_CONTENT_SUMMARY
+        )
         self.assertEqual(len(get_added_content(repo)), RPM_FIXTURE_COUNT)
 
         # Sync the repository again.
@@ -80,7 +84,10 @@ class BasicSyncTestCase(unittest.TestCase):
 
         # Check that nothing has changed since the last sync.
         self.assertNotEqual(latest_version_href, repo['_latest_version_href'])
-        self.assertDictEqual(get_content_summary(repo), RPM_FIXTURE_CONTENT_SUMMARY)
+        self.assertDictEqual(
+            get_content_summary(repo),
+            RPM_FIXTURE_CONTENT_SUMMARY
+        )
         self.assertEqual(len(get_added_content(repo)), 0)
 
 
@@ -94,18 +101,21 @@ class SyncMutatedPackagesTestCase(unittest.TestCase):
         cls.cfg = config.get_config()
 
     def test_all(self):
-        """Sync two copies of the same packages, make sure we end up with only one copy.
+        """Sync two copies of the same packages.
+
+        Make sure we end up with only one copy.
 
         Do the following:
 
         1. Create a repository and a remote.
         2. Sync the remote.
         3. Assert that the content summary matches what is expected.
-        4. Create a new remote w/ using fixture containing updated errata (packages with the same
-           NEVRA as the existing package content, but different pkgId)
+        4. Create a new remote w/ using fixture containing updated errata
+           (packages with the same NEVRA as the existing package content, but
+           different pkgId).
         5. Sync the remote again.
-        6. Assert that repository version is different from the previous one but has the same
-           content summary.
+        6. Assert that repository version is different from the previous one
+           but has the same content summary.
         7. Assert that the packages have changed since the last sync.
         """
         client = api.Client(self.cfg, api.json_handler)
@@ -122,7 +132,10 @@ class SyncMutatedPackagesTestCase(unittest.TestCase):
         self.assertIsNone(repo['_latest_version_href'])
         sync(self.cfg, remote, repo)
         repo = client.get(repo['_href'])
-        self.assertDictEqual(get_content_summary(repo), RPM_FIXTURE_CONTENT_SUMMARY)
+        self.assertDictEqual(
+            get_content_summary(repo),
+            RPM_FIXTURE_CONTENT_SUMMARY
+        )
 
         # Save a copy of the original packages.
         original_packages = {
@@ -130,7 +143,8 @@ class SyncMutatedPackagesTestCase(unittest.TestCase):
             if content['type'] == 'packages'
         }
 
-        # Create a remote with a different test fixture with the same NEVRA but different digests.
+        # Create a remote with a different test fixture with the same NEVRA but
+        # different digests.
         body = gen_rpm_remote(url=RPM_SIGNED_FIXTURE_URL)
         remote = client.post(RPM_REMOTE_PATH, body)
         self.addCleanup(client.delete, remote['_href'])
@@ -138,7 +152,10 @@ class SyncMutatedPackagesTestCase(unittest.TestCase):
         # Sync the repository again.
         sync(self.cfg, remote, repo)
         repo = client.get(repo['_href'])
-        self.assertDictEqual(get_content_summary(repo), RPM_FIXTURE_CONTENT_SUMMARY)
+        self.assertDictEqual(
+            get_content_summary(repo),
+            RPM_FIXTURE_CONTENT_SUMMARY
+        )
         self.assertEqual(len(get_added_content(repo)), 0)
 
         # Test that the packages have been modified.
@@ -148,8 +165,10 @@ class SyncMutatedPackagesTestCase(unittest.TestCase):
         }
 
         self.assertNotEqual(mutated_packages, original_packages)
-        self.assertNotEqual(mutated_packages[RPM_PACKAGE_NAME]['pkgId'],
-                            original_packages[RPM_PACKAGE_NAME]['pkgId'])
+        self.assertNotEqual(
+            mutated_packages[RPM_PACKAGE_NAME]['pkgId'],
+            original_packages[RPM_PACKAGE_NAME]['pkgId']
+        )
 
 
 @unittest.skip('FIXME: Enable this test after we can throw out duplicate UpdateRecords')
@@ -162,7 +181,9 @@ class SyncMutatedUpdateRecordTestCase(unittest.TestCase):
         cls.cfg = config.get_config()
 
     def test_all(self):
-        """Sync two copies of the same UpdateRecords, make sure we end up with only one copy.
+        """Sync two copies of the same UpdateRecords.
+
+        Make sure we end up with only one copy.
 
         Do the following:
 
@@ -170,11 +191,11 @@ class SyncMutatedUpdateRecordTestCase(unittest.TestCase):
         2. Sync the remote.
         3. Assert that the content summary matches what is expected.
         4. Create a new remote w/ using fixture containing updated errata
-        (updaterecords with the ID as the existing updaterecord content, but
-        different metadata)
+           (updaterecords with the ID as the existing updaterecord content, but
+           different metadata).
         5. Sync the remote again.
         6. Assert that repository version is different from the previous one
-        but has the same content summary.
+           but has the same content summary.
         7. Assert that the updaterecords have changed since the last sync.
         """
         client = api.Client(self.cfg, api.json_handler)

--- a/pulp_rpm/tests/functional/constants.py
+++ b/pulp_rpm/tests/functional/constants.py
@@ -9,6 +9,10 @@ from pulp_smash.pulp3.constants import (
     CONTENT_PATH,
 )
 
+
+RPM_ALT_LAYOUT_FIXTURE_URL = urljoin(PULP_FIXTURES_BASE_URL, 'rpm-alt-layout/')
+"""The URL to a signed RPM repository. See :data:`RPM_SIGNED_FIXTURE_URL`."""
+
 RPM_CONTENT_PATH = urljoin(CONTENT_PATH, 'rpm/packages/')
 """The location of RPM packages on the content endpoint."""
 
@@ -18,6 +22,9 @@ RPM_PUBLISHER_PATH = urljoin(BASE_PUBLISHER_PATH, 'rpm/')
 
 RPM_SIGNED_FIXTURE_URL = urljoin(PULP_FIXTURES_BASE_URL, 'rpm-signed/')
 """The URL to a repository with signed RPM packages."""
+
+RPM_SHA512_FIXTURE_URL = urljoin(PULP_FIXTURES_BASE_URL, 'rpm-with-sha-512/')
+"""The URL to an RPM repository with sha512 checksum."""
 
 RPM_UNSIGNED_FIXTURE_URL = urljoin(PULP_FIXTURES_BASE_URL, 'rpm-unsigned/')
 """The URL to a repository with unsigned RPM packages."""
@@ -34,6 +41,12 @@ standard repositories, i.e. :data:`RPM_SIGNED_FIXTURE_URL` and
 "content_summary" field on "../repositories/../versions/../".
 """
 
+RPM_LONG_UPDATEINFO_FIXTURE_URL = urljoin(
+    PULP_FIXTURES_BASE_URL,
+    'rpm-long-updateinfo/'
+)
+"""The URL to RPM with a long updateinfo.xml."""
+
 RPM_PACKAGE_DATA = {
     'name': 'bear',
     'epoch': '0',
@@ -45,7 +58,8 @@ RPM_PACKAGE_DATA = {
     'rpm_license': 'GPLv2',
     'rpm_group': 'Internet/Applications',
     'rpm_vendor': '',
-    # TODO: Complete this information once we figure out how to serialize everything nicely
+    # TODO: Complete this information once we figure out how to serialize
+    # everything nicely
 }
 """The metadata for one RPM package."""
 
@@ -70,15 +84,22 @@ This repository includes errata with reference element (0, 1 or 2 references)
 and without it.
 """
 
+RPM_RICH_WEAK_FIXTURE_URL = urljoin(
+    PULP_FIXTURES_BASE_URL,
+    'rpm-richnweak-deps/'
+)
+"""The URL to an RPM repository with weak and rich dependencies."""
+
 RPM_SIGNED_URL = urljoin(RPM_SIGNED_FIXTURE_URL, RPM_PACKAGE_FILENAME)
 """The path to a single signed RPM package."""
 
 RPM_UNSIGNED_URL = urljoin(RPM_UNSIGNED_FIXTURE_URL, RPM_PACKAGE_FILENAME)
 """The path to a single unsigned RPM package."""
 
-
 RPM_UPDATED_UPDATEINFO_FIXTURE_URL = urljoin(
-    PULP_FIXTURES_BASE_URL, 'rpm-updated-updateinfo/')
+    PULP_FIXTURES_BASE_URL,
+    'rpm-updated-updateinfo/'
+)
 """The URL to a repository containing UpdateRecords (Errata) with the same IDs
 as the ones in the standard repositories, but with different metadata.
 

--- a/pulp_rpm/tests/functional/utils.py
+++ b/pulp_rpm/tests/functional/utils.py
@@ -71,12 +71,14 @@ def get_rpm_package_paths(repo):
 
 
 def populate_pulp(cfg, url=RPM_SIGNED_FIXTURE_URL):
-    """Add rpm contents to Pulp.
+    """Add RPM contents to Pulp.
 
-    :param pulp_smash.config.PulpSmashConfig: Information about a Pulp application.
-    :param url: The rpm repository URL. Defaults to
-        :data:`pulp_smash.constants.RPM_SIGNED_FIXTURE_URL`
-    :returns: A list of dicts, where each dict describes one file content in Pulp.
+    :param pulp_smash.config.PulpSmashConfig: Information about a Pulp
+        application.
+    :param url: The RPM repository URL. Defaults to
+        :data:`pulp_smash.constants.RPM_UNSIGNED_FIXTURE_URL`
+    :returns: A list of dicts, where each dict describes one RPM content in
+        Pulp.
     """
     client = api.Client(cfg, api.json_handler)
     remote = {}


### PR DESCRIPTION
Add tests to sync/publish with different types of RPMs repositories.

* Long updateinfo
* Alternative repo layout
* RPM with sha512

ref: #4134
https://pulp.plan.io/issues/4134

