### PR TITLE
Refactor naming for pakcage attr

### DIFF
--- a/pulp_rpm/app/constants.py
+++ b/pulp_rpm/app/constants.py
@@ -34,7 +34,7 @@ CHECKSUM_CHOICES = (
     (CHECKSUM_TYPES.SHA512, CHECKSUM_TYPES.SHA512)
 )
 
-CREATEREPO_PACKAGE_ATTRS = SimpleNamespace(
+CR_PACKAGE_ATTRS = SimpleNamespace(
     ARCH='arch',
     CHANGELOGS='changelogs',
     CHECKSUM_TYPE='checksum_type',
@@ -75,7 +75,7 @@ CREATEREPO_PACKAGE_ATTRS = SimpleNamespace(
 PACKAGE_REPODATA = ['primary', 'filelists', 'other']
 UPDATE_REPODATA = ['updateinfo']
 
-CREATEREPO_UPDATE_RECORD_ATTRS = SimpleNamespace(
+CR_UPDATE_RECORD_ATTRS = SimpleNamespace(
     ID='id',
     UPDATED_DATE='updated_date',
     DESCRIPTION='description',
@@ -93,12 +93,12 @@ CREATEREPO_UPDATE_RECORD_ATTRS = SimpleNamespace(
     PUSHCOUNT='pushcount'
 )
 
-CREATEREPO_UPDATE_COLLECTION_ATTRS = SimpleNamespace(
+CR_UPDATE_COLLECTION_ATTRS = SimpleNamespace(
     NAME='name',
     SHORTNAME='shortname'
 )
 
-CREATEREPO_UPDATE_COLLECTION_PACKAGE_ATTRS = SimpleNamespace(
+CR_UPDATE_COLLECTION_PACKAGE_ATTRS = SimpleNamespace(
     ARCH='arch',
     EPOCH='epoch',
     FILENAME='filename',
@@ -111,9 +111,21 @@ CREATEREPO_UPDATE_COLLECTION_PACKAGE_ATTRS = SimpleNamespace(
     VERSION='version'
 )
 
-CREATEREPO_UPDATE_REFERENCE_ATTRS = SimpleNamespace(
+CR_UPDATE_REFERENCE_ATTRS = SimpleNamespace(
     HREF='href',
     ID='id',
     TITLE='title',
     TYPE='type'
+)
+
+PULP_PACKAGE_ATTRS = CR_PACKAGE_ATTRS
+PULP_UPDATE_RECORD_ATTRS = CR_UPDATE_RECORD_ATTRS
+PULP_UPDATE_COLLECTION_ATTRS = CR_UPDATE_COLLECTION_ATTRS
+PULP_UPDATE_COLLECTION_PACKAGE_ATTRS = CR_UPDATE_COLLECTION_PACKAGE_ATTRS
+
+PULP_UPDATE_REFERENCE_ATTRS = SimpleNamespace(
+    HREF='href',
+    ID='ref_id',
+    TITLE='title',
+    TYPE='ref_type'
 )

--- a/pulp_rpm/app/models.py
+++ b/pulp_rpm/app/models.py
@@ -6,11 +6,17 @@ import createrepo_c as cr
 from django.db import models
 from pulpcore.plugin.models import Content, Model, Remote, Publication, PublicationDistribution
 
-from pulp_rpm.app.constants import (CHECKSUM_CHOICES, CREATEREPO_PACKAGE_ATTRS,
-                                    CREATEREPO_UPDATE_COLLECTION_ATTRS,
-                                    CREATEREPO_UPDATE_COLLECTION_PACKAGE_ATTRS,
-                                    CREATEREPO_UPDATE_RECORD_ATTRS,
-                                    CREATEREPO_UPDATE_REFERENCE_ATTRS)
+from pulp_rpm.app.constants import (CHECKSUM_CHOICES, CR_PACKAGE_ATTRS,
+                                    CR_UPDATE_COLLECTION_ATTRS,
+                                    CR_UPDATE_COLLECTION_PACKAGE_ATTRS,
+                                    CR_UPDATE_RECORD_ATTRS,
+                                    CR_UPDATE_REFERENCE_ATTRS,
+                                    PULP_PACKAGE_ATTRS,
+                                    PULP_UPDATE_COLLECTION_ATTRS,
+                                    PULP_UPDATE_COLLECTION_PACKAGE_ATTRS,
+                                    PULP_UPDATE_RECORD_ATTRS,
+                                    PULP_UPDATE_REFERENCE_ATTRS
+                                    )
 
 
 log = getLogger(__name__)
@@ -221,41 +227,54 @@ class Package(Content):
 
         """
         return {
-            'arch': getattr(package, CREATEREPO_PACKAGE_ATTRS.ARCH),
-            'changelogs': json.dumps(getattr(package, CREATEREPO_PACKAGE_ATTRS.CHANGELOGS) or []),
-            'checksum_type': getattr(package, CREATEREPO_PACKAGE_ATTRS.CHECKSUM_TYPE),
-            'conflicts': json.dumps(getattr(package, CREATEREPO_PACKAGE_ATTRS.CONFLICTS) or []),
-            'description': getattr(package, CREATEREPO_PACKAGE_ATTRS.DESCRIPTION) or '',
-            'enhances': json.dumps(getattr(package, CREATEREPO_PACKAGE_ATTRS.ENHANCES) or []),
-            'epoch': getattr(package, CREATEREPO_PACKAGE_ATTRS.EPOCH) or '',
-            'files': json.dumps(getattr(package, CREATEREPO_PACKAGE_ATTRS.FILES) or []),
-            'location_base': getattr(package, CREATEREPO_PACKAGE_ATTRS.LOCATION_BASE) or '',
-            'location_href': getattr(package, CREATEREPO_PACKAGE_ATTRS.LOCATION_HREF),
-            'name': getattr(package, CREATEREPO_PACKAGE_ATTRS.NAME),
-            'obsoletes': json.dumps(getattr(package, CREATEREPO_PACKAGE_ATTRS.OBSOLETES) or []),
-            'pkgId': getattr(package, CREATEREPO_PACKAGE_ATTRS.PKGID),
-            'provides': json.dumps(getattr(package, CREATEREPO_PACKAGE_ATTRS.PROVIDES) or []),
-            'recommends': json.dumps(getattr(package, CREATEREPO_PACKAGE_ATTRS.RECOMMENDS) or []),
-            'release': getattr(package, CREATEREPO_PACKAGE_ATTRS.RELEASE),
-            'requires': json.dumps(getattr(package, CREATEREPO_PACKAGE_ATTRS.REQUIRES) or []),
-            'rpm_buildhost': getattr(package, CREATEREPO_PACKAGE_ATTRS.RPM_BUILDHOST) or '',
-            'rpm_group': getattr(package, CREATEREPO_PACKAGE_ATTRS.RPM_GROUP) or '',
-            'rpm_header_end': getattr(package, CREATEREPO_PACKAGE_ATTRS.RPM_HEADER_END),
-            'rpm_header_start': getattr(package, CREATEREPO_PACKAGE_ATTRS.RPM_HEADER_START),
-            'rpm_license': getattr(package, CREATEREPO_PACKAGE_ATTRS.RPM_LICENSE) or '',
-            'rpm_packager': getattr(package, CREATEREPO_PACKAGE_ATTRS.RPM_PACKAGER) or '',
-            'rpm_sourcerpm': getattr(package, CREATEREPO_PACKAGE_ATTRS.RPM_SOURCERPM) or '',
-            'rpm_vendor': getattr(package, CREATEREPO_PACKAGE_ATTRS.RPM_VENDOR) or '',
-            'size_archive': getattr(package, CREATEREPO_PACKAGE_ATTRS.SIZE_ARCHIVE),
-            'size_installed': getattr(package, CREATEREPO_PACKAGE_ATTRS.SIZE_INSTALLED),
-            'size_package': getattr(package, CREATEREPO_PACKAGE_ATTRS.SIZE_PACKAGE),
-            'suggests': json.dumps(getattr(package, CREATEREPO_PACKAGE_ATTRS.SUGGESTS) or []),
-            'summary': getattr(package, CREATEREPO_PACKAGE_ATTRS.SUMMARY) or '',
-            'supplements': json.dumps(getattr(package, CREATEREPO_PACKAGE_ATTRS.SUPPLEMENTS) or []),
-            'time_build': getattr(package, CREATEREPO_PACKAGE_ATTRS.TIME_BUILD),
-            'time_file': getattr(package, CREATEREPO_PACKAGE_ATTRS.TIME_FILE),
-            'url': getattr(package, CREATEREPO_PACKAGE_ATTRS.URL) or '',
-            'version': getattr(package, CREATEREPO_PACKAGE_ATTRS.VERSION)
+            PULP_PACKAGE_ATTRS.ARCH: getattr(package, CR_PACKAGE_ATTRS.ARCH),
+            PULP_PACKAGE_ATTRS.CHANGELOGS: json.dumps(
+                getattr(package, CR_PACKAGE_ATTRS.CHANGELOGS) or []),
+            PULP_PACKAGE_ATTRS.CHECKSUM_TYPE: getattr(package, CR_PACKAGE_ATTRS.CHECKSUM_TYPE),
+            PULP_PACKAGE_ATTRS.CONFLICTS: json.dumps(
+                getattr(package, CR_PACKAGE_ATTRS.CONFLICTS) or []),
+            PULP_PACKAGE_ATTRS.DESCRIPTION: getattr(package, CR_PACKAGE_ATTRS.DESCRIPTION) or '',
+            PULP_PACKAGE_ATTRS.ENHANCES: json.dumps(
+                getattr(package, CR_PACKAGE_ATTRS.ENHANCES) or []),
+            PULP_PACKAGE_ATTRS.EPOCH: getattr(package, CR_PACKAGE_ATTRS.EPOCH) or '',
+            PULP_PACKAGE_ATTRS.FILES: json.dumps(getattr(package, CR_PACKAGE_ATTRS.FILES) or []),
+            PULP_PACKAGE_ATTRS.LOCATION_BASE: getattr(
+                package, CR_PACKAGE_ATTRS.LOCATION_BASE) or '',
+            PULP_PACKAGE_ATTRS.LOCATION_HREF: getattr(package, CR_PACKAGE_ATTRS.LOCATION_HREF),
+            PULP_PACKAGE_ATTRS.NAME: getattr(package, CR_PACKAGE_ATTRS.NAME),
+            PULP_PACKAGE_ATTRS.OBSOLETES: json.dumps(
+                getattr(package, CR_PACKAGE_ATTRS.OBSOLETES) or []),
+            PULP_PACKAGE_ATTRS.PKGID: getattr(package, CR_PACKAGE_ATTRS.PKGID),
+            PULP_PACKAGE_ATTRS.PROVIDES: json.dumps(
+                getattr(package, CR_PACKAGE_ATTRS.PROVIDES) or []),
+            PULP_PACKAGE_ATTRS.RECOMMENDS: json.dumps(
+                getattr(package, CR_PACKAGE_ATTRS.RECOMMENDS) or []),
+            PULP_PACKAGE_ATTRS.RELEASE: getattr(package, CR_PACKAGE_ATTRS.RELEASE),
+            PULP_PACKAGE_ATTRS.REQUIRES: json.dumps(
+                getattr(package, CR_PACKAGE_ATTRS.REQUIRES) or []),
+            PULP_PACKAGE_ATTRS.RPM_BUILDHOST: getattr(
+                package, CR_PACKAGE_ATTRS.RPM_BUILDHOST) or '',
+            PULP_PACKAGE_ATTRS.RPM_GROUP: getattr(package, CR_PACKAGE_ATTRS.RPM_GROUP) or '',
+            PULP_PACKAGE_ATTRS.RPM_HEADER_END: getattr(package, CR_PACKAGE_ATTRS.RPM_HEADER_END),
+            PULP_PACKAGE_ATTRS.RPM_HEADER_START: getattr(
+                package, CR_PACKAGE_ATTRS.RPM_HEADER_START),
+            PULP_PACKAGE_ATTRS.RPM_LICENSE: getattr(package, CR_PACKAGE_ATTRS.RPM_LICENSE) or '',
+            PULP_PACKAGE_ATTRS.RPM_PACKAGER: getattr(package, CR_PACKAGE_ATTRS.RPM_PACKAGER) or '',
+            PULP_PACKAGE_ATTRS.RPM_SOURCERPM: getattr(
+                package, CR_PACKAGE_ATTRS.RPM_SOURCERPM) or '',
+            PULP_PACKAGE_ATTRS.RPM_VENDOR: getattr(package, CR_PACKAGE_ATTRS.RPM_VENDOR) or '',
+            PULP_PACKAGE_ATTRS.SIZE_ARCHIVE: getattr(package, CR_PACKAGE_ATTRS.SIZE_ARCHIVE),
+            PULP_PACKAGE_ATTRS.SIZE_INSTALLED: getattr(package, CR_PACKAGE_ATTRS.SIZE_INSTALLED),
+            PULP_PACKAGE_ATTRS.SIZE_PACKAGE: getattr(package, CR_PACKAGE_ATTRS.SIZE_PACKAGE),
+            PULP_PACKAGE_ATTRS.SUGGESTS: json.dumps(
+                getattr(package, CR_PACKAGE_ATTRS.SUGGESTS) or []),
+            PULP_PACKAGE_ATTRS.SUMMARY: getattr(package, CR_PACKAGE_ATTRS.SUMMARY) or '',
+            PULP_PACKAGE_ATTRS.SUPPLEMENTS: json.dumps(
+                getattr(package, CR_PACKAGE_ATTRS.SUPPLEMENTS) or []),
+            PULP_PACKAGE_ATTRS.TIME_BUILD: getattr(package, CR_PACKAGE_ATTRS.TIME_BUILD),
+            PULP_PACKAGE_ATTRS.TIME_FILE: getattr(package, CR_PACKAGE_ATTRS.TIME_FILE),
+            PULP_PACKAGE_ATTRS.URL: getattr(package, CR_PACKAGE_ATTRS.URL) or '',
+            PULP_PACKAGE_ATTRS.VERSION: getattr(package, CR_PACKAGE_ATTRS.VERSION)
         }
 
     def to_createrepo_c(self):
@@ -294,50 +313,50 @@ class Package(Content):
             return createrepo_c_list
 
         package = cr.Package()
-        package.arch = getattr(self, CREATEREPO_PACKAGE_ATTRS.ARCH)
+        package.arch = getattr(self, PULP_PACKAGE_ATTRS.ARCH)
         package.changelogs = str_list_to_createrepo_c(
-            getattr(self, CREATEREPO_PACKAGE_ATTRS.CHANGELOGS))
-        package.checksum_type = getattr(self, CREATEREPO_PACKAGE_ATTRS.CHECKSUM_TYPE)
+            getattr(self, PULP_PACKAGE_ATTRS.CHANGELOGS))
+        package.checksum_type = getattr(self, PULP_PACKAGE_ATTRS.CHECKSUM_TYPE)
         package.conflicts = str_list_to_createrepo_c(
-            getattr(self, CREATEREPO_PACKAGE_ATTRS.CONFLICTS))
-        package.description = getattr(self, CREATEREPO_PACKAGE_ATTRS.DESCRIPTION)
+            getattr(self, PULP_PACKAGE_ATTRS.CONFLICTS))
+        package.description = getattr(self, PULP_PACKAGE_ATTRS.DESCRIPTION)
         package.enhances = str_list_to_createrepo_c(
-            getattr(self, CREATEREPO_PACKAGE_ATTRS.ENHANCES))
-        package.epoch = getattr(self, CREATEREPO_PACKAGE_ATTRS.EPOCH)
-        package.files = str_list_to_createrepo_c(getattr(self, CREATEREPO_PACKAGE_ATTRS.FILES))
-        package.location_base = getattr(self, CREATEREPO_PACKAGE_ATTRS.LOCATION_BASE)
-        package.location_href = getattr(self, CREATEREPO_PACKAGE_ATTRS.LOCATION_HREF)
-        package.name = getattr(self, CREATEREPO_PACKAGE_ATTRS.NAME)
+            getattr(self, PULP_PACKAGE_ATTRS.ENHANCES))
+        package.epoch = getattr(self, PULP_PACKAGE_ATTRS.EPOCH)
+        package.files = str_list_to_createrepo_c(getattr(self, PULP_PACKAGE_ATTRS.FILES))
+        package.location_base = getattr(self, PULP_PACKAGE_ATTRS.LOCATION_BASE)
+        package.location_href = getattr(self, PULP_PACKAGE_ATTRS.LOCATION_HREF)
+        package.name = getattr(self, PULP_PACKAGE_ATTRS.NAME)
         package.obsoletes = str_list_to_createrepo_c(
-            getattr(self, CREATEREPO_PACKAGE_ATTRS.OBSOLETES))
-        package.pkgId = getattr(self, CREATEREPO_PACKAGE_ATTRS.PKGID)
+            getattr(self, PULP_PACKAGE_ATTRS.OBSOLETES))
+        package.pkgId = getattr(self, PULP_PACKAGE_ATTRS.PKGID)
         package.provides = str_list_to_createrepo_c(
-            getattr(self, CREATEREPO_PACKAGE_ATTRS.PROVIDES))
+            getattr(self, PULP_PACKAGE_ATTRS.PROVIDES))
         package.recommends = str_list_to_createrepo_c(
-            getattr(self, CREATEREPO_PACKAGE_ATTRS.RECOMMENDS))
-        package.release = getattr(self, CREATEREPO_PACKAGE_ATTRS.RELEASE)
+            getattr(self, PULP_PACKAGE_ATTRS.RECOMMENDS))
+        package.release = getattr(self, PULP_PACKAGE_ATTRS.RELEASE)
         package.requires = str_list_to_createrepo_c(
-            getattr(self, CREATEREPO_PACKAGE_ATTRS.REQUIRES))
-        package.rpm_buildhost = getattr(self, CREATEREPO_PACKAGE_ATTRS.RPM_BUILDHOST)
-        package.rpm_group = getattr(self, CREATEREPO_PACKAGE_ATTRS.RPM_GROUP)
-        package.rpm_header_end = getattr(self, CREATEREPO_PACKAGE_ATTRS.RPM_HEADER_END)
-        package.rpm_header_start = getattr(self, CREATEREPO_PACKAGE_ATTRS.RPM_HEADER_START)
-        package.rpm_license = getattr(self, CREATEREPO_PACKAGE_ATTRS.RPM_LICENSE)
-        package.rpm_packager = getattr(self, CREATEREPO_PACKAGE_ATTRS.RPM_PACKAGER)
-        package.rpm_sourcerpm = getattr(self, CREATEREPO_PACKAGE_ATTRS.RPM_SOURCERPM)
-        package.rpm_vendor = getattr(self, CREATEREPO_PACKAGE_ATTRS.RPM_VENDOR)
-        package.size_archive = getattr(self, CREATEREPO_PACKAGE_ATTRS.SIZE_ARCHIVE)
-        package.size_installed = getattr(self, CREATEREPO_PACKAGE_ATTRS.SIZE_INSTALLED)
-        package.size_package = getattr(self, CREATEREPO_PACKAGE_ATTRS.SIZE_PACKAGE)
+            getattr(self, PULP_PACKAGE_ATTRS.REQUIRES))
+        package.rpm_buildhost = getattr(self, PULP_PACKAGE_ATTRS.RPM_BUILDHOST)
+        package.rpm_group = getattr(self, PULP_PACKAGE_ATTRS.RPM_GROUP)
+        package.rpm_header_end = getattr(self, PULP_PACKAGE_ATTRS.RPM_HEADER_END)
+        package.rpm_header_start = getattr(self, PULP_PACKAGE_ATTRS.RPM_HEADER_START)
+        package.rpm_license = getattr(self, PULP_PACKAGE_ATTRS.RPM_LICENSE)
+        package.rpm_packager = getattr(self, PULP_PACKAGE_ATTRS.RPM_PACKAGER)
+        package.rpm_sourcerpm = getattr(self, PULP_PACKAGE_ATTRS.RPM_SOURCERPM)
+        package.rpm_vendor = getattr(self, PULP_PACKAGE_ATTRS.RPM_VENDOR)
+        package.size_archive = getattr(self, PULP_PACKAGE_ATTRS.SIZE_ARCHIVE)
+        package.size_installed = getattr(self, PULP_PACKAGE_ATTRS.SIZE_INSTALLED)
+        package.size_package = getattr(self, PULP_PACKAGE_ATTRS.SIZE_PACKAGE)
         package.suggests = str_list_to_createrepo_c(
-            getattr(self, CREATEREPO_PACKAGE_ATTRS.SUGGESTS))
-        package.summary = getattr(self, CREATEREPO_PACKAGE_ATTRS.SUMMARY)
+            getattr(self, PULP_PACKAGE_ATTRS.SUGGESTS))
+        package.summary = getattr(self, PULP_PACKAGE_ATTRS.SUMMARY)
         package.supplements = str_list_to_createrepo_c(
-            getattr(self, CREATEREPO_PACKAGE_ATTRS.SUPPLEMENTS))
-        package.time_build = getattr(self, CREATEREPO_PACKAGE_ATTRS.TIME_BUILD)
-        package.time_file = getattr(self, CREATEREPO_PACKAGE_ATTRS.TIME_FILE)
-        package.url = getattr(self, CREATEREPO_PACKAGE_ATTRS.URL)
-        package.version = getattr(self, CREATEREPO_PACKAGE_ATTRS.VERSION)
+            getattr(self, PULP_PACKAGE_ATTRS.SUPPLEMENTS))
+        package.time_build = getattr(self, PULP_PACKAGE_ATTRS.TIME_BUILD)
+        package.time_file = getattr(self, PULP_PACKAGE_ATTRS.TIME_FILE)
+        package.url = getattr(self, PULP_PACKAGE_ATTRS.URL)
+        package.version = getattr(self, PULP_PACKAGE_ATTRS.VERSION)
 
         return package
 
@@ -434,21 +453,27 @@ class UpdateRecord(Content):
 
         """
         return {
-            'id': getattr(update, CREATEREPO_UPDATE_RECORD_ATTRS.ID),
-            'updated_date': str(getattr(update, CREATEREPO_UPDATE_RECORD_ATTRS.UPDATED_DATE)),
-            'description': getattr(update, CREATEREPO_UPDATE_RECORD_ATTRS.DESCRIPTION) or '',
-            'issued_date': str(getattr(update, CREATEREPO_UPDATE_RECORD_ATTRS.ISSUED_DATE)) or '',
-            'fromstr': getattr(update, CREATEREPO_UPDATE_RECORD_ATTRS.FROMSTR) or '',
-            'status': getattr(update, CREATEREPO_UPDATE_RECORD_ATTRS.STATUS) or '',
-            'title': getattr(update, CREATEREPO_UPDATE_RECORD_ATTRS.TITLE) or '',
-            'summary': getattr(update, CREATEREPO_UPDATE_RECORD_ATTRS.SUMMARY) or '',
-            'version': getattr(update, CREATEREPO_UPDATE_RECORD_ATTRS.VERSION) or '',
-            'type': getattr(update, CREATEREPO_UPDATE_RECORD_ATTRS.TYPE) or '',
-            'severity': getattr(update, CREATEREPO_UPDATE_RECORD_ATTRS.SEVERITY) or '',
-            'solution': getattr(update, CREATEREPO_UPDATE_RECORD_ATTRS.SOLUTION) or '',
-            'release': getattr(update, CREATEREPO_UPDATE_RECORD_ATTRS.RELEASE) or '',
-            'rights': getattr(update, CREATEREPO_UPDATE_RECORD_ATTRS.RIGHTS) or '',
-            'pushcount': getattr(update, CREATEREPO_UPDATE_RECORD_ATTRS.PUSHCOUNT) or ''
+            PULP_UPDATE_RECORD_ATTRS.ID: getattr(update, CR_UPDATE_RECORD_ATTRS.ID),
+            PULP_UPDATE_RECORD_ATTRS.UPDATED_DATE: str(
+                getattr(update, CR_UPDATE_RECORD_ATTRS.UPDATED_DATE)),
+            PULP_UPDATE_RECORD_ATTRS.DESCRIPTION: getattr(
+                update, CR_UPDATE_RECORD_ATTRS.DESCRIPTION) or '',
+            PULP_UPDATE_RECORD_ATTRS.ISSUED_DATE: str(
+                getattr(update, CR_UPDATE_RECORD_ATTRS.ISSUED_DATE)) or '',
+            PULP_UPDATE_RECORD_ATTRS.FROMSTR: getattr(update, CR_UPDATE_RECORD_ATTRS.FROMSTR) or '',
+            PULP_UPDATE_RECORD_ATTRS.STATUS: getattr(update, CR_UPDATE_RECORD_ATTRS.STATUS) or '',
+            PULP_UPDATE_RECORD_ATTRS.TITLE: getattr(update, CR_UPDATE_RECORD_ATTRS.TITLE) or '',
+            PULP_UPDATE_RECORD_ATTRS.SUMMARY: getattr(update, CR_UPDATE_RECORD_ATTRS.SUMMARY) or '',
+            PULP_UPDATE_RECORD_ATTRS.VERSION: getattr(update, CR_UPDATE_RECORD_ATTRS.VERSION) or '',
+            PULP_UPDATE_RECORD_ATTRS.TYPE: getattr(update, CR_UPDATE_RECORD_ATTRS.TYPE) or '',
+            PULP_UPDATE_RECORD_ATTRS.SEVERITY: getattr(
+                update, CR_UPDATE_RECORD_ATTRS.SEVERITY) or '',
+            PULP_UPDATE_RECORD_ATTRS.SOLUTION: getattr(
+                update, CR_UPDATE_RECORD_ATTRS.SOLUTION) or '',
+            PULP_UPDATE_RECORD_ATTRS.RELEASE: getattr(update, CR_UPDATE_RECORD_ATTRS.RELEASE) or '',
+            PULP_UPDATE_RECORD_ATTRS.RIGHTS: getattr(update, CR_UPDATE_RECORD_ATTRS.RIGHTS) or '',
+            PULP_UPDATE_RECORD_ATTRS.PUSHCOUNT: getattr(
+                update, CR_UPDATE_RECORD_ATTRS.PUSHCOUNT) or ''
         }
 
     def __init__(self, *args, **kwargs):
@@ -498,8 +523,9 @@ class UpdateCollection(Model):
 
         """
         return {
-            'name': getattr(collection, CREATEREPO_UPDATE_COLLECTION_ATTRS.NAME),
-            'shortname': getattr(collection, CREATEREPO_UPDATE_COLLECTION_ATTRS.SHORTNAME)
+            PULP_UPDATE_COLLECTION_ATTRS.NAME: getattr(collection, CR_UPDATE_COLLECTION_ATTRS.NAME),
+            PULP_UPDATE_COLLECTION_ATTRS.SHORTNAME: getattr(
+                collection, CR_UPDATE_COLLECTION_ATTRS.SHORTNAME)
         }
 
     def __init__(self, *args, **kwargs):
@@ -572,16 +598,26 @@ class UpdateCollectionPackage(Model):
 
         """
         return {
-            'arch': getattr(package, CREATEREPO_UPDATE_COLLECTION_PACKAGE_ATTRS.ARCH) or '',
-            'epoch': getattr(package, CREATEREPO_UPDATE_COLLECTION_PACKAGE_ATTRS.EPOCH) or '0',
-            'filename': getattr(package, CREATEREPO_UPDATE_COLLECTION_PACKAGE_ATTRS.FILENAME) or '',
-            'name': getattr(package, CREATEREPO_UPDATE_COLLECTION_PACKAGE_ATTRS.NAME) or '',
-            'reboot_suggested': getattr(package, CREATEREPO_UPDATE_COLLECTION_PACKAGE_ATTRS.REBOOT_SUGGESTED),  # noqa
-            'release': getattr(package, CREATEREPO_UPDATE_COLLECTION_PACKAGE_ATTRS.RELEASE) or '',
-            'src': getattr(package, CREATEREPO_UPDATE_COLLECTION_PACKAGE_ATTRS.SRC) or '',
-            'sum': getattr(package, CREATEREPO_UPDATE_COLLECTION_PACKAGE_ATTRS.SUM) or '',
-            'sum_type': getattr(package, CREATEREPO_UPDATE_COLLECTION_PACKAGE_ATTRS.SUM_TYPE) or '',
-            'version': getattr(package, CREATEREPO_UPDATE_COLLECTION_PACKAGE_ATTRS.VERSION) or ''
+            PULP_UPDATE_COLLECTION_PACKAGE_ATTRS.ARCH: getattr(
+                package, CR_UPDATE_COLLECTION_PACKAGE_ATTRS.ARCH) or '',
+            PULP_UPDATE_COLLECTION_PACKAGE_ATTRS.EPOCH: getattr(
+                package, CR_UPDATE_COLLECTION_PACKAGE_ATTRS.EPOCH) or '0',
+            PULP_UPDATE_COLLECTION_PACKAGE_ATTRS.FILENAME: getattr(
+                package, CR_UPDATE_COLLECTION_PACKAGE_ATTRS.FILENAME) or '',
+            PULP_UPDATE_COLLECTION_PACKAGE_ATTRS.NAME: getattr(
+                package, CR_UPDATE_COLLECTION_PACKAGE_ATTRS.NAME) or '',
+            PULP_UPDATE_COLLECTION_PACKAGE_ATTRS.REBOOT_SUGGESTED: getattr(
+                package, CR_UPDATE_COLLECTION_PACKAGE_ATTRS.REBOOT_SUGGESTED),  # noqa
+            PULP_UPDATE_COLLECTION_PACKAGE_ATTRS.RELEASE: getattr(
+                package, CR_UPDATE_COLLECTION_PACKAGE_ATTRS.RELEASE) or '',
+            PULP_UPDATE_COLLECTION_PACKAGE_ATTRS.SRC: getattr(
+                package, CR_UPDATE_COLLECTION_PACKAGE_ATTRS.SRC) or '',
+            PULP_UPDATE_COLLECTION_PACKAGE_ATTRS.SUM: getattr(
+                package, CR_UPDATE_COLLECTION_PACKAGE_ATTRS.SUM) or '',
+            PULP_UPDATE_COLLECTION_PACKAGE_ATTRS.SUM_TYPE: getattr(
+                package, CR_UPDATE_COLLECTION_PACKAGE_ATTRS.SUM_TYPE) or '',
+            PULP_UPDATE_COLLECTION_PACKAGE_ATTRS.VERSION: getattr(
+                package, CR_UPDATE_COLLECTION_PACKAGE_ATTRS.VERSION) or ''
         }
 
 
@@ -629,10 +665,10 @@ class UpdateReference(Model):
 
         """
         return {
-            'href': getattr(reference, CREATEREPO_UPDATE_REFERENCE_ATTRS.HREF),
-            'ref_id': getattr(reference, CREATEREPO_UPDATE_REFERENCE_ATTRS.ID),
-            'title': getattr(reference, CREATEREPO_UPDATE_REFERENCE_ATTRS.TITLE),
-            'ref_type': getattr(reference, CREATEREPO_UPDATE_REFERENCE_ATTRS.TYPE)
+            PULP_UPDATE_REFERENCE_ATTRS.HREF: getattr(reference, CR_UPDATE_REFERENCE_ATTRS.HREF),
+            PULP_UPDATE_REFERENCE_ATTRS.ID: getattr(reference, CR_UPDATE_REFERENCE_ATTRS.ID),
+            PULP_UPDATE_REFERENCE_ATTRS.TITLE: getattr(reference, CR_UPDATE_REFERENCE_ATTRS.TITLE),
+            PULP_UPDATE_REFERENCE_ATTRS.TYPE: getattr(reference, CR_UPDATE_REFERENCE_ATTRS.TYPE)
         }
 
 


### PR DESCRIPTION
to better readability code package method to convert data
to createrepo_c using PULP namespace.

closes: #4567
https://pulp.plan.io/issues/4567

Signed-off-by: Pavel Picka <ppicka@redhat.com>