### PR TITLE
Publish modulemd/productid when generate_sqlite is set to true 

### DIFF
--- a/plugins/pulp_rpm/plugins/distributors/yum/publish.py
+++ b/plugins/pulp_rpm/plugins/distributors/yum/publish.py
@@ -1176,15 +1176,16 @@ class GenerateSqliteForRepoStep(platform_steps.PluginStep):
         Call out to createrepo command line in order to process the files.
         """
         checksum_type = self.parent.get_checksum_type()
-        pipe = subprocess.Popen('createrepo_c -d --update --keep-all-metadata '
-                                '--local-sqlite '
-                                '-s %(checksum_type)s --skip-stat %(content_dir)s' %
-                                {'checksum_type': checksum_type, 'content_dir': self.content_dir},
+        pipe = subprocess.Popen('sqliterepo_c --local-sqlite -f '
+                                '--checksum %(checksum_type)s '
+                                '%(content_dir)s' %
+                                {'checksum_type': checksum_type,
+                                 'content_dir': self.content_dir},
                                 shell=True, stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE)
         stdout, stderr = pipe.communicate()
         if pipe.returncode != 0:
-            raise PulpCodedException(error_codes.RPM0001, command='createrepo_c', stdout=stdout,
+            raise PulpCodedException(error_codes.RPM0001, command='sqliterepo_c', stdout=stdout,
                                      stderr=stderr)
 
 

--- a/plugins/test/unit/plugins/distributors/yum/test_publish.py
+++ b/plugins/test/unit/plugins/distributors/yum/test_publish.py
@@ -1492,10 +1492,9 @@ class GenerateSqliteForRepoStepTests(BaseYumDistributorPublishStepTests):
         step.parent = mock.MagicMock()
         step.parent.get_checksum_type.return_value = 'sha1'
         step.process_main()
-        Popen.assert_called_once_with('createrepo_c -d --update --keep-all-metadata '
-                                      '--local-sqlite '
-                                      '-s sha1 '
-                                      '--skip-stat /foo',
+        Popen.assert_called_once_with('sqliterepo_c --local-sqlite -f '
+                                      '--checksum sha1 '
+                                      '/foo',
                                       shell=True, stderr=mock.ANY, stdout=mock.ANY)
 
     @mock.patch('pulp_rpm.plugins.distributors.yum.publish.subprocess.Popen')
@@ -1506,7 +1505,7 @@ class GenerateSqliteForRepoStepTests(BaseYumDistributorPublishStepTests):
         Popen.return_value = mock.MagicMock()
         Popen.return_value.returncode = 1
         Popen.return_value.communicate.return_value = pipe_output
-        with self.assertRaisesRegexp(PulpCodedException, 'createrepo_c') as cm:
+        with self.assertRaisesRegexp(PulpCodedException, 'sqliterepo_c') as cm:
             step.process_main()
         self.assertEqual(cm.exception.error_code.code, 'RPM0001')
 


### PR DESCRIPTION

When publish repos, the command createrepo_c could be used but the option
--keep-all-metadata for this command doesn't really keep all metadata --
moudlemd and product_id file will be thrown away.
Now make it keeps these file by running command sqliterepo_c

bug filed by Rohan Mcgovern:
https://bugzilla.redhat.com/show_bug.cgi?id=1670651