### PR TITLE
Use relative_path instead of filename

### DIFF
--- a/CHANGES/4987.bugfix
+++ b/CHANGES/4987.bugfix
@@ -1,0 +1,1 @@
+Use the field relative_path instead of filename in the API calls while creating a content from an artifact

--- a/docs/workflows/upload.rst
+++ b/docs/workflows/upload.rst
@@ -26,7 +26,7 @@ Create ``rpm`` content from an Artifact
 
 Create a content unit and point it to your artifact
 
-``$ http POST http://localhost:24817/pulp/api/v3/content/rpm/packages/ _artifact="/pulp/api/v3/artifacts/d1dd56aa-c236-414a-894f-b3d9334d2e73/" filename=foo-4.1-1.noarch.rpm``
+``$ http POST http://localhost:24817/pulp/api/v3/content/rpm/packages/ _artifact="/pulp/api/v3/artifacts/d1dd56aa-c236-414a-894f-b3d9334d2e73/" relative_path=foo-4.1-1.noarch.rpm``
 
 .. code:: json
 

--- a/pulp_rpm/app/serializers.py
+++ b/pulp_rpm/app/serializers.py
@@ -42,8 +42,6 @@ class PackageSerializer(SingleArtifactContentSerializer):
     relative_path = serializers.CharField(
         help_text=_("File name of the package"),
         required=True,
-        allow_null=True,
-        allow_blank=True,
         write_only=True,
     )
 

--- a/pulp_rpm/app/viewsets.py
+++ b/pulp_rpm/app/viewsets.py
@@ -85,14 +85,14 @@ class PackageViewSet(ContentViewSet):
             raise serializers.ValidationError(detail={'_artifact': _('This field is required')})
 
         try:
-            filename = request.data['filename']
+            relative_path = request.data['relative_path']
         except KeyError:
-            raise serializers.ValidationError(detail={'filename': _('This field is required')})
+            raise serializers.ValidationError(detail={'relative_path': _('This field is required')})
 
         try:
-            new_pkg = _prepare_package(artifact, filename)
+            new_pkg = _prepare_package(artifact, relative_path)
             new_pkg['_artifact'] = request.data['_artifact']
-            new_pkg['relative_path'] = request.data.get('relative_path', '')
+            new_pkg['relative_path'] = relative_path
         except OSError:
             return Response('RPM file cannot be parsed for metadata.',
                             status=status.HTTP_406_NOT_ACCEPTABLE)

--- a/pulp_rpm/tests/functional/api/test_character_encoding.py
+++ b/pulp_rpm/tests/functional/api/test_character_encoding.py
@@ -47,7 +47,7 @@ class UploadEncodingMetadataTestCase(unittest.TestCase):
         artifact = self.client.post(ARTIFACTS_PATH, files=files)
         content_unit = self.client.post(RPM_CONTENT_PATH, {
             '_artifact': artifact['_href'],
-            'filename': RPM_WITH_NON_ASCII_NAME
+            'relative_path': RPM_WITH_NON_ASCII_NAME
         })
         repo = self.client.post(REPO_PATH, gen_repo())
         self.addCleanup(self.client.delete, repo['_href'])
@@ -67,5 +67,5 @@ class UploadEncodingMetadataTestCase(unittest.TestCase):
         with self.assertRaises(HTTPError):
             self.client.post(RPM_CONTENT_PATH, {
                 '_artifact': artifact['_href'],
-                'filename': RPM_WITH_NON_UTF_8_NAME
+                'relative_path': RPM_WITH_NON_UTF_8_NAME
             })

--- a/pulp_rpm/tests/functional/api/test_crud_content_unit.py
+++ b/pulp_rpm/tests/functional/api/test_crud_content_unit.py
@@ -50,7 +50,7 @@ class ContentUnitTestCase(unittest.TestCase):
         self.content_unit.update(
             self.client.post(RPM_CONTENT_PATH, {
                 '_artifact': self.artifact['_href'],
-                'filename': RPM_PACKAGE_FILENAME
+                'relative_path': RPM_PACKAGE_FILENAME
             })
         )
         for key, val in RPM_PACKAGE_DATA.items():
@@ -137,7 +137,7 @@ class DuplicateContentUnit(unittest.TestCase):
         artifact = self.client.post(ARTIFACTS_PATH, files=files)
         attrs = {
             '_artifact': artifact['_href'],
-            'filename': RPM_PACKAGE_FILENAME
+            'relative_path': RPM_PACKAGE_FILENAME
         }
 
         # create first content unit.


### PR DESCRIPTION
The field filename seems to be redundant. Therefore, it's usages were removed from
the corresponding view set. Now, relative_path is used as filename instead.

In this commit, the field relative_path is no longer nullable. Also, the field
cannot be initialized to an empty string because it is used for a package creation
where the path is stored as location_href.

closes #4987
https://pulp.plan.io/issues/4987