### PR TITLE
Misc fixes from the latest plugin_template branch

### DIFF
--- a/.travis/before_script.sh
+++ b/.travis/before_script.sh
@@ -7,7 +7,7 @@
 #
 # For more info visit https://github.com/pulp/plugin_template
 
-set -v
+set -euv
 
 export PRE_BEFORE_SCRIPT=$TRAVIS_BUILD_DIR/.travis/pre_before_script.sh
 export POST_BEFORE_SCRIPT=$TRAVIS_BUILD_DIR/.travis/post_before_script.sh

--- a/.travis/check_commit.sh
+++ b/.travis/check_commit.sh
@@ -7,6 +7,8 @@
 #
 # For more info visit https://github.com/pulp/plugin_template
 
+set -euv
+
 # skip this check for everything but PRs
 if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
   exit 0
@@ -18,7 +20,7 @@ elif [ "$TRAVIS_COMMIT" != "" ]; then
   RANGE=$TRAVIS_COMMIT
 fi
 
-# Travis sends the ranges with 3 dots. Git only wants one.
+# Travis sends the ranges with 3 dots. Git only wants two.
 if [[ "$RANGE" == *...* ]]; then
   RANGE=`echo $TRAVIS_COMMIT_RANGE | sed 's/\.\.\./../'`
 else

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -7,7 +7,7 @@
 #
 # For more info visit https://github.com/pulp/plugin_template
 
-set -v
+set -euv
 
 if [ "$TEST" = 'docs' ]; then
 
@@ -80,6 +80,7 @@ spec:
     username: pulp
     password: pulp
     admin_password: pulp
+  content_host: $(hostname):24816
 CRYAML
 
 # Install k3s, lightweight Kubernetes

--- a/.travis/publish_client_gem.sh
+++ b/.travis/publish_client_gem.sh
@@ -7,6 +7,8 @@
 #
 # For more info visit https://github.com/pulp/plugin_template
 
+set -euv
+
 echo "---
 :rubygems_api_key: $RUBYGEMS_API_KEY" > ~/.gem/credentials
 sudo chmod 600 ~/.gem/credentials

--- a/.travis/publish_client_pypi.sh
+++ b/.travis/publish_client_pypi.sh
@@ -7,6 +7,8 @@
 #
 # For more info visit https://github.com/pulp/plugin_template
 
+set -euv
+
 pip install twine
 
 django-admin runserver 24817 >> ~/django_runserver.log 2>&1 &

--- a/.travis/publish_plugin_pypi.sh
+++ b/.travis/publish_plugin_pypi.sh
@@ -7,6 +7,8 @@
 #
 # For more info visit https://github.com/pulp/plugin_template
 
+set -euv
+
 pip install twine
 
 python setup.py sdist bdist_wheel --python-tag py3

--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -108,16 +108,13 @@ export CMD_PREFIX="sudo kubectl exec $PULP_API_POD --"
 # This has to be done after wait_for_pulp (although not at the very end of it.)
 $CMD_PREFIX pip3 install pytest mock
 # Many functional tests require these
-$CMD_PREFIX dnf install -y lsof which dnf-plugins-core
+$CMD_PREFIX dnf install -yq lsof which dnf-plugins-core
 # The alias does not seem to work in Travis / the scripting framework
 #alias pytest="$CMD_PREFIX pytest"
 
 # Run unit tests.
 $CMD_PREFIX bash -c "sed \"s/'USER': 'pulp'/'USER': 'postgres'/g\" /etc/pulp/settings.py > unit-test.py"
-# Temporarily continue here while we fix them under containers.
-set +e
 $CMD_PREFIX bash -c "PULP_SETTINGS=/unit-test.py django-admin test  --noinput /usr/local/lib/python${TRAVIS_PYTHON_VERSION}/site-packages/pulp_rpm/tests/unit/"
-set -e
 
 # Note: This function is in the process of being merged into after_failure
 show_logs_and_return_non_zero() {
@@ -129,6 +126,7 @@ show_logs_and_return_non_zero() {
   echo -en "travis_fold:end:$containerlog"'\\r'
   return "${rc}"
 }
+export -f show_logs_and_return_non_zero
 
 # Run functional tests
 set +u


### PR DESCRIPTION
"use-containers-for-CI"

Most significantly, unit test failures will now make travis fail.

[noissue]

re: 5064
migrate travis plugin-template to installing pulp in containers
https://pulp.plan.io/issues/5004