### PR TITLE
[Pulp2, WIP] On sync-and-feed-was-changed, update existing entries

### DIFF
--- a/plugins/pulp_rpm/plugins/importers/yum/existing.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/existing.py
@@ -128,8 +128,7 @@ def check_all_and_associate(wanted, conduit, config, download_deferred, catalog)
     importer = Importer.objects.get(id=conduit.importer_object_id)
     # If UPDATED doesn't exist in the importer's config, or it exists but is false - feed-url
     # hasn't changed since last sync
-    same_feed = importer_constants.KEY_FEED_UPDATED not in importer.config or \
-        not importer.config[importer_constants.KEY_FEED_UPDATED]
+    same_feed = not importer._get_scratchpad_entry(importer_constants.KEY_FEED_UPDATED)
 
     for unit_type, values in sorted_units.iteritems():
         model = plugin_api.get_unit_model_by_id(unit_type)

--- a/plugins/pulp_rpm/plugins/importers/yum/existing.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/existing.py
@@ -7,7 +7,6 @@ from pulp.plugins.loader import api as plugin_api
 from pulp.plugins.util.misc import paginate
 from pulp.server.controllers import repository as repo_controller
 from pulp.server.controllers import units as units_controller
-from pulp.server.db.model import Importer
 from pulp.server.exceptions import PulpCodedException
 
 from pulp_rpm.common import ids
@@ -125,10 +124,9 @@ def check_all_and_associate(wanted, conduit, config, download_deferred, catalog)
 
     sorted_units = _sort_by_type(wanted.iterkeys())
 
-    importer = Importer.objects.get(id=conduit.importer_object_id)
     # If UPDATED doesn't exist in the importer's config, or it exists but is false - feed-url
     # hasn't changed since last sync
-    same_feed = not importer._get_scratchpad_entry(importer_constants.KEY_FEED_UPDATED)
+    same_feed = not conduit.get_scratchpad_entry(importer_constants.KEY_FEED_UPDATED)
 
     for unit_type, values in sorted_units.iteritems():
         model = plugin_api.get_unit_model_by_id(unit_type)

--- a/plugins/pulp_rpm/plugins/importers/yum/sync.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/sync.py
@@ -846,7 +846,7 @@ class RepoSync(object):
                     # possibly-new download-urls
                     if feed_updated:
                         num_unit_found = unit.__class__.objects.filter(**unit.unit_key).count()
-                        if num_unit_found > 0: # We have an LCE for this-nevra, punt it
+                        if num_unit_found > 0:  # We have an LCE for this-nevra, punt it
                             catalog.delete(unit)
                     unit = self.add_rpm_unit(metadata_files, unit)
                     self.associate_rpm_unit(unit)
@@ -912,7 +912,8 @@ class RepoSync(object):
                             # LazyCatalogEntry if there is one, in order to safely rebuild LCE with
                             # possibly-new download-urls
                             if feed_updated:
-                                num_unit_found = unit.__class__.objects.filter(**unit.unit_key).count()
+                                num_unit_found = \
+                                    unit.__class__.objects.filter(**unit.unit_key).count()
                                 if num_unit_found > 0:  # We have an LCE for this-nevra, punt it
                                     catalog.delete(unit)
                             unit = self.add_rpm_unit(metadata_files, unit)

--- a/plugins/pulp_rpm/plugins/importers/yum/sync.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/sync.py
@@ -371,9 +371,8 @@ class RepoSync(object):
             # If we're here, sync was successful (for some definition of 'success')
             # If feed-url had been updated, clear the flag set in config
             importer = Importer.objects.get(id=self.conduit.importer_object_id)
-            if importer_constants.KEY_FEED_UPDATED in importer.config and \
-                    importer.config[importer_constants.KEY_FEED_UPDATED]:
-                importer.config[importer_constants.KEY_FEED_UPDATED] = False
+            if importer._get_scratchpad_entry(importer_constants.KEY_FEED_UPDATED):
+                importer._set_scratchpad_entry(importer_constants.KEY_FEED_UPDATED, False)
                 importer.save()
 
             if self.config.override_config.get(importer_constants.KEY_FEED):
@@ -827,6 +826,7 @@ class RepoSync(object):
         """
         event_listener = RPMListener(self, metadata_files)
         primary_file_handle = metadata_files.get_metadata_file_handle(primary.METADATA_FILE_NAME)
+
         try:
             package_model_generator = packages.package_list_generator(
                 primary_file_handle,
@@ -848,8 +848,7 @@ class RepoSync(object):
                     # in order to safely rebuild LCE with possibly-new download-urls
                     # [NOTE: "if there is one" is almost certainly paranoia at this point in the
                     # code-flow. Paranoia is not always invalid, however...]
-                    if importer_constants.KEY_FEED_UPDATED in importer.config and \
-                            importer.config[importer_constants.KEY_FEED_UPDATED]:
+                    if importer._get_scratchpad_entry(importer_constants.KEY_FEED_UPDATED):
                         units = unit.__class__.objects.filter(**unit.unit_key)
                         repo_controller.disassociate_units(self.repo, units)
                         for old_unit in units:
@@ -920,8 +919,7 @@ class RepoSync(object):
                             # in order to safely rebuild LCE with possibly-new download-urls
                             # [NOTE: "if there is one" is almost certainly paranoia at this point
                             # in the code-flow. Paranoia is not always invalid, however...]
-                            if importer_constants.KEY_FEED_UPDATED in importer.config and \
-                                    importer.config[importer_constants.KEY_FEED_UPDATED]:
+                            if importer._get_scratchpad_entry(importer_constants.KEY_FEED_UPDATED):
                                 units = unit.__class__.objects.filter(**unit.unit_key)
                                 repo_controller.disassociate_units(self.repo, units)
                                 for old_unit in units:


### PR DESCRIPTION
for on-demand units

NOTE: *requires* https://github.com/pulp/pulp/pull/3938 to be
successful.

closes #4265
https://pulp.plan.io/issues/4265