### PR TITLE
Single upload filename fix

### DIFF
--- a/pulp_rpm/app/upload.py
+++ b/pulp_rpm/app/upload.py
@@ -1,5 +1,3 @@
-import os
-
 from pulp_rpm.app.shared_utils import _prepare_package
 from pulp_rpm.app.models import Package
 from pulpcore.app.models.task import CreatedResource
@@ -7,16 +5,15 @@ from pulpcore.app.models.content import ContentArtifact
 from pulpcore.app.models.repository import RepositoryVersion
 
 
-def one_shot_upload(artifact, repository=None):
+def one_shot_upload(artifact, filename, repository=None):
     """
     One shot upload for RPM package.
 
     Args:
         artifact: validated artifact for a file
+        filename : name of file
         repository: repository to extend with new pkg
     """
-    filename = os.path.basename(artifact.file.path)
-
     # export META from rpm and prepare dict as saveable format
     try:
         new_pkg = _prepare_package(artifact, filename)

--- a/pulp_rpm/app/viewsets.py
+++ b/pulp_rpm/app/viewsets.py
@@ -233,6 +233,7 @@ class OneShotUploadView(views.APIView):
         serializer.is_valid(raise_exception=True)
 
         artifact = Artifact.init_and_validate(request.data['file'])
+        filename = request.data['file'].name
 
         if 'repository' in request.data:
             repository = serializer.validated_data['repository']
@@ -249,6 +250,7 @@ class OneShotUploadView(views.APIView):
             one_shot_upload, [artifact],
             kwargs={
                 'artifact': artifact,
+                'filename': filename,
                 'repository': repository,
             })
         return OperationPostponedResponse(async_result, request)


### PR DESCRIPTION
Add right 'location_href' property (from artifact)                             
when creating content by one shot uploader.                                    
                                                                               
closes: #4656                                                                  
https://pulp.plan.io/issues/4656

Signed-off-by: Pavel Picka <ppicka@redhat.com>