### PR TITLE
Sync modulemd and modulemd-defaults

### DIFF
--- a/CHANGES/5172.misc
+++ b/CHANGES/5172.misc
@@ -1,0 +1,2 @@
+Modularity sync.
+

--- a/pulp_rpm/app/constants.py
+++ b/pulp_rpm/app/constants.py
@@ -75,6 +75,7 @@ CR_PACKAGE_ATTRS = SimpleNamespace(
 PACKAGE_REPODATA = ['primary', 'filelists', 'other']
 PACKAGE_DB_REPODATA = ['primary_db', 'filelists_db', 'other_db']
 UPDATE_REPODATA = ['updateinfo']
+MODULAR_REPODATA = ['modules']
 
 CR_UPDATE_RECORD_ATTRS = SimpleNamespace(
     ID='id',
@@ -141,3 +142,28 @@ PULP_UPDATE_COLLECTION_ATTRS = CR_UPDATE_COLLECTION_ATTRS
 PULP_UPDATE_COLLECTION_PACKAGE_ATTRS = CR_UPDATE_COLLECTION_PACKAGE_ATTRS
 
 PULP_UPDATE_COLLECTION_ATTRS_MODULE = CR_UPDATE_COLLECTION_ATTRS_MODULE
+
+MODULEMD_MODULE_ATTR = SimpleNamespace(
+    ARCH='arch',
+    ARTIFACTS='artifacts',
+    CONTEXT='context',
+    NAME='name',
+    STREAM='stream',
+    VERSION='version',
+    DEPENDENCIES='dependencies'
+)
+
+MODULEMD_MODULEDEFAULTS_ATTR = SimpleNamespace(
+    MODULE='module',
+    STREAM='stream',
+    PROFILES='profiles'
+)
+
+PULP_MODULEDEFAULTS_ATTR = SimpleNamespace(
+    MODULE='module',
+    STREAM='stream',
+    PROFILES='profiles',
+    DIGEST='digest'
+)
+
+PULP_MODULE_ATTR = MODULEMD_MODULE_ATTR

--- a/pulp_rpm/app/models.py
+++ b/pulp_rpm/app/models.py
@@ -959,7 +959,7 @@ class ModulemdDefaults(Content):
         profiles (Text):
             Default profiles for modulemd streams.
         digest (Text):
-            Modulmd digest
+            Modulemd digest
     """
 
     TYPE = "modulemd-defaults"
@@ -969,6 +969,13 @@ class ModulemdDefaults(Content):
     profiles = models.TextField(default='[]')
 
     digest = models.CharField(unique=True, max_length=64)
+
+    @classmethod
+    def natural_key_fields(cls):
+        """
+        Digest is used as a natural key for ModulemdDefaults.
+        """
+        return ('digest',)
 
     class Meta:
         default_related_name = "%(app_label)s_%(model_name)s"

--- a/pulp_rpm/app/modulemd.py
+++ b/pulp_rpm/app/modulemd.py
@@ -1,0 +1,100 @@
+import json
+import os
+import tempfile
+
+from pulpcore.app.models.content import Artifact
+from pulp_rpm.app.constants import PULP_MODULE_ATTR, PULP_MODULEDEFAULTS_ATTR
+
+import gi
+gi.require_version('Modulemd', '2.0')
+from gi.repository import Modulemd as mmdlib  # noqa: E402
+
+
+def _create_snippet(snippet_string):
+    """
+    Create snippet of modulemd[-defaults] as artifact.
+
+    Args:
+        snippet_string (string):
+            Snippet with modulemd[-defaults] yaml
+
+    Returns:
+        Snippet as unsaved Artifact object
+
+    """
+    tmp_file = tempfile.NamedTemporaryFile(dir=os.getcwd(), delete=False)
+    with open(tmp_file.name, 'w') as snippet:
+        snippet.write(snippet_string)
+    return Artifact.init_and_validate(tmp_file.name)
+
+
+def parse_modulemd(module_names, module_index):
+    """
+    Get modulemd NSVCA, artifacts, dependencies.
+
+    Args:
+        module_names (list):
+            list of modulemd names
+        module_index (mmdlib.ModuleIndex):
+            libmodulemd index object
+
+    """
+    ret = list()
+    for module in module_names:
+        for s in module_index.get_module(module).get_all_streams():
+            modulemd = dict()
+            modulemd[PULP_MODULE_ATTR.NAME] = s.props.module_name
+            modulemd[PULP_MODULE_ATTR.STREAM] = s.props.stream_name
+            modulemd[PULP_MODULE_ATTR.VERSION] = s.props.version
+            modulemd[PULP_MODULE_ATTR.CONTEXT] = s.props.context
+            modulemd[PULP_MODULE_ATTR.ARCH] = s.props.arch
+            modulemd[PULP_MODULE_ATTR.ARTIFACTS] = json.dumps(s.get_rpm_artifacts())
+
+            dependencies_list = s.get_dependencies()
+            dependencies = dict()
+            for dep in dependencies_list:
+                d_list = dep.get_runtime_modules()
+                for dependency in d_list:
+                    dependencies[dependency] = dep.get_runtime_streams(dependency)
+            modulemd[PULP_MODULE_ATTR.DEPENDENCIES] = json.dumps(dependencies)
+            # create yaml snippet for this modulemd stream
+            temp_index = mmdlib.ModuleIndex.new()
+            temp_index.add_module_stream(s)
+            artifact = _create_snippet(temp_index.dump_to_string())
+            modulemd["artifact"] = artifact
+            ret.append(modulemd)
+    return ret
+
+
+def parse_defaults(module_index):
+    """
+    Get modulemd-defaults.
+
+    Args:
+        module_index (mmdlib.ModuleIndex):
+            libmodulemd index object
+
+    Returns:
+        list of modulemd-defaults as dict
+
+    """
+    ret = list()
+    modulemd_defaults = module_index.get_default_streams().keys()
+    for module in modulemd_defaults:
+        modulemd = module_index.get_module(module)
+        defaults = modulemd.get_defaults()
+        if defaults:
+            default_stream = defaults.get_default_stream()
+            default_profile = defaults.get_default_profiles_for_stream(default_stream)
+            # create modulemd-default snippet
+            temp_index = mmdlib.ModuleIndex.new()
+            temp_index.add_defaults(defaults)
+            artifact = _create_snippet(temp_index.dump_to_string())
+            ret.append({
+                PULP_MODULEDEFAULTS_ATTR.MODULE: modulemd.get_module_name(),
+                PULP_MODULEDEFAULTS_ATTR.STREAM: default_stream,
+                PULP_MODULEDEFAULTS_ATTR.PROFILES: json.dumps(default_profile),
+                PULP_MODULEDEFAULTS_ATTR.DIGEST: artifact.sha256,
+                'artifact': artifact
+            })
+    return ret

--- a/pulp_rpm/app/serializers.py
+++ b/pulp_rpm/app/serializers.py
@@ -533,7 +533,7 @@ class ModulemdDefaultsSerializer(SingleArtifactContentSerializer):
         fields = (
             'module', 'stream', 'profiles'
         )
-    model = ModulemdDefaults
+        model = ModulemdDefaults
 
 
 class AddonSerializer(serializers.ModelSerializer):

--- a/pulp_rpm/app/viewsets.py
+++ b/pulp_rpm/app/viewsets.py
@@ -33,14 +33,17 @@ from pulp_rpm.app.models import (
     RpmDistribution,
     RpmRemote,
     RpmPublication,
-    UpdateRecord
+    UpdateRecord,
+    Modulemd,
+    ModulemdDefaults
 )
-
 from pulp_rpm.app.serializers import (
     CopySerializer,
     DistributionTreeSerializer,
     MinimalPackageSerializer,
     MinimalUpdateRecordSerializer,
+    ModulemdDefaultsSerializer,
+    ModulemdSerializer,
     OneShotUploadSerializer,
     PackageSerializer,
     RepoMetadataFileSerializer,
@@ -343,3 +346,23 @@ class RepoMetadataFileViewSet(NamedModelViewSet,
     endpoint_name = 'repo_metadata_files'
     queryset = RepoMetadataFile.objects.all()
     serializer_class = RepoMetadataFileSerializer
+
+
+class ModulemdViewSet(ContentViewSet):
+    """
+    ViewSet for Modulemd.
+    """
+
+    endpoint_name = 'modulemd'
+    queryset = Modulemd.objects.all()
+    serializer_class = ModulemdSerializer
+
+
+class ModulemdDefaultsViewSet(ContentViewSet):
+    """
+    ViewSet for Modulemd.
+    """
+
+    endpoint_name = 'modulemd-defaults'
+    queryset = ModulemdDefaults.objects.all()
+    serializer_class = ModulemdDefaultsSerializer


### PR DESCRIPTION
Add sync support for modulemd and modulemd-defaults and create relations between modulemd and RPM packages.
And keep snippet from modules.yaml as an artifact for content (modulemd and modulemd-defaults).

Required PR: https://github.com/pulp/pulpcore-plugin/pull/130

re #5172
https://pulp.plan.io/issues/5172