### PR TITLE
Oneshot uploader doc adjust

### DIFF
--- a/docs/workflows/upload.rst
+++ b/docs/workflows/upload.rst
@@ -46,7 +46,7 @@ Add content to repository ``foo``
 One shot upload
 ---------------
 
-You can use feature to upload one rpm directly to repository which substitute
-previous three steps (create artifact, content from artifact and add content to repo).
+You can use one shot uploader to upload one rpm and optionally create new repository version with rpm you uploaded.
+With this call you can substitute previous two (or three) steps (create artifact, content from artifact and optionally add content to repo).
 
 ``http --form POST http://localhost:8000/pulp/api/v3/rpm/upload/ file@./foo-1.0-1.noarch.rpm repository=/pulp/api/v3/repositories/1/``


### PR DESCRIPTION
As in the code create repository version from uploaded
rpm is optionally, it should reflect in the docs too.

closes: #4433
https://pulp.plan.io/issues/4433

Signed-off-by: Pavel Picka <ppicka@redhat.com>