### PR TITLE
Fix unit_metadata is ignore during iso import [DELIVERY-5965]

### DIFF
--- a/plugins/pulp_rpm/plugins/importers/iso/importer.py
+++ b/plugins/pulp_rpm/plugins/importers/iso/importer.py
@@ -137,6 +137,11 @@ class ISOImporter(Importer):
             # this is a new ISO, create it
             iso = models.ISO(**unit_key)
 
+        # if metadata avaiable, set/update it
+        if metadata:
+            for key, value in metadata.iteritems():
+                setattr(iso, key, value)
+
         validate = config.get_boolean(importer_constants.KEY_VALIDATE)
         validate = validate if validate is not None else constants.CONFIG_VALIDATE_DEFAULT
         try:

--- a/plugins/test/unit/plugins/importers/iso/test_importer.py
+++ b/plugins/test/unit/plugins/importers/iso/test_importer.py
@@ -338,7 +338,7 @@ class TestISOImporter(PulpRPMTests):
         repo.working_dir = working_dir
         unit_key = {'name': 'test.iso', 'size': 16,
                     'checksum': 'f02d5a72cd2d57fa802840a76b44c6c6920a8b8e6b90b20e26c03876275069e0'}
-        metadata = {}
+        metadata = {'checksum_type': 'sha256'}
         temp_file_location = os.path.join(self.temp_dir, 'test.iso')
         with open(temp_file_location, 'w') as temp_file:
             temp_file.write(file_data)


### PR DESCRIPTION
Now pulp will set/update the metadata during iso upload

Fix #2729
https://pulp.plan.io/issues/2729