### PR TITLE
Added quickstart page

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,6 +16,13 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #sys.path.insert(0, os.path.abspath('.'))
 
+try:
+    import sphinx_rtd_theme
+except ImportError:
+    sphinx_rtd_theme = False
+
+
+
 # -- General configuration -----------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
@@ -89,7 +96,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'default'
+html_theme = 'sphinx_rtd_theme' if sphinx_rtd_theme else 'default'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -97,7 +104,7 @@ html_theme = 'default'
 #html_theme_options = {}
 
 # Add any paths that contain custom themes here, relative to this directory.
-#html_theme_path = []
+html_theme_path = [sphinx_rtd_theme.get_html_theme_path()] if sphinx_rtd_theme else []
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -42,6 +42,7 @@ Table of Contents
    :maxdepth: 1
 
    installation
+   quickstart
    workflows/index
    release-notes/3.0.z.rst
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -1,0 +1,68 @@
+Quickstart
+==========
+
+Run Pulplift
+------------
+
+Use pulplift to try out Pulp. From `their quickstart <https://github.com/pulp/pulplift#quickstart>`_
+pulplift uses `Vagrant <https://www.vagrantup.com/docs/installation/>`_ so you'll need to have that
+installed.
+
+::
+
+    git clone --recurse-submodules https://github.com/pulp/pulplift.git
+    cd pulplift
+
+
+Create your pulp_rpm.yaml playbook with these contents::
+
+.. code-block:: yaml
+
+   ---
+   - hosts: all
+     vars:
+       pulp_secret_key: secret
+       pulp_default_admin_password: password
+       pulp_install_plugins:
+         pulp-rpm:
+           app_label: "rpm"
+     roles:
+       - pulp.pulp_rpm_prerequisites
+       - pulp-database
+       - pulp-workers
+       - pulp-resource-manager
+       - pulp-webserver
+       - pulp-content
+     environment:
+       DJANGO_SETTINGS_MODULE: pulpcore.app.settings
+
+
+Install the dependency bootstrapping role ````:
+
+    ansible-galaxy install pulp.pulp_rpm_prerequisites -p ./roles/
+
+
+Start your box, run ansible on it, ssh to your box::
+
+    vagrant up fedora29
+    ansible-playbook pulp_rpm.yaml -l fedora29
+    vagrant ssh fedora29
+
+
+
+Check Pulp's Status
+-------------------
+
+Check the status API using ``httpie``::
+
+    sudo dnf install httpie -y
+    http :24817/pulp/api/v3/status/  # This should show the status API
+
+
+Next Steps
+----------
+
+* Sync rpms "lazily" from the zoo repo using the :ref:`sync-publish-workflow`.
+* Upload or mirror content using the :ref:`rpm one-shot uploader <one-shot-upload-workflow>`.
+* Configure a client to :ref:`download packages <get-content-workflow>` from a RPM repository hosted
+  by Pulp.

--- a/docs/workflows/use_pulp_repo.rst
+++ b/docs/workflows/use_pulp_repo.rst
@@ -1,3 +1,5 @@
+.. _get-content-workflow:
+
 Get content from Pulp
 =====================
 


### PR DESCRIPTION
The quickstart page gets the user going with pulplift and helps them
check the status API. From there it links to the already great workflows
page.

This also fixed the readthedocs theme to be used which is important
because only that theme renders the left-panel in a way that you can see
this PR as it appears on the website. If you don't have the
sphinx_rtd_theme package installed you get the default theme as a
fallback.

https://github.com/rtfd/sphinx_rtd_theme

https://pulp.plan.io/issues/4620
closes #4620