### PR TITLE
Populate created resources

### DIFF
--- a/pulp_rpm/app/upload.py
+++ b/pulp_rpm/app/upload.py
@@ -2,6 +2,7 @@ import os
 
 from pulp_rpm.app.shared_utils import _prepare_package
 from pulp_rpm.app.models import Package
+from pulpcore.app.models.task import CreatedResource
 from pulpcore.app.models.content import ContentArtifact
 from pulpcore.app.models.repository import RepositoryVersion
 
@@ -32,6 +33,9 @@ def one_shot_upload(artifact, repository=None):
         content=pkg,
         relative_path=filename
     )
+
+    resource = CreatedResource(content_object=pkg)
+    resource.save()
 
     if repository:
         content_to_add = Package.objects.filter(pkgId=pkg.pkgId)


### PR DESCRIPTION
As one shot upload run in task it should
return some created resources.
As repository is optional the task now returns
package or package and repository version as
resource created.

closes: #4474
https://pulp.plan.io/issues/4474

Signed-off-by: Pavel Picka <ppicka@redhat.com>