### PR TITLE
Changes for the new field names on Content

### DIFF
--- a/pulp_rpm/app/models.py
+++ b/pulp_rpm/app/models.py
@@ -182,7 +182,7 @@ class Package(Content):
         """
         Return the artifact id (there is only one for this content type).
         """
-        return self.artifacts.get().pk
+        return self._artifacts.get().pk
 
     @artifact.setter
     def artifact(self, artifact):
@@ -321,7 +321,7 @@ class UpdateRecord(Content):
     TYPE = 'update'
 
     # Required metadata
-    errata_id = models.TextField(db_index=True)  # TODO: change field name?
+    id = models.TextField(db_index=True)
     updated_date = models.TextField()
 
     # Optional metadata
@@ -333,7 +333,7 @@ class UpdateRecord(Content):
     summary = models.TextField(blank=True)
     version = models.TextField(blank=True)
 
-    update_type = models.TextField(blank=True)  # TODO: change field name?
+    type = models.TextField(blank=True)  # TODO: change field name?
     severity = models.TextField(blank=True)
     solution = models.TextField(blank=True)
     release = models.TextField(blank=True)
@@ -366,7 +366,7 @@ class UpdateRecord(Content):
 
         """
         return {
-            'errata_id': getattr(update, CREATEREPO_UPDATE_RECORD_ATTRS.ID),
+            'id': getattr(update, CREATEREPO_UPDATE_RECORD_ATTRS.ID),
             'updated_date': str(getattr(update, CREATEREPO_UPDATE_RECORD_ATTRS.UPDATED_DATE)),
             'description': getattr(update, CREATEREPO_UPDATE_RECORD_ATTRS.DESCRIPTION) or '',
             'issued_date': str(getattr(update, CREATEREPO_UPDATE_RECORD_ATTRS.ISSUED_DATE)) or '',
@@ -375,7 +375,7 @@ class UpdateRecord(Content):
             'title': getattr(update, CREATEREPO_UPDATE_RECORD_ATTRS.TITLE) or '',
             'summary': getattr(update, CREATEREPO_UPDATE_RECORD_ATTRS.SUMMARY) or '',
             'version': getattr(update, CREATEREPO_UPDATE_RECORD_ATTRS.VERSION) or '',
-            'update_type': getattr(update, CREATEREPO_UPDATE_RECORD_ATTRS.TYPE) or '',
+            'type': getattr(update, CREATEREPO_UPDATE_RECORD_ATTRS.TYPE) or '',
             'severity': getattr(update, CREATEREPO_UPDATE_RECORD_ATTRS.SEVERITY) or '',
             'solution': getattr(update, CREATEREPO_UPDATE_RECORD_ATTRS.SOLUTION) or '',
             'release': getattr(update, CREATEREPO_UPDATE_RECORD_ATTRS.RELEASE) or '',

--- a/pulp_rpm/app/serializers.py
+++ b/pulp_rpm/app/serializers.py
@@ -188,7 +188,7 @@ class PackageSerializer(ContentSerializer):
         return package
 
     class Meta:
-        fields = tuple(set(ContentSerializer.Meta.fields) - {'artifacts'}) + (
+        fields = tuple(set(ContentSerializer.Meta.fields) - {'_artifacts'}) + (
             'artifact',
             'name', 'epoch', 'version', 'release', 'arch', 'pkgId', 'checksum_type',
             'summary', 'description', 'url', 'changelogs', 'files',
@@ -241,7 +241,7 @@ class UpdateRecordSerializer(ContentSerializer):
     A Serializer for UpdateRecord.
     """
 
-    errata_id = serializers.CharField(
+    id = serializers.CharField(
         help_text=_("Update id (short update name, e.g. RHEA-2013:1777)")
     )
     updated_date = serializers.CharField(
@@ -270,7 +270,7 @@ class UpdateRecordSerializer(ContentSerializer):
         help_text=_("Update version (probably always an integer number)")
     )
 
-    update_type = serializers.CharField(
+    type = serializers.CharField(
         help_text=_("Update type ('enhancement', 'bugfix', ...)")
     )
     severity = serializers.CharField(
@@ -292,9 +292,9 @@ class UpdateRecordSerializer(ContentSerializer):
 
     class Meta:
         fields = ContentSerializer.Meta.fields + (
-            'errata_id', 'updated_date', 'description', 'issued_date',
+            'id', 'updated_date', 'description', 'issued_date',
             'fromstr', 'status', 'title', 'summary', 'version',
-            'update_type', 'severity', 'solution', 'release', 'rights',
+            'type', 'severity', 'solution', 'release', 'rights',
             'pushcount'
         )
         model = UpdateRecord
@@ -307,6 +307,6 @@ class MinimalUpdateRecordSerializer(UpdateRecordSerializer):
 
     class Meta:
         fields = ContentSerializer.Meta.fields + (
-            'errata_id', 'title', 'severity', 'update_type'
+            'id', 'title', 'severity', 'type'
         )
         model = UpdateRecord

--- a/pulp_rpm/app/tasks/publishing.py
+++ b/pulp_rpm/app/tasks/publishing.py
@@ -38,9 +38,9 @@ def update_record_xml(update_record):
     rec = cr.UpdateRecord()
     rec.fromstr = update_record.fromstr
     rec.status = update_record.status
-    rec.type = update_record.update_type
+    rec.type = update_record.type
     rec.version = update_record.version
-    rec.id = update_record.errata_id
+    rec.id = update_record.id
     rec.title = update_record.title
     rec.issued_date = parse_datetime(update_record.issued_date)
     rec.updated_date = parse_datetime(update_record.updated_date)

--- a/pulp_rpm/app/viewsets.py
+++ b/pulp_rpm/app/viewsets.py
@@ -202,10 +202,10 @@ class UpdateRecordFilter(ContentFilter):
     class Meta:
         model = UpdateRecord
         fields = {
-            'errata_id': ['exact', 'in'],
+            'id': ['exact', 'in'],
             'status': ['exact', 'in'],
             'severity': ['exact', 'in'],
-            'update_type': ['exact', 'in'],
+            'type': ['exact', 'in'],
         }
 
 

--- a/pulp_rpm/tests/functional/api/test_sync.py
+++ b/pulp_rpm/tests/functional/api/test_sync.py
@@ -172,7 +172,7 @@ class SyncMutatedPackagesTestCase(unittest.TestCase):
 
         # Save a copy of the original packages.
         original_packages = {
-            content['errata_id']: content
+            content['id']: content
             for content in get_content(repo)[RPM_PACKAGE_CONTENT_NAME]
             if content['type'] == 'packages'
         }
@@ -197,7 +197,7 @@ class SyncMutatedPackagesTestCase(unittest.TestCase):
 
         # Test that the packages have been modified.
         mutated_packages = {
-            content['errata_id']: content
+            content['id']: content
             for content in get_content(repo)[RPM_PACKAGE_CONTENT_NAME]
             if content['type'] == 'update'
         }
@@ -260,7 +260,7 @@ class SyncMutatedUpdateRecordTestCase(unittest.TestCase):
 
         # Save a copy of the original updateinfo
         original_updaterecords = {
-            content['errata_id']: content
+            content['id']: content
             for content in get_content(repo)[RPM_PACKAGE_CONTENT_NAME]
             if content['type'] == 'update'
         }
@@ -285,7 +285,7 @@ class SyncMutatedUpdateRecordTestCase(unittest.TestCase):
 
         # Test that the updateinfo have been modified.
         mutated_updaterecords = {
-            content['errata_id']: content
+            content['id']: content
             for content in get_content(repo)[RPM_PACKAGE_CONTENT_NAME]
             if content['type'] == 'update'
         }


### PR DESCRIPTION
Update errata_id and update_type now that id and type have been renamed
on Content. Also, fix a couple places that reference _artifacts.

fixes #4207
https://pulp.plan.io/issues/4207