### PR TITLE
Require relative path

### DIFF
--- a/pulp_rpm/app/serializers.py
+++ b/pulp_rpm/app/serializers.py
@@ -32,7 +32,7 @@ class PackageSerializer(SingleArtifactContentSerializer):
 
     relative_path = serializers.CharField(
         help_text=_("File name of the package"),
-        required=False,
+        required=True,
         allow_null=True,
         allow_blank=True,
         write_only=True,


### PR DESCRIPTION
As missing 'relative_path' can break publish, change
it for required everytime.

closes: #4835
https://pulp.plan.io/issues/4835

Signed-off-by: Pavel Picka <ppicka@redhat.com>