### PR TITLE
Modular serialzers fix

### DIFF
--- a/pulp_rpm/app/serializers.py
+++ b/pulp_rpm/app/serializers.py
@@ -518,7 +518,7 @@ class ModulemdSerializer(SingleArtifactContentUploadSerializer):
     )
 
     class Meta:
-        fields = (
+        fields = SingleArtifactContentUploadSerializer.Meta.fields + (
             'name', 'stream', 'version', 'context', 'arch',
             'artifacts', 'dependencies', 'packages'
         )
@@ -541,7 +541,7 @@ class ModulemdDefaultsSerializer(SingleArtifactContentUploadSerializer):
     )
 
     class Meta:
-        fields = (
+        fields = SingleArtifactContentUploadSerializer.Meta.fields + (
             'module', 'stream', 'profiles'
         )
         model = ModulemdDefaults


### PR DESCRIPTION
With new change for upload modular serializers didn't inherit news fields
so viewsets broke at missing fields.

[noissue]