### PR TITLE
Update importer.py

### DIFF
--- a/plugins/pulp_rpm/plugins/importers/iso/importer.py
+++ b/plugins/pulp_rpm/plugins/importers/iso/importer.py
@@ -152,8 +152,10 @@ class ISOImporter(Importer):
             iso = iso.__class__.objects.get(**iso.unit_key)
 
         # remove any existing units with the same name
+        unit_keys_same_name = models.ISO.objects(name=iso['name']).values_list('id')
         units = repo_controller.find_repo_content_units(transfer_repo.repo_obj,
-                                                        units_q=Q(name=iso['name']),
+                                                        repo_content_unit_q=Q(
+                                                            unit_id__in=unit_keys_same_name),
                                                         yield_content_unit=True)
         repo_controller.disassociate_units(transfer_repo.repo_obj, units)
 


### PR DESCRIPTION
Adding a search criteria to filter out units as need to improve performance of "find_repo_content_units".

We suffered serious performance to uploading units to a repo when data volume get larger and larger. After applying the change, performance improved. In addition, some our internal function tests had been done, it's pass.