### PR TITLE
Change return status

### DIFF
--- a/pulp_rpm/app/viewsets.py
+++ b/pulp_rpm/app/viewsets.py
@@ -93,7 +93,8 @@ class PackageViewSet(ContentViewSet):
             new_pkg['_artifact'] = request.data['_artifact']
             new_pkg['relative_path'] = request.data.get('relative_path', '')
         except OSError:
-            return Response('RPM file cannot be parsed for metadata.')
+            return Response('RPM file cannot be parsed for metadata.',
+                            status=status.HTTP_406_NOT_ACCEPTABLE)
 
         serializer = self.get_serializer(data=new_pkg)
         serializer.is_valid(raise_exception=True)


### PR DESCRIPTION
When RPM file is not parsable return 406 (Not Acceptable)
as rpm cannot be accepted due to metadata parse failed.

closes: #4471
https://pulp.plan.io/issues/4471

Signed-off-by: Pavel Picka <ppicka@redhat.com>