### PR TITLE
Fix relative_url paragraph in docs

### DIFF
--- a/docs/tech-reference/export-distributor.rst
+++ b/docs/tech-reference/export-distributor.rst
@@ -66,7 +66,7 @@ Optional Configuration Parameters
 
 ``relative_url``
  Relative path at which the repository will be served when exported. If this option is specified with
-``export_dir``, this will become the exported subdirectory name instead of the default, which is the
+ ``export_dir``, this will become the exported subdirectory name instead of the default, which is the
  repository id.
 
 ``manifest``


### PR DESCRIPTION
Add missing space that was breaking the paragraph in two.