### PR TITLE
Problem: docs are missing REST API documentation

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -42,6 +42,8 @@ clean:
 	-rm -rf $(BUILDDIR)/*
 
 html:
+	mkdir -p $(BUILDDIR)/html
+	curl -o _build/html/api.json "http://localhost:8000/pulp/api/v3/docs/api.json?plugin=pulp_rpm"
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."

--- a/docs/_templates/restapi.html
+++ b/docs/_templates/restapi.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>REST API for Pulp 3 RPM Plugin</title>
+    <!-- needed for adaptive design -->
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
+
+    <!--
+    ReDoc doesn't change outer page styles
+    -->
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <redoc spec-url='api.json'></redoc>
+    <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
+  </body>
+</html>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -133,7 +133,7 @@ html_static_path = ['_static']
 
 # Additional templates that should be rendered to pages, maps page names to
 # template names.
-#html_additional_pages = {}
+html_additional_pages = {'restapi': 'restapi.html'}
 
 # If false, no module index is generated.
 #html_domain_indices = True

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,6 +30,11 @@ Community contributions are encouraged.
   <https://pulp.plan.io/projects/pulp_rpm/issues>`_.
 
 
+REST API
+--------
+
+REST API documentation for the RPM plugin can be found `here <restapi.html>`_
+
 Table of Contents
 -----------------
 


### PR DESCRIPTION
Solution: add a ReDoc page that loads the OpenAPI schema for RPM plugin only

[noissue]