### PR TITLE
Modulemd model and serializer

### DIFF
--- a/pulp_rpm/app/models.py
+++ b/pulp_rpm/app/models.py
@@ -100,6 +100,8 @@ class Package(Content):
             First byte of the header
         rpm_header_end (BigInteger):
             Last byte of the header
+        is_modular (Bool):
+            Flag to identify if the package is modular
 
         size_archive (BigInteger):
             Size, in bytes, of the archive portion of the original package file
@@ -177,6 +179,8 @@ class Package(Content):
     rpm_vendor = models.TextField()
     rpm_header_start = models.BigIntegerField(null=True)
     rpm_header_end = models.BigIntegerField(null=True)
+
+    is_modular = models.BooleanField(default=False)
 
     size_archive = models.BigIntegerField(null=True)
     size_installed = models.BigIntegerField(null=True)
@@ -678,3 +682,42 @@ class RpmDistribution(PublicationDistribution):
     """
 
     TYPE = 'rpm'
+
+
+class Modulemd(Content):
+    """
+    The "Modulemd" content type. Modularity support.
+
+    Fields:
+        name (Text):
+            Name of the modulemd
+        stream (Text):
+            The modulemd's stream
+        version (Text):
+            The version of the modulemd.
+        context (Text):
+            The context flag serves to distinguish module builds with the
+            same name, stream and version and plays an important role in
+            future automatic module stream name expansion.
+        arch (Text):
+            Module artifact architecture.
+        dependencies (Text):
+            Module dependencies, if any.
+        artifacts (List):
+            Artifacts shipped with this module.
+        packages (List):
+            List of Packages connected to this modulemd.
+    """
+
+    TYPE = "modulemd"
+
+    # required metadata
+    name = models.CharField(max_length=255)
+    stream = models.CharField(max_length=255)
+    version = models.CharField(max_length=255)
+    context = models.CharField(max_length=255)
+    arch = models.CharField(max_length=255)
+
+    dependencies = models.TextField(default='[]')
+    artifacts = models.TextField(default='[]')
+    packages = models.ManyToManyField(Package)

--- a/pulp_rpm/app/serializers.py
+++ b/pulp_rpm/app/serializers.py
@@ -18,6 +18,7 @@ from pulpcore.plugin.serializers import (
 )
 
 from pulp_rpm.app.models import (
+    Modulemd,
     Package,
     RpmDistribution,
     RpmRemote,
@@ -165,6 +166,10 @@ class PackageSerializer(SingleArtifactContentSerializer):
     rpm_header_end = serializers.IntegerField(
         help_text=_("Last byte of the header"),
     )
+    is_modular = serializers.BooleanField(
+        help_text=_("Flag to identify if the package is modular"),
+        required=False
+    )
 
     size_archive = serializers.IntegerField(
         help_text=_("Size, in bytes, of the archive portion of the original package file")
@@ -210,7 +215,7 @@ class PackageSerializer(SingleArtifactContentSerializer):
             'location_base', 'location_href',
             'rpm_buildhost', 'rpm_group', 'rpm_license',
             'rpm_packager', 'rpm_sourcerpm', 'rpm_vendor',
-            'rpm_header_start', 'rpm_header_end',
+            'rpm_header_start', 'rpm_header_end', 'is_modular',
             'size_archive', 'size_installed', 'size_package',
             'time_build', 'time_file', 'relative_path'
         )
@@ -458,3 +463,47 @@ class CopySerializer(serializers.Serializer):
             new_data.update({'types': final_types})
 
         return new_data
+
+
+class ModulemdSerializer(SingleArtifactContentSerializer):
+    """
+    Modulemd serializer.
+    """
+
+    name = serializers.CharField(
+        help_text=_("Modulemd name."),
+    )
+    stream = serializers.CharField(
+        help_text=_("Stream name."),
+    )
+    version = serializers.CharField(
+        help_text=_("Modulemd version."),
+    )
+    context = serializers.CharField(
+        help_text=_("Modulemd context."),
+    )
+    arch = serializers.CharField(
+        help_text=_("Modulemd architecture."),
+    )
+    artifacts = serializers.CharField(
+        help_text=_("Modulemd artifacts."),
+        allow_null=True
+    )
+    dependencies = serializers.CharField(
+        help_text=_("Modulemd dependencies."),
+        allow_null=True
+    )
+    packages = serializers.PrimaryKeyRelatedField(
+        help_text=_("Modulemd artifacts' packages."),
+        allow_null=True,
+        required=False,
+        queryset=Package.objects.all(),
+        many=True
+    )
+
+    class Meta:
+        fields = (
+            'name', 'stream', 'version', 'context', 'arch',
+            'artifacts', 'dependencies', 'packages'
+        )
+        model = Modulemd


### PR DESCRIPTION
Add pre-requisities for modularity support.
Modulemd model, modulemd serializer.
Add boolean field to Package model if rpm is modular
and its serializer.

re: #4873
https://pulp.plan.io/issues/4873

Signed-off-by: Pavel Picka <ppicka@redhat.com>