### PR TITLE
Problem: docs can't be built without pulp-api running

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -43,7 +43,7 @@ clean:
 
 html:
 	mkdir -p $(BUILDDIR)/html
-	curl -o _build/html/api.json "http://localhost:8000/pulp/api/v3/docs/api.json?plugin=pulp_rpm"
+	curl -o _build/html/api.json "https://repos.fedorapeople.org/pulp/pulp/openapi/pulp_rpm.json"
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."


### PR DESCRIPTION
Solution: host schema on repos.fedorapeople.org
    
This patch modifies how the docs are built. Instead of looking for the schema on localhost, the docs builder
downloads the schema from repos.fedorapeople.org.

[noissue]
