### PR TITLE
Problem: YumMetadataFile is a symlink

### DIFF
--- a/plugins/pulp_rpm/plugins/distributors/yum/publish.py
+++ b/plugins/pulp_rpm/plugins/distributors/yum/publish.py
@@ -2,6 +2,7 @@ import copy
 import datetime
 import itertools
 import os
+import shutil
 import subprocess
 
 from gettext import gettext as _
@@ -522,12 +523,12 @@ class PublishMetadataStep(platform_steps.UnitModelPluginStep):
                                                       REPO_DATA_DIR_NAME)
 
         metadata_file_name = os.path.basename(unit._storage_path)
-        link_path = os.path.join(publish_location_relative_path, metadata_file_name)
-        plugin_misc.create_symlink(unit._storage_path, link_path)
+        file_path = os.path.join(publish_location_relative_path, metadata_file_name)
+        shutil.copyfile(unit._storage_path, file_path)
 
         # Add the proper relative reference to the metadata file to repomd
         self.parent.repomd_file_context.\
-            add_metadata_file_metadata(unit.data_type, link_path)
+            add_metadata_file_metadata(unit.data_type, file_path)
 
 
 class PublishDrpmStep(platform_steps.UnitModelPluginStep):


### PR DESCRIPTION
Solution: Copy YumMetadataFile to the publish directory

YumCloneDistributor and RPMRsyncDistributor both copy the content of repodata directory.
This results in broken symlinks for all YumMetadataFile content.

fixes: #4550
https://pulp.plan.io/issues/4550

fixes: #4560
https://pulp.plan.io/issues/4560