### PR TITLE
Fix travis distro to "trusty"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: python
 python:
   - "2.6"


### PR DESCRIPTION
Travis recently changed their default from Trusty to Xenial, which no
longer supports Python 2.6.

[noissue]