### PR TITLE
Problem: Package's unique together index key is too long

### DIFF
--- a/pulp_rpm/app/models.py
+++ b/pulp_rpm/app/models.py
@@ -114,13 +114,13 @@ class Package(Content):
 
     # Required metadata
     name = models.CharField(max_length=255)
-    epoch = models.CharField(max_length=255)
+    epoch = models.CharField(max_length=10)
     version = models.CharField(max_length=255)
     release = models.CharField(max_length=255)
-    arch = models.CharField(max_length=255)
+    arch = models.CharField(max_length=20)
 
-    pkgId = models.CharField(unique=True, max_length=255)  # formerly "checksum" in Pulp 2
-    checksum_type = models.CharField(choices=CHECKSUM_CHOICES, max_length=255)
+    pkgId = models.CharField(unique=True, max_length=128)  # formerly "checksum" in Pulp 2
+    checksum_type = models.CharField(choices=CHECKSUM_CHOICES, max_length=10)
 
     # Optional metadata
     summary = models.TextField()


### PR DESCRIPTION
Solution: set shorter max_length for all appropriate fields

This patch reduces the max_length for epoch, arch, pkgId, and checksum_type.

fixes: #4916
https://pulp.plan.io/issues/4916