### PR TITLE
Use new RPMTAG_MODULARITYLABEL to identify modular RPMs

### DIFF
--- a/common/pulp_rpm/common/constants.py
+++ b/common/pulp_rpm/common/constants.py
@@ -210,3 +210,7 @@ GPG_KEY_ID = "gpg_key_id"
 
 # used in profiler for applicability
 VIRTUAL_MODULEMDS = ['platform']
+
+# Id of the tag which is used to analyze RPM headers at upload or download time.
+# It's availiable in rpm package in F30+ and Centos8+.
+RPMTAG_MODULARITYLABEL = 5096


### PR DESCRIPTION
Old RPMTAG_DISTTAG is still in the code for the old content
that might be still around.

closes #4869
https://pulp.plan.io/issues/4869