### PR TITLE
Add test for non-ascii RPM metadata encoding

### DIFF
--- a/pulp_rpm/tests/functional/api/test_character_encoding.py
+++ b/pulp_rpm/tests/functional/api/test_character_encoding.py
@@ -1,0 +1,61 @@
+# coding=utf-8
+"""Tests for Pulp's characters encoding."""
+import unittest
+
+from pulp_smash import api, config, utils
+from pulp_smash.pulp3.constants import ARTIFACTS_PATH, REPO_PATH
+from pulp_smash.pulp3.utils import (
+    delete_orphans,
+    gen_repo,
+    get_versions,
+)
+
+from pulp_rpm.tests.functional.constants import (
+    RPM_CONTENT_PATH,
+    RPM_WITH_NON_ASCII_NAME,
+    RPM_WITH_NON_ASCII_URL,
+)
+from pulp_rpm.tests.functional.utils import set_up_module as setUpModule  # noqa:F401
+
+
+class UploadEncodingMetadataTestCase(unittest.TestCase):
+    """Test upload of RPMs with different character encoding.
+
+    This test targets the following issues:
+
+    * `Pulp #4210 <https://pulp.plan.io/issues/4210>`_
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Create class-wide variable."""
+        cls.cfg = config.get_config()
+        cls.client = api.Client(cls.cfg, api.json_handler)
+
+    @classmethod
+    def tearDownClass(cls):
+        """Clean class-wide variable."""
+        delete_orphans(cls.cfg)
+
+    def test_upload_non_ascii(self):
+        """Test whether one can upload an RPM with non-ascii metadata."""
+        self.do_test(RPM_WITH_NON_ASCII_URL, RPM_WITH_NON_ASCII_NAME)
+
+    def do_test(self, url, filename):
+        """Test whether one can upload an RPM."""
+        files = {'file': utils.http_get(url)}
+        artifact = self.client.post(ARTIFACTS_PATH, files=files)
+        content_unit = self.client.post(RPM_CONTENT_PATH, {
+            'artifact': artifact['_href'],
+            'filename': filename
+        })
+        repo = self.client.post(REPO_PATH, gen_repo())
+        self.addCleanup(self.client.delete, repo['_href'])
+        repo_versions = get_versions(repo)
+        self.assertEqual(len(repo_versions), 0, repo_versions)
+        self.client.post(
+            repo['_versions_href'],
+            {'add_content_units': [content_unit['_href']]}
+        )
+        repo_versions = get_versions(repo)
+        self.assertEqual(len(repo_versions), 1, repo_versions)

--- a/pulp_rpm/tests/functional/constants.py
+++ b/pulp_rpm/tests/functional/constants.py
@@ -9,7 +9,6 @@ from pulp_smash.pulp3.constants import (
     CONTENT_PATH,
 )
 
-
 RPM_ALT_LAYOUT_FIXTURE_URL = urljoin(PULP_FIXTURES_BASE_URL, 'rpm-alt-layout/')
 """The URL to a signed RPM repository. See :data:`RPM_SIGNED_FIXTURE_URL`."""
 
@@ -117,6 +116,22 @@ repositories, i.e. :data:`RPM_SIGNED_FIXTURE_URL` and
 
 RPM_UPDATERECORD_RPM_NAME = 'gorilla'
 """The name of the RPM named by :data:`RPM_UPDATERECORD_ID`."""
+
+RPM_WITH_NON_ASCII_NAME = 'rpm-with-non-ascii'
+
+RPM_WITH_NON_ASCII_URL = urljoin(
+    PULP_FIXTURES_BASE_URL,
+    'rpm-with-non-ascii/{}-1-1.fc25.noarch.rpm'.format(RPM_WITH_NON_ASCII_NAME)
+)
+"""The URL to an RPM with non-ascii metadata in its header."""
+
+RPM_WITH_NON_UTF_8_NAME = 'rpm-with-non-utf-8'
+
+RPM_WITH_NON_UTF_8_URL = urljoin(
+    PULP_FIXTURES_BASE_URL,
+    'rpm-with-non-utf-8/{}-1-1.fc25.noarch.rpm'.format(RPM_WITH_NON_UTF_8_NAME)
+)
+"""The URL to an RPM with non-UTF-8 metadata in its header."""
 
 UPDATERECORD_CONTENT_PATH = urljoin(CONTENT_PATH, 'rpm/updates/')
 """The location of RPM UpdateRecords on the content endpoint."""


### PR DESCRIPTION
Add test for non-ascii RPM metadata. Upload non-ascii RPM to pulp and assert
that no error was raised.

https://pulp.plan.io/issues/4210
ref #4210