### PR TITLE
One shot RPM uploader

### DIFF
--- a/docs/workflows/upload.rst
+++ b/docs/workflows/upload.rst
@@ -42,3 +42,11 @@ Add content to repository ``foo``
 
 ``$ http POST :8000${REPO_HREF}versions/ add_content_units:="[\"$CONTENT_HREF\"]"``
 
+
+One shot upload
+---------------
+
+You can use feature to upload one rpm directly to repository which substitute
+previous three steps (create artifact, content from artifact and add content to repo).
+
+``http --form POST http://localhost:8000/pulp/api/v3/rpm/upload/ file@./foo-1.0-1.noarch.rpm repository=/pulp/api/v3/repositories/1/``

--- a/pulp_rpm/app/serializers.py
+++ b/pulp_rpm/app/serializers.py
@@ -2,6 +2,7 @@ from gettext import gettext as _
 
 from rest_framework import serializers
 
+from pulpcore.plugin.models import Repository
 from pulpcore.plugin.serializers import (
     NoArtifactContentSerializer,
     SingleArtifactContentSerializer,
@@ -279,3 +280,20 @@ class MinimalUpdateRecordSerializer(UpdateRecordSerializer):
             'id', 'title', 'severity', 'type'
         )
         model = UpdateRecord
+
+
+class OneShotUploadSerializer(serializers.Serializer):
+    """
+    A serializer for the One Shot Upload API.
+    """
+
+    repository = serializers.HyperlinkedRelatedField(
+        help_text=_('A URI of the repository.'),
+        required=False,
+        queryset=Repository.objects.all(),
+        view_name='repositories-detail',
+    )
+    file = serializers.FileField(
+        help_text=_("The rpm file."),
+        required=True,
+    )

--- a/pulp_rpm/app/shared_utils.py
+++ b/pulp_rpm/app/shared_utils.py
@@ -1,0 +1,42 @@
+import createrepo_c
+import json
+import os
+import tempfile
+import shutil
+
+from pulp_rpm.app.models import Package
+
+
+def _prepare_package(artifact, filename):
+    """
+    Helper function for creating package.
+
+    Copy file to a temp directory under
+    the user provided filename and
+    parsing it into a saveable format.
+
+    Returns: artifact model as dict
+
+    Args:
+        artifact: inited and validated artifact to save
+        filename: name of file uploaded by user
+    """
+    # Copy file to a temp directory under the user provided filename
+    with tempfile.TemporaryDirectory() as td:
+        temp_path = os.path.join(td, filename)
+        shutil.copy2(artifact.file.path, temp_path)
+        cr_pkginfo = createrepo_c.package_from_rpm(temp_path)
+
+        package = Package.createrepo_to_dict(cr_pkginfo)
+
+    package['location_href'] = filename
+
+    # parsing it into a saveable format
+    new_pkg = {}
+    for key, value in package.items():
+        if isinstance(value, list):
+            new_pkg[key] = json.dumps(value)
+        else:
+            new_pkg[key] = value
+
+    return new_pkg

--- a/pulp_rpm/app/upload.py
+++ b/pulp_rpm/app/upload.py
@@ -1,0 +1,39 @@
+import os
+
+from pulp_rpm.app.shared_utils import _prepare_package
+from pulp_rpm.app.models import Package
+from pulpcore.app.models.content import ContentArtifact
+from pulpcore.app.models.repository import RepositoryVersion
+
+
+def one_shot_upload(artifact, repository=None):
+    """
+    One shot upload for RPM package.
+
+    Args:
+        artifact: validated artifact for a file
+        repository: repository to extend with new pkg
+        path: artifact href
+    """
+    filename = os.path.basename(artifact.file.path)
+
+    # export META from rpm and prepare dict as saveable format
+    try:
+        new_pkg = _prepare_package(artifact, filename)
+    except OSError:
+        raise OSError('RPM file cannot be parsed for metadata.')
+
+    pkg, created = Package.objects.get_or_create(**new_pkg)
+
+    ContentArtifact.objects.create(
+        artifact=artifact,
+        content=pkg,
+        relative_path=filename
+    )
+
+    if repository:
+        content_to_add = Package.objects.filter(pkgId=pkg.pkgId)
+
+        # create new repo version with uploaded package
+        with RepositoryVersion.create(repository) as new_version:
+            new_version.add_content(content_to_add)

--- a/pulp_rpm/app/urls.py
+++ b/pulp_rpm/app/urls.py
@@ -1,0 +1,8 @@
+from django.conf.urls import url
+
+from .viewsets import OneShotUploadView
+
+
+urlpatterns = [
+    url(r'rpm/upload/$', OneShotUploadView.as_view())
+]


### PR DESCRIPTION
RFE to upload one RPM file and optionally create new
version of repository with this added package.

closes: #4087
https://pulp.plan.io/issues/4087

Signed-off-by: Pavel Picka <ppicka@redhat.com>