### PR TITLE
Fix incremental publish for yum_repo_metadata_file content

### DIFF
--- a/plugins/pulp_rpm/plugins/distributors/yum/publish.py
+++ b/plugins/pulp_rpm/plugins/distributors/yum/publish.py
@@ -524,6 +524,13 @@ class PublishMetadataStep(platform_steps.UnitModelPluginStep):
 
         metadata_file_name = os.path.basename(unit._storage_path)
         file_path = os.path.join(publish_location_relative_path, metadata_file_name)
+
+        # it is possible to have symlink pointing to the file which should be copied
+        # see https://pulp.plan.io/issues/4661
+        if os.path.samefile(unit._storage_path, file_path):
+            # it's an old way of publishing,
+            # symlink should be removed so file is copied instead
+            os.unlink(file_path)
         shutil.copy2(unit._storage_path, file_path)
 
         # Add the proper relative reference to the metadata file to repomd


### PR DESCRIPTION
Old way of publishing yum_repo_metadata_file content was to create a symlink.
Recently yum_repo_metadata_file content started to be copied at publish time.
This fix affects upgrade cases, when yum_repo_metadata_file was published
the old way, but incremental publish happened in a new way.

closes #4661
https://pulp.plan.io/issues/4661