### PR TITLE
Skip malformed modular content during migration

### DIFF
--- a/docs/user-guide/release-notes/2.19.x.rst
+++ b/docs/user-guide/release-notes/2.19.x.rst
@@ -2,6 +2,21 @@
 Pulp 2.19 Release Notes
 =======================
 
+Pulp 2.19.1
+===========
+
+Bug Fixes
+---------
+
+See the list of :fixedbugs_pulp_rpm:`2.19.1`
+
+* Upgrade (from <=2.16 to 2.17+) fix: `Issue 4741 <https://pulp.plan.io/issues/4741>`_
+
+  * Old experimental modular content which doesn't contain all the necessary information,
+    like in Fedora 26, is skipped during migration and unassociated from a repo. Such
+    content becomes orphaned and can be removed from Pulp with the orphan cleanup task.
+
+
 Pulp 2.19.0
 ===========
 

--- a/plugins/pulp_rpm/plugins/migrations/0043_add_modulemd_modulemd-defaults.py
+++ b/plugins/pulp_rpm/plugins/migrations/0043_add_modulemd_modulemd-defaults.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 from hashlib import sha256
 
 import bson
-from mongoengine import Q, NotUniqueError
+from mongoengine import Q, NotUniqueError, ValidationError
 
 from pulp.plugins.loader import api as plugin_api
 from pulp.server.controllers import repository as repository_controller
@@ -164,6 +164,11 @@ def add_modulemd(repository, modulemd, model, working_dir):
         model.save_and_import_content(path)
     except NotUniqueError:
         model = Modulemd.objects.get(**model.unit_key)
+    except ValidationError as e:
+        _logger.warn("Modulemd content import failure. Repo: %s, content: %s, "
+                     "error: %s" % (repository.repo_id, model.unit_key, e))
+        return
+
     repository_controller.associate_single_unit(repository, model)
 
 


### PR DESCRIPTION
Some users might have old experimental modular content in Pulp.
Such content doesn't contain all the necessary info to be imported
in Pulp. E.g. no `context` which is a part of unit_key.

closes #4741
https://pulp.plan.io/issues/4741