### PR TITLE
Switch tasks to use pks

### DIFF
--- a/pulp_rpm/app/tasks/copy.py
+++ b/pulp_rpm/app/tasks/copy.py
@@ -1,17 +1,20 @@
 from django.db.models import Q
 
-from pulpcore.app.models.repository import RepositoryVersion
+from pulpcore.app.models.repository import Repository, RepositoryVersion
 
 
-def copy_content(source_repo_version, dest_repo, types):
+def copy_content(source_repo_version_pk, dest_repo_pk, types):
     """
     Copy content from one repo to another.
 
     Args:
-        source_repo_version: repository version to copy units from
-        dest_repo: repository to copy units into
+        source_repo_version_pk: repository version primary key to copy units from
+        dest_repo_pk: repository primary key to copy units into
         types: a tuple of strings representing the '_type' values of types to include in the copy
     """
+    source_repo_version = RepositoryVersion.objects.get(pk=source_repo_version_pk)
+    dest_repo = Repository.objects.get(pk=dest_repo_pk)
+
     query = None
     for ptype in types:
         if query:

--- a/pulp_rpm/app/tasks/upload.py
+++ b/pulp_rpm/app/tasks/upload.py
@@ -1,19 +1,21 @@
 from pulp_rpm.app.shared_utils import _prepare_package
 from pulp_rpm.app.models import Package
 from pulpcore.app.models.task import CreatedResource
-from pulpcore.app.models.content import ContentArtifact
-from pulpcore.app.models.repository import RepositoryVersion
+from pulpcore.app.models.content import Artifact, ContentArtifact
+from pulpcore.app.models.repository import Repository, RepositoryVersion
 
 
-def one_shot_upload(artifact, filename, repository=None):
+def one_shot_upload(artifact_pk, filename, repository_pk=None):
     """
     One shot upload for RPM package.
 
     Args:
-        artifact: validated artifact for a file
+        artifact_pk: validated artifact for a file
         filename : name of file
-        repository: repository to extend with new pkg
+        repository_pk: repository to extend with new pkg
     """
+    artifact = Artifact.objects.get(pk=artifact_pk)
+
     # export META from rpm and prepare dict as saveable format
     try:
         new_pkg = _prepare_package(artifact, filename)
@@ -34,7 +36,8 @@ def one_shot_upload(artifact, filename, repository=None):
     resource = CreatedResource(content_object=pkg)
     resource.save()
 
-    if repository:
+    if repository_pk:
+        repository = Repository.objects.get(pk=repository_pk)
         content_to_add = Package.objects.filter(pkgId=pkg.pkgId)
 
         # create new repo version with uploaded package

--- a/pulp_rpm/app/viewsets.py
+++ b/pulp_rpm/app/viewsets.py
@@ -208,8 +208,9 @@ class OneShotUploadViewSet(viewsets.ViewSet):
                 data=request.data, context={'request': request})
             serializer.is_valid(raise_exception=True)
             repository = serializer.validated_data['repository']
+            repository_pk = repository.pk
         else:
-            repository = None
+            repository_pk = None
 
         try:
             artifact.save()
@@ -220,9 +221,9 @@ class OneShotUploadViewSet(viewsets.ViewSet):
         async_result = enqueue_with_reservation(
             tasks.one_shot_upload, [artifact],
             kwargs={
-                'artifact': artifact,
+                'artifact_pk': artifact.pk,
                 'filename': filename,
-                'repository': repository,
+                'repository_pk': repository_pk,
             })
         return OperationPostponedResponse(async_result, request)
 
@@ -298,7 +299,7 @@ class CopyViewSet(viewsets.ViewSet):
 
         async_result = enqueue_with_reservation(
             tasks.copy_content, [source_repo, dest_repo],
-            args=[source_repo_version, dest_repo, types],
+            args=[source_repo_version.pk, dest_repo.pk, types],
             kwargs={}
         )
         return OperationPostponedResponse(async_result, request)


### PR DESCRIPTION
The copy and upload tasks were passing large objects instead of passing
pks. This switches those (and their corresponding dispatch code) to use
pks instead, and the objects are re-queried in the task. Some of the
tasks didn't need an update because they already used that form. All
tasks were checked.

https://pulp.plan.io/issues/4876
closes #4876