### PR TITLE
Update for pulp-smash constant name change

### DIFF
--- a/pulp_rpm/tests/functional/api/test_consume_content.py
+++ b/pulp_rpm/tests/functional/api/test_consume_content.py
@@ -5,7 +5,7 @@ from urllib.parse import urljoin
 
 from pulp_smash import api, cli, config
 from pulp_smash.pulp3.constants import (
-    LAZY_DOWNLOAD_POLICIES,
+    ON_DEMAND_DOWNLOAD_POLICIES,
     REPO_PATH,
 )
 from pulp_smash.pulp3.utils import (
@@ -39,14 +39,14 @@ class PackageManagerConsumeTestCase(unittest.TestCase):
             'This test requires dnf or yum.'
         )
 
-    def test_lazy_policies(self):
-        """Verify whether content lazy synced can be consumed.
+    def test_on_demand_policies(self):
+        """Verify whether content on demand synced can be consumed.
 
         This test targets the following issue:
 
         `Pulp #4496 <https://pulp.plan.io/issues/4496>`_
         """
-        for policy in LAZY_DOWNLOAD_POLICIES:
+        for policy in ON_DEMAND_DOWNLOAD_POLICIES:
             delete_orphans(self.cfg)
             self.do_test(policy)
 

--- a/pulp_rpm/tests/functional/api/test_crud_remotes.py
+++ b/pulp_rpm/tests/functional/api/test_crud_remotes.py
@@ -6,7 +6,10 @@ import unittest
 from requests.exceptions import HTTPError
 
 from pulp_smash import api, config, utils
-from pulp_smash.pulp3.constants import DOWNLOAD_POLICIES
+from pulp_smash.pulp3.constants import (
+    IMMEDIATE_DOWNLOAD_POLICIES,
+    ON_DEMAND_DOWNLOAD_POLICIES,
+)
 
 from pulp_rpm.tests.functional.constants import RPM_REMOTE_PATH
 from pulp_rpm.tests.functional.utils import gen_rpm_remote, skip_if
@@ -56,9 +59,9 @@ class CRUDRemotesTestCase(unittest.TestCase):
     @skip_if(bool, 'remote', False)
     def test_02_read_remotes(self):
         """Read a remote by its name."""
-        page = self.client.get(RPM_REMOTE_PATH, params={
-            'name': self.remote['name']
-        })
+        page = self.client.get(
+            RPM_REMOTE_PATH, params={'name': self.remote['name']}
+        )
         self.assertEqual(len(page['results']), 1)
         for key, val in self.remote.items():
             with self.subTest(key=key):
@@ -121,7 +124,8 @@ class CreateRemoteNoURLTestCase(unittest.TestCase):
                     key in response.json()['url'][0]
                     for key in ['field', 'required']
                 ]
-            ), response.json()
+            ),
+            response.json(),
         )
 
 
@@ -136,9 +140,13 @@ def _gen_verbose_remote():
     Note that 'username' and 'password' are write-only attributes.
     """
     attrs = gen_rpm_remote()
-    attrs.update({
-        'password': utils.uuid4(),
-        'username': utils.uuid4(),
-        'policy': choice(DOWNLOAD_POLICIES),
-    })
+    attrs.update(
+        {
+            'password': utils.uuid4(),
+            'username': utils.uuid4(),
+            'policy': choice(
+                IMMEDIATE_DOWNLOAD_POLICIES + ON_DEMAND_DOWNLOAD_POLICIES
+            ),
+        }
+    )
     return attrs


### PR DESCRIPTION
The names were updated to replace 'lazy' with 'on demand' and also
reflect the recently changed validation in pulpcore.

Required PR: pulp/pulpcore#199
Required PR: PulpQE/pulp-smash#1210

[noissue]