### PR TITLE
Remove createrepo_c dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@
 from setuptools import setup, find_packages
 
 requirements = [
-    'createrepo_c',
     'pulpcore-plugin~=0.1rc1',
 ]
 


### PR DESCRIPTION
As ansible-pulp installer will use RPM package
to use createrepo_c.

re: #4163
https://pulp.plan.io/issues/4163

Required PR: https://github.com/pulp/ansible-pulp/pull/107

Signed-off-by: Pavel Picka <ppicka@redhat.com>