### PR TITLE
Fix multiple bugs related to modularity

### DIFF
--- a/plugins/pulp_rpm/plugins/distributors/yum/metadata/modules.py
+++ b/plugins/pulp_rpm/plugins/distributors/yum/metadata/modules.py
@@ -1,0 +1,37 @@
+import hashlib
+import os
+
+from pulp.plugins.util.metadata_writer import MetadataFileContext
+from pulp.server.exceptions import PulpCodedException
+
+from pulp_rpm.common.constants import CONFIG_DEFAULT_CHECKSUM
+from pulp_rpm.plugins import error_codes
+from pulp_rpm.plugins.distributors.yum.metadata.metadata import REPO_DATA_DIR_NAME
+from pulp_rpm.yum_plugin import util
+
+
+_LOG = util.getLogger(__name__)
+
+MODULES_FILE_NAME = 'modules.yaml.gz'
+
+
+# Note that this is "MetadataFileContext" from the core plugin API, not from
+# pulp_rpm.plugin.distributors.yum.metadata.metadata
+class ModulesFileContext(MetadataFileContext):
+
+    def __init__(self, working_dir, checksum_type=CONFIG_DEFAULT_CHECKSUM):
+        metadata_file_path = os.path.join(working_dir, REPO_DATA_DIR_NAME, MODULES_FILE_NAME)
+        super(ModulesFileContext, self).__init__(metadata_file_path, checksum_type)
+
+    def initialize(self):
+        super(ModulesFileContext, self).initialize()
+
+    def finalize(self):
+        super(ModulesFileContext, self).finalize()
+
+    def add_document(self, document, doc_checksum):
+        checksum = hashlib.sha256(document).hexdigest()
+        if checksum == doc_checksum:
+            self.metadata_file_handle.write(document)
+        else:
+            raise PulpCodedException(error_codes.RPM1017)


### PR DESCRIPTION
Ensure we don't publish module metadata files for repositories where the source repo had none.

Use the correct mechanism for determining the checksum used in the name
of the modules.yaml.gz metadata file.

Additionally, refactor the module publish step to be more similar to the
others.

closes #4252
https://pulp.plan.io/issues/4252
closes #4253
https://pulp.plan.io/issues/4253