### PR TITLE
Skip zchunk metadata at sync time

### DIFF
--- a/docs/tech-reference/rpm.rst
+++ b/docs/tech-reference/rpm.rst
@@ -122,7 +122,17 @@ sadly a dead link) contains ``data`` elements with one attribute, ``type``. The
 ``data`` element refers to. Common values are ``group``, ``filelists``, ``group_gz``,
 ``primary``, ``other``, ``filelists_db``, ``primary_db``, and ``other_db``. ``<thing>_db``
 refer to SQLite versions of the metadata, while those sans ``_db`` refer to XML
-versions. Each ``data`` element contains several other elements describing the
+versions. Each metadata can be compressed, often the format of compression will be present in the
+``type`` attribute: ``<thing>_gz`` or ``<thing>_zck`` mean that metadata was compressed using
+gzip or zchunk format respectively.
+
+.. note::
+  Metadata compressed into `Zchunk format <https://fedoraproject
+  .org/wiki/Changes/Zchunk_Metadata>`_ is not synced and ignored by Pulp to avoid creating a
+  broken repository at publish time. Zchunk metadata is optional, metadata in other formats is
+  present as well, so all repositories are synced properly.
+
+Each ``data`` element contains several other elements describing the
 metadata and where it is located: ``checksum``, ``location``, ``timestamp``, and
 ``size`` seem to be always present, with ``open-size``, ``open-checksum``, and
 ``database_version`` potentially appearing as well.

--- a/plugins/pulp_rpm/plugins/importers/yum/sync.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/sync.py
@@ -547,11 +547,26 @@ class RepoSync(object):
         Import metadata files whose type is not known to us. These are any files
         that we are not already parsing.
 
+        Skip those which we don't support yet and which can break repo if not supported fully.
+
         :param metadata_files:  object containing access to all metadata files
         :type  metadata_files:  pulp_rpm.plugins.importers.yum.repomd.metadata.MetadataFiles
         """
+        def is_needed(metadata_type):
+            """
+            Decide if metadata should be processed or should be skipped.
+
+            Skip zchunk metadata.
+
+            :param metadata_type: type of metadata
+            :type  metadata_type: str
+            :return: True, if metadata should be processed, otherwise it is skipped
+            :rtype: bool
+            """
+            return not metadata_type.endswith('_zck')
+
         for metadata_type, file_info in metadata_files.metadata.iteritems():
-            if metadata_type not in metadata_files.KNOWN_TYPES:
+            if metadata_type not in metadata_files.KNOWN_TYPES and is_needed(metadata_type):
                 file_path = file_info['local_path']
                 checksum_type = file_info['checksum']['algorithm']
                 checksum_type = util.sanitize_checksum_type(checksum_type)


### PR DESCRIPTION
Pulp 2 doesn't support zchunk compression format.
Keeping mirrored zchunk metadata in a repository can cause
a repository to be in a broken state.

closes #4529
https://pulp.plan.io/issues/4529