### PR TITLE
Problem: RPMs from distribution published twice

### DIFF
--- a/plugins/pulp_rpm/plugins/distributors/yum/publish.py
+++ b/plugins/pulp_rpm/plugins/distributors/yum/publish.py
@@ -1095,7 +1095,6 @@ class PublishDistributionStep(platform_steps.UnitModelPluginStep):
         :type distribution_unit: pulp_rpm.plugins.db.models.Distribution
         """
         symlink_dir = self.get_working_dir()
-        package_path = None
 
         if distribution_unit.packagedir:
             # The packages_dir is a relative directory that exists underneath the repo directory
@@ -1118,11 +1117,6 @@ class PublishDistributionStep(platform_steps.UnitModelPluginStep):
                 # a package path exists as a symlink we are going to remove it since
                 # the _create_symlink will create a real directory
                 os.unlink(package_path)
-
-        default_packages_symlink = os.path.join(symlink_dir, 'Packages')
-        if package_path != default_packages_symlink:
-            # Add the Packages directory to the content directory
-            self.package_dirs.append(default_packages_symlink)
 
 
 class CreateIsoStep(platform_steps.PluginStep):


### PR DESCRIPTION
Solution: stop publishing Distributions in Packages directory

fixes: #4541
https://pulp.plan.io/issues/4541