### PR TITLE
Change the user-facing name of "update" to "errata"

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -44,9 +44,9 @@ Install the dependency bootstrapping role ``pulp.pulp_rpm_prerequisites``:
 
 Start your box, run ansible on it, ssh to your box::
 
-    vagrant up fedora29
-    ansible-playbook pulp_rpm.yaml -l fedora29
-    vagrant ssh fedora29
+    vagrant up fedora30
+    ansible-playbook pulp_rpm.yaml -l fedora30
+    vagrant ssh fedora30
 
 
 Check Pulp's Status

--- a/docs/release-notes/3.0.z.rst
+++ b/docs/release-notes/3.0.z.rst
@@ -5,6 +5,11 @@
 pulp-rpm 3.0 is currently in Beta. Backwards incompatible changes
 might be made until Beta is over.
 
+3.0.0b4 (in-progress)
+=======
+
+* Renamed Errata/Update content to Advisory to better match the terminology of the RPM/DNF ecosystem.
+
 
 3.0.0b3
 =======
@@ -24,7 +29,7 @@ might be made until Beta is over.
 * Add support for on_demand sync
 * Add one-shot upload
 * Performance improvements and bug fixes
-* Compatibility with pulpcore-plugin-0.1.0rc1 
+* Compatibility with pulpcore-plugin-0.1.0rc1
 
 `Comprehensive list of changes and bugfixes for beta 2 <https://github.com/pulp/pulp_rpm/compare/3.0.0b1...3.0.0b2>`_.
 

--- a/docs/workflows/copy.rst
+++ b/docs/workflows/copy.rst
@@ -1,0 +1,33 @@
+Copy RPM content between repositories
+=====================================
+
+If you want to copy RPM content from one repository into another repository, you can do so.
+
+
+.. _copy-workflow:
+
+Copy workflow
+-------------
+
+You can use the copy endpoint to copy RPM-related content present in one repository / repository version to another repository. If you specify a repository, then the latest repository version for that repository will be used.
+
+``http POST http://localhost:24817/pulp/api/v3/rpm/copy/ source_repo=${SRC_REPO_HREF} dest_repo=${DEST_REPO_HREF}``
+
+or
+
+``http POST http://localhost:24817/pulp/api/v3/rpm/copy/ source_repo_version=${SRC_REPO_VER_HREF} dest_repo=${DEST_REPO_HREF}``
+
+.. code:: json
+
+    {
+       "_href": "/pulp/api/v3/tasks/f2b525e3-8d8f-4246-adab-2fabd2b089a8/",
+       "created_resources": [
+           "/pulp/api/v3/content/rpm/packages/1edf8d4e-4293-4b66-93cd-8e913731c87a/",
+       ],
+
+       ...
+    }
+
+You can also specify which types of content you would like to copy by providing a value for the "types" parameter. Types that are not listed will not be copied. The supported types are "package" and "advisory". For example, this query will copy only advisories, and not packages.
+
+``http POST http://localhost:24817/pulp/api/v3/rpm/copy/ source_repo=${SRC_REPO_HREF} dest_repo=${DEST_REPO_HREF} types=advisory``

--- a/docs/workflows/create_sync_publish.rst
+++ b/docs/workflows/create_sync_publish.rst
@@ -63,7 +63,7 @@ Look at the new Repository Version created
         "_removed_href": "/pulp/api/v3/repositories/5eeabc0b-3b86-4264-bb3a-5889530a6f5b/versions/1/removed_content/",
         "content_summary": {
             "package": 35,
-            "update": 4
+            "advisory": 4
         },
         "created": "2018-02-23T20:29:54.499055Z",
         "number": 1

--- a/docs/workflows/use_pulp_repo.rst
+++ b/docs/workflows/use_pulp_repo.rst
@@ -29,12 +29,12 @@ Now use dnf to install a package:
 
 ``$ sudo dnf install walrus``
 
-List and Install applicable Errata
-----------------------------------
+List and Install applicable Advisories
+--------------------------------------
 
-Make sure Pulp repo is configured in /etc/yum.repos.d/, then use dnf to work with Errata content.
+Make sure Pulp repo is configured in /etc/yum.repos.d/, then use dnf to work with Advisory content.
 
-List applicable Errata:
+List applicable Advisories:
 
 ``$ dnf list-sec``
 

--- a/pulp_rpm/app/models.py
+++ b/pulp_rpm/app/models.py
@@ -386,7 +386,7 @@ class UpdateRecord(Content):
 
     """
 
-    TYPE = 'update'
+    TYPE = 'advisory'
 
     # Required metadata
     id = models.TextField(db_index=True)
@@ -401,7 +401,7 @@ class UpdateRecord(Content):
     summary = models.TextField()
     version = models.TextField()
 
-    type = models.TextField()  # TODO: change field name?
+    type = models.TextField()
     severity = models.TextField()
     solution = models.TextField()
     release = models.TextField()

--- a/pulp_rpm/app/viewsets.py
+++ b/pulp_rpm/app/viewsets.py
@@ -165,12 +165,12 @@ class UpdateRecordViewSet(ContentViewSet):
 
     Define endpoint name which will appear in the API endpoint for this content type.
     For example::
-        http://pulp.example.com/pulp/api/v3/content/rpm/errata/
+        http://pulp.example.com/pulp/api/v3/content/rpm/advisories/
 
     Also specify queryset and serializer for UpdateRecord.
     """
 
-    endpoint_name = 'errata'
+    endpoint_name = 'advisories'
     queryset = UpdateRecord.objects.all()
     serializer_class = UpdateRecordSerializer
     minimal_serializer_class = MinimalUpdateRecordSerializer

--- a/pulp_rpm/tests/functional/api/test_sync.py
+++ b/pulp_rpm/tests/functional/api/test_sync.py
@@ -19,7 +19,7 @@ from pulp_smash.pulp3.utils import (
 from pulp_rpm.tests.functional.constants import (
     RPM_EPEL_URL,
     RPM_FIXTURE_SUMMARY,
-    RPM_PACKAGES_COUNT,
+    RPM_PACKAGE_COUNT,
     RPM_PACKAGE_CONTENT_NAME,
     RPM_REFERENCES_UPDATEINFO_URL,
     RPM_REMOTE_PATH,
@@ -28,7 +28,7 @@ from pulp_rpm.tests.functional.constants import (
     RPM_UNSIGNED_FIXTURE_URL,
     RPM_UPDATED_UPDATEINFO_FIXTURE_URL,
     RPM_UPDATERECORD_ID,
-    RPM_UPDATE_CONTENT_NAME,
+    RPM_ADVISORY_CONTENT_NAME,
 )
 from pulp_rpm.tests.functional.utils import gen_rpm_remote, skip_if
 from pulp_rpm.tests.functional.utils import set_up_module as setUpModule  # noqa:F401
@@ -211,12 +211,12 @@ class SyncMutatedPackagesTestCase(unittest.TestCase):
         # package is removed from and the new one is added to a repo version.
         self.assertEqual(
             len(get_added_content(repo)[RPM_PACKAGE_CONTENT_NAME]),
-            RPM_PACKAGES_COUNT,
+            RPM_PACKAGE_COUNT,
             get_added_content(repo)[RPM_PACKAGE_CONTENT_NAME]
         )
         self.assertEqual(
             len(get_removed_content(repo)[RPM_PACKAGE_CONTENT_NAME]),
-            RPM_PACKAGES_COUNT,
+            RPM_PACKAGE_COUNT,
             get_removed_content(repo)[RPM_PACKAGE_CONTENT_NAME]
         )
 
@@ -281,7 +281,7 @@ class EPELSyncTestCase(unittest.TestCase):
 
 @unittest.skip('FIXME: Enable this test after we can throw out duplicate UpdateRecords')
 class SyncMutatedUpdateRecordTestCase(unittest.TestCase):
-    """Sync a new Erratum with the same ID."""
+    """Sync a new UpdateRecord (Advisory / Erratum) with the same ID."""
 
     @classmethod
     def setUpClass(cls):
@@ -331,7 +331,7 @@ class SyncMutatedUpdateRecordTestCase(unittest.TestCase):
         # Save a copy of the original updateinfo
         original_updaterecords = {
             content['id']: content
-            for content in get_content(repo)[RPM_UPDATE_CONTENT_NAME]
+            for content in get_content(repo)[RPM_ADVISORY_CONTENT_NAME]
         }
 
         # Create a remote with a different test fixture, one containing mutated
@@ -348,18 +348,18 @@ class SyncMutatedUpdateRecordTestCase(unittest.TestCase):
             RPM_FIXTURE_SUMMARY
         )
         self.assertEqual(
-            len(get_added_content(repo)[RPM_UPDATE_CONTENT_NAME]),
+            len(get_added_content(repo)[RPM_ADVISORY_CONTENT_NAME]),
             4
         )
         self.assertEqual(
-            len(get_removed_content(repo)[RPM_UPDATE_CONTENT_NAME]),
+            len(get_removed_content(repo)[RPM_ADVISORY_CONTENT_NAME]),
             4
         )
 
         # Test that the updateinfo have been modified.
         mutated_updaterecords = {
             content['id']: content
-            for content in get_content(repo)[RPM_UPDATE_CONTENT_NAME]
+            for content in get_content(repo)[RPM_ADVISORY_CONTENT_NAME]
         }
 
         self.assertNotEqual(mutated_updaterecords, original_updaterecords)
@@ -422,12 +422,12 @@ class SyncDiffChecksumPackagesTestCase(unittest.TestCase):
         # package is removed from and the new one is added to a repo version.
         self.assertEqual(
             len(added_content),
-            RPM_PACKAGES_COUNT,
+            RPM_PACKAGE_COUNT,
             added_content
         )
         self.assertEqual(
             len(removed_content),
-            RPM_PACKAGES_COUNT,
+            RPM_PACKAGE_COUNT,
             removed_content
         )
 

--- a/pulp_rpm/tests/functional/constants.py
+++ b/pulp_rpm/tests/functional/constants.py
@@ -16,7 +16,7 @@ DRPM_UNSIGNED_FIXTURE_URL = urljoin(PULP_FIXTURES_BASE_URL, 'drpm-unsigned/')
 
 RPM_PACKAGE_CONTENT_NAME = 'rpm.package'
 
-RPM_UPDATE_CONTENT_NAME = 'rpm.update'
+RPM_ADVISORY_CONTENT_NAME = 'rpm.advisory'
 
 RPM_ALT_LAYOUT_FIXTURE_URL = urljoin(PULP_FIXTURES_BASE_URL, 'rpm-alt-layout/')
 """The URL to a signed RPM repository. See :data:`RPM_SIGNED_FIXTURE_URL`."""
@@ -69,17 +69,17 @@ RPM_SINGLE_REQUEST_UPLOAD = urljoin(BASE_PATH, 'rpm/upload/')
 RPM_UNSIGNED_FIXTURE_URL = urljoin(PULP_FIXTURES_BASE_URL, 'rpm-unsigned/')
 """The URL to a repository with unsigned RPM packages."""
 
-RPM_PACKAGES_COUNT = 35
+RPM_PACKAGE_COUNT = 35
 """The number of packages available at
 :data:`RPM_SIGNED_FIXTURE_URL` and :data:`RPM_UNSIGNED_FIXTURE_URL`
 """
 
-RPM_UPDATE_COUNT = 4
+RPM_ADVISORY_COUNT = 4
 """The number of updated record units."""
 
 RPM_FIXTURE_SUMMARY = {
-    RPM_PACKAGE_CONTENT_NAME: RPM_PACKAGES_COUNT,
-    RPM_UPDATE_CONTENT_NAME: RPM_UPDATE_COUNT
+    RPM_PACKAGE_CONTENT_NAME: RPM_PACKAGE_COUNT,
+    RPM_ADVISORY_CONTENT_NAME: RPM_ADVISORY_COUNT
 }
 """The breakdown of how many of each type of content unit are present in the
 standard repositories, i.e. :data:`RPM_SIGNED_FIXTURE_URL` and
@@ -159,10 +159,10 @@ Note: This repository uses unsigned RPMs.
 """
 
 RPM_UPDATERECORD_ID = 'RHEA-2012:0058'
-"""The ID of an UpdateRecord (erratum).
+"""The ID of an UpdateRecord (advisory/erratum).
 
-The package contained on this erratum is defined by
-:data:`RPM_UPDATERECORD_RPM_NAME` and the erratum is present in the standard
+The package contained on this advisory is defined by
+:data:`RPM_UPDATERECORD_RPM_NAME` and the advisory is present in the standard
 repositories, i.e. :data:`RPM_SIGNED_FIXTURE_URL` and
 :data:`RPM_UNSIGNED_FIXTURE_URL`.
 """


### PR DESCRIPTION
[noissue]

Justification: The name "UpdateRecord" is exclusively an implementation detail of createrepo_c, it doesn't seem like they are named as such anywhere else in the ecosystem.  We shouldn't expose such an implementation detail to end users.  