### PR TITLE
 As a user, multiple source/target repositories can be used for recursive copy

### DIFF
--- a/common/pulp_rpm/common/constants.py
+++ b/common/pulp_rpm/common/constants.py
@@ -118,6 +118,7 @@ CONFIG_SKIP = 'type_skip_list'
 CONFIG_SSL_AUTH_CA_CERT = 'ssl_auth_ca_cert'
 
 # Copy operation config
+CONFIG_ADDITIONAL_REPOS = 'additional_repos'
 CONFIG_RECURSIVE = 'recursive'
 # use the conservative dependency solver to compute unit dependencies
 CONFIG_RECURSIVE_CONSERVATIVE = 'recursive_conservative'

--- a/docs/tech-reference/yum-plugins.rst
+++ b/docs/tech-reference/yum-plugins.rst
@@ -619,12 +619,26 @@ configuration values are optional.
  make it easy to filter packages based on their signing key and does not use these key IDs for
  package signature verification.
 
-``recursive`` Boolean flag. If true, units are copied together with the latest versions
+``recursive``
+Boolean flag. If true, units are copied together with the latest versions
 of their dependencies. False by default. More information about its usage can be found in :ref:`advanced_copy_between_repositories`.
 
-``recursive_conservative`` Boolean flag. If true, units are copied together with their
+``recursive_conservative``
+Boolean flag. If true, units are copied together with their
 dependencies, unless those are already satisfied by the content in the target repository.
 False by default. More information about its usage can be found in :ref:`advanced_copy_between_repositories`.
+
+``additional_repos``
+Supported only as an override config option to a repository copy command, and must be used
+in conjunction with ``recursive`` or ``recursive_conservative`` options. This option allows
+for dependencies to be found in repositories ouside of the one the specified in the copy
+command, and copied to repositories apart from the one specified in the copy command. For
+example, you may have a repository whose units depend on RPMs in another repo,
+(e.g. a cloned modular repo) and want to maintain correctness when copying new modules into
+and out of that repository. Unlike other config options, ``additional_repos`` must be provided
+as a JSON object. In this object, the "key" should be the name of a repository to copy *from*,
+and the "value" should be the name of a repository to copy *to*.  Default is to not consider
+any additional repos.More information about its usage can be found in :ref:`advanced_copy_between_repositories`.
 
 Yum Distributor
 ===============

--- a/plugins/pulp_rpm/plugins/db/models.py
+++ b/plugins/pulp_rpm/plugins/db/models.py
@@ -1174,11 +1174,10 @@ class Errata(UnitMixin, ContentUnit):
 
     @property
     def module_search_dicts(self):
-        ret = self.get_unique_modules(errata_id=self.errata_id)
-        for sd in ret:
+        for mod in self.get_unique_modules(errata_id=self.errata_id):
             # FIXME: this is already a second place I need to cast, somthing's fishy
-            sd.update(version=int(sd['version']))
-        return ret
+            mod.update(version=int(mod['version']))
+            yield mod
 
     @classmethod
     def get_unique_pkglists(cls, errata_id):

--- a/plugins/pulp_rpm/plugins/importers/yum/associate.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/associate.py
@@ -189,6 +189,16 @@ def associate(source_repo, dest_repo, import_conduit, config, units=None):
             repo_controller.update_last_unit_added(dst_repo.repo_id)
             repo_controller.rebuild_content_unit_counts(dst_repo)
 
+    # filter out these types from the set of failed units because they must be cloned, not
+    # simply copied, and the cloned units are not identical to the originals and thus
+    # get erroneously included in the set of failed units.
+    # this is not a good "solution" but a "good solution" is not forthcoming. this has also
+    # been a longstanding issue that went totally unnoticed for a long time.
+    failed_units = set([
+        unit for unit in failed_units if not
+        isinstance(unit, (models.YumMetadataFile, models.ModulemdDefaults))
+    ])
+
     # allow garbage collection
     del units
 

--- a/plugins/pulp_rpm/plugins/importers/yum/associate.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/associate.py
@@ -104,14 +104,8 @@ def associate(source_repo, dest_repo, import_conduit, config, units=None):
         target_repo=dest_repo,
         conservative=config.get(constants.CONFIG_RECURSIVE_CONSERVATIVE),
         additional_repos=additional_repos,
-        ignore_missing=False
-        # the line above disables the code which injects "dummy solvables" to provide
-        # missing packages. it is not known whether that code is 100% necessary, but it
-        # is feeding invalid data to libsolv somehow resulting in a violated invariant
-        # and failure on an assert statement here
-        # https://github.com/openSUSE/libsolv/blob/master/src/solver.c#L1979-L1981
+        ignore_missing=True
     )
-    # Only loads the original source and destination repositories
     solver.load()
 
     (group_ids, rpm_names, rpm_search_dicts,

--- a/plugins/pulp_rpm/plugins/importers/yum/associate.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/associate.py
@@ -182,7 +182,10 @@ def associate(source_repo, dest_repo, import_conduit, config, units=None):
         )
         failed_units |= units_to_copy - associated_units
 
-        if associated_units:
+        # Update content unit counts
+        # This is normally done by core for the destination repository, however, that will
+        # not update things for our additional repositories, so we have to do it ourself
+        if associated_units and dst_repo.repo_id != dest_repo.repo_id:
             repo_controller.update_last_unit_added(dst_repo.repo_id)
             repo_controller.rebuild_content_unit_counts(dst_repo)
 

--- a/plugins/pulp_rpm/plugins/importers/yum/pulp_solv.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/pulp_solv.py
@@ -582,10 +582,9 @@ def module_defaults_unit_to_solvable(solv_repo, unit):
         """
         Links a module and its default with dependencies.
         """
-        if stream:
-            module_depid = pool.Dep('module({}:{})'.format(name, stream), 0)
-        else:
-            module_depid = pool.Dep('module({})'.format(name), 0)
+        # we are making all modules require the module-default regardless of they are default
+        # since the module-default can cary profile information
+        module_depid = pool.Dep('module({})'.format(name), 0)
 
         module_default_depid = pool.Dep(solvable.name)
         if not module_depid:

--- a/plugins/pulp_rpm/plugins/importers/yum/pulp_solv.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/pulp_solv.py
@@ -737,18 +737,16 @@ class Solver(object):
         if self._loaded:
             return
 
-        # Load the primary source and (if provided) target repos
-        self.load_source_repo(self.primary_source_repo.repo_id)
-        if self.primary_target_repo:
-            self.load_target_repo(self.primary_target_repo.repo_id)
+        source_repos = \
+            set([self.primary_source_repo.repo_id]) | set(self._additional_repo_mapping.keys())
+        target_repos = \
+            set([self.primary_target_repo.repo_id]) | set(self._additional_repo_mapping.values())
 
-        # Load the additional source and target repos, if provided
-        if self._additional_repo_mapping:
-            for source_repo_id in set(self._additional_repo_mapping.keys()):
-                self.load_source_repo(source_repo_id)
+        for source_repo_id in source_repos:
+            self.load_source_repo(source_repo_id)
 
-            for target_repo_id in set(self._additional_repo_mapping.values()):
-                self.load_target_repo(target_repo_id)
+        for target_repo_id in target_repos:
+            self.load_target_repo(target_repo_id)
 
         self._pool.installed = self.mapping.get_repo(COMBINED_TARGET_REPO_NAME)
 

--- a/plugins/pulp_rpm/plugins/importers/yum/pulp_solv.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/pulp_solv.py
@@ -691,13 +691,15 @@ class UnitSolvableMapping(object):
         ret = collections.defaultdict(set)
         for repo, unit_ids in repo_unit_map.items():
             for paginated_unit_ids in misc_utils.paginate(unit_ids):
+                modulemd_fields = ['_storage_path']
+                modulemd_fields.extend(models.ModulemdDefaults.unit_key_fields)
                 iterator = itertools.chain(
                     models.RPM.objects.filter(id__in=paginated_unit_ids).only(
                         *models.RPM.unit_key_fields),
                     models.Modulemd.objects.filter(id__in=paginated_unit_ids).only(
                         *models.Modulemd.unit_key_fields),
                     models.ModulemdDefaults.objects.filter(id__in=paginated_unit_ids).only(
-                        *models.ModulemdDefaults.unit_key_fields))
+                        *modulemd_fields))
                 for unit in iterator:
                     ret[repo].add(unit)
         return ret

--- a/plugins/pulp_rpm/plugins/importers/yum/pulp_solv.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/pulp_solv.py
@@ -883,6 +883,11 @@ class Solver(object):
                         # A solvable provides the dep but could not be installed for some reason
                         continue
 
+                    elif info.type == solv.Solver.SOLVER_RULE_INFARCH:
+                        # The solver isn't allowed to rely on packages of an inferior architecture
+                        # ie. i686 when x86_64 is being solved for
+                        continue
+
                     elif info.type == solv.Solver.SOLVER_RULE_PKG_SAME_NAME:
                         # The deps can only be fulfilled by multiple versions of a package,
                         # but installing multiple versions of the same package is not allowed.
@@ -890,11 +895,11 @@ class Solver(object):
 
                     else:
                         _LOGGER.warning(
-                            'No workaround available for problem type %s. '
-                            'You may refer to the libsolv Solver class documetnation '
+                            'No workaround available for problem \'%s\'. '
+                            'You may refer to the libsolv Solver class documentation '
                             'for more details. See https://github.com/openSUSE/'
                             'libsolv/blob/master/doc/libsolv-bindings.txt'
-                            '#the-solver-class.', info.type
+                            '#the-solver-class.', problem_rule.info().problemstr()
                         )
         self._pool.createwhatprovides()
 

--- a/plugins/pulp_rpm/plugins/importers/yum/pulp_solv.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/pulp_solv.py
@@ -771,7 +771,7 @@ class Solver(object):
         """
         units = fetch_units_from_repo(repo_id)
         self.add_repo_units(units, repo_id)
-        _LOGGER.info('Loaded repository %s', repo_id)
+        _LOGGER.debug('Loaded repository %s', repo_id)
 
     def load_target_repo(self, repo_id):
         """Load the provided Pulp repo into the combined target repo.
@@ -781,7 +781,7 @@ class Solver(object):
         """
         units = fetch_units_from_repo(repo_id)
         self.add_repo_units(units, repo_id, override_repo_name=COMBINED_TARGET_REPO_NAME)
-        _LOGGER.info('Loaded repository %s into combined target repo' % str(repo_id))
+        _LOGGER.debug('Loaded repository %s into combined target repo' % str(repo_id))
 
     def add_repo_units(self, units, repo_id, override_repo_name=None):
         """Generate solvables from Pulp units and add them to the mapping.
@@ -1033,7 +1033,7 @@ class Solver(object):
 
         targets = self.mapping.get_repo_units(self.primary_target_repo.repo_id)
         for target_repo in self._additional_repo_mapping.values():
-            targets.extend(self.mapping.get_repo_units(target_repo))
+            targets |= self.mapping.get_repo_units(target_repo)
 
         return [s for s in seen if self.mapping.get_unit_id(s)[0] not in targets]
 


### PR DESCRIPTION
# multi-repo copy

This PR has a companion here: https://github.com/pulp/pulp/pull/3947

This PR is best reviewed as a series of individual commits.

### Testing this PR (manually)

Create 4 repositories:

* 1 repository must contain modules or RPMs that depend on other RPMs in the second repo
* 1 repository must contain all of the RPM dependencies needed by the first repo
* 2 empty repositories

Personally, I used these two Fedora repositories:

* releases/30/Modular: https://dl.fedoraproject.org/pub/fedora/linux/releases/30/Modular/x86_64/
* releases/30/Everything: https://dl.fedoraproject.org/pub/fedora/linux/releases/30/Everything/x86_64/os/

The former repo depends on stuff in the latter repo.

Make a direct API request -- there is no ```pulp-admin``` support for this feature at the moment

```curl -k -u admin:admin  --cert ~/.pulp/user-cert.pem -d '{"source_repo_id":"modular-release","criteria":{"type_ids":["modulemd"],"filters":{"unit":{"$and":[{"name":"mariadb","stream":"10.4"}]}}},"override_config":{"recursive_conservative":true,"additional_repos":{"release": "test2"}}}' -H "Content-Type: application/json" -X POST https://localhost/pulp/api/v2/repositories/test1/actions/associate/```

In this request, I copied the module ```mariadb``` stream ```10.4``` from repo ```modular-release``` to repo ```test1``` while using an override config that specifies ```"recursive_conservative": true``` and ```"additional_repos":{"release": "test2"}```.  ```"additional_repos":{"release": "test2"}``` means that the repo ```release``` will be loaded into the depsolver also, and any dependencies found in ```release``` will be copied to repo ```test2``` instead of the normal destination repository.

Results (as per ```pulp-admin rpm repo list```):

```
Id:                  test1
Display Name:        None
Description:         None
Content Unit Counts:
  Modulemd:          1
  Modulemd Defaults: 1
  Rpm:               19
 
Id:                  test2
Display Name:        None
Description:         None
Content Unit Counts:
  Rpm: 238
```

### Design decisions

I put the ```additional_repos``` key in the override config because ```recursive``` and ```recursive_conservative``` are also in the override config, because the RPM plugin is the only plugin that will use this and therefore this is the least invasive way to make sure no other plugins are affected.  Information in the ```additional_repos``` key has to be used by both Pulp 2 core and by the plugin, and so it has to be passed up through every single layer of the API -- and the config already is.

This PR does a significant amount of refactoring and cleans up the copy code quite a bit.  Several existing, undiscovered bugs were discovered in the process of the refactoring which can be found in the individual commits. 

Among the significant changes:

* ```associate.py::associate()``` is no longer called recursively
* depsolving is no longer a process that occurs *as* the RPMs are copied inside ```associate.py::copy_rpms()```, called repeatedly as more and more RPM children of errata, groups, etc. are discovered.  Instead, the children are found first, combined into one single set of units along with the original ones from which the children were found, then combined again with the dependencies discovered via depsolving (which only happens once), which are then associated with the target repo(s) all at once and in one place.
    * the changes above enabled the simple copy branch to be combined with recursive copy -- only the depsolving step is skipped. this reduces a lot of duplicate code.
* discovery of RPM children of groups now happens iteratively instead of recursively

### Future work

There are no smash tests (or unit tests) that currently cover the ```additional_repos``` key.  Since it's difficult to test manually this will be the only realistic way to really verify the behavior is correct.