### PR TITLE
Fix gen_yum_config_file function and reads content_host role.

### DIFF
--- a/pulp_rpm/tests/functional/api/test_consume_content.py
+++ b/pulp_rpm/tests/functional/api/test_consume_content.py
@@ -64,10 +64,10 @@ class PackageManagerConsumeTestCase(unittest.TestCase):
 
         repo_path = gen_yum_config_file(
             cfg,
-            baseurl=urljoin(cfg.get_base_url(), urljoin(
-                'pulp/content/',
-                distribution['base_path']
-            )),
+            baseurl=urljoin(
+                cfg.get_content_host_base_url(),
+                '//' + distribution['base_url']
+            ),
             name=repo['name'],
             repositoryid=repo['name']
         )

--- a/pulp_rpm/tests/functional/api/test_download_content.py
+++ b/pulp_rpm/tests/functional/api/test_download_content.py
@@ -8,6 +8,7 @@ from urllib.parse import urljoin
 from pulp_smash import api, config, utils
 from pulp_smash.pulp3.constants import DISTRIBUTION_PATH, REPO_PATH
 from pulp_smash.pulp3.utils import (
+    download_content_unit,
     gen_distribution,
     gen_repo,
     publish,
@@ -90,11 +91,7 @@ class DownloadContentTestCase(unittest.TestCase):
         ).hexdigest()
 
         # …and Pulp.
-        client.response_handler = api.safe_handler
+        content = download_content_unit(cfg, distribution, unit_path)
+        pulp_hash = hashlib.sha256(content).hexdigest()
 
-        unit_url = cfg.get_hosts('api')[0].roles['api']['scheme']
-        unit_url += '://' + distribution['base_url'] + '/'
-        unit_url = urljoin(unit_url, unit_path)
-
-        pulp_hash = hashlib.sha256(client.get(unit_url).content).hexdigest()
         self.assertEqual(fixtures_hash, pulp_hash)


### PR DESCRIPTION
Fix gen_yum_config_file function and reads content_host role.

1. gen_yum_config_file was generating repo file using `:` intead of `=`
   and that was causing dnf errors.
2. Consume and Download test cases are now using the host defined in
   the new `content` role if defined.

Required PR: https://github.com/PulpQE/pulp-smash/pull/1169

closes: #4320
https://pulp.plan.io/issues/4320
