### PR TITLE
Package duplicate check for oneshot uploader

### DIFF
--- a/pulp_rpm/app/upload.py
+++ b/pulp_rpm/app/upload.py
@@ -13,7 +13,6 @@ def one_shot_upload(artifact, repository=None):
     Args:
         artifact: validated artifact for a file
         repository: repository to extend with new pkg
-        path: artifact href
     """
     filename = os.path.basename(artifact.file.path)
 
@@ -24,6 +23,9 @@ def one_shot_upload(artifact, repository=None):
         raise OSError('RPM file cannot be parsed for metadata.')
 
     pkg, created = Package.objects.get_or_create(**new_pkg)
+
+    if not created:
+        raise OSError('RPM package {} already exists.'.format(pkg.filename))
 
     ContentArtifact.objects.create(
         artifact=artifact,


### PR DESCRIPTION
Check for package as already exists in pulp.
One line of doc string removed as not used/present.

closes: #4485
https://pulp.plan.io/issues/4485

Signed-off-by: Pavel Picka <ppicka@redhat.com>