### PR TITLE
Set version to .dev for the master branch

### DIFF
--- a/.travis/publish_client_gem.sh
+++ b/.travis/publish_client_gem.sh
@@ -14,7 +14,7 @@ if [[ $DESCRIPTION == 'tags/'$REPORTED_VERSION ]]; then
   export VERSION=${REPORTED_VERSION}
 else
   export EPOCH="$(date +%s)"
-  export VERSION=${REPORTED_VERSION}.dev.${EPOCH}
+  export VERSION=${REPORTED_VERSION}.${EPOCH}
 fi
 
 export response=$(curl --write-out %{http_code} --silent --output /dev/null https://rubygems.org/gems/pulp_rpm_client/versions/$VERSION)

--- a/pulp_rpm/__init__.py
+++ b/pulp_rpm/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '3.0.0b3'
+__version__ = '3.0.0b4.dev'
 
 
 default_app_config = 'pulp_rpm.app.PulpRpmPluginAppConfig'

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open('README.rst') as f:
 
 setup(
     name='pulp-rpm',
-    version='3.0.0b3',
+    version='3.0.0b4.dev',
     description='RPM plugin for the Pulp Project',
     long_description=long_description,
     license='GPLv2+',


### PR DESCRIPTION
A correct version would be shown for installations from the master branch.
Bindings will be generated with a proper version as well.

re #4936
https://pulp.plan.io/issues/4936