### PR TITLE
Move content endpoints under /content/rpm

### DIFF
--- a/CHANGES/5533.removal
+++ b/CHANGES/5533.removal
@@ -1,0 +1,1 @@
+Moved the viewsets for distribution trees and repo metadata files to /pulp/api/v3/content/rpm/distribution_trees/ and /pulp/api/v3/content/rpm/repo_metadata_files/ respectively.

--- a/pulp_rpm/app/viewsets.py
+++ b/pulp_rpm/app/viewsets.py
@@ -239,7 +239,7 @@ class DistributionTreeViewSet(NamedModelViewSet,
 
     """
 
-    endpoint_name = 'distribution_trees'
+    endpoint_name = 'content/rpm/distribution_trees'
     queryset = DistributionTree.objects.all()
     serializer_class = DistributionTreeSerializer
 
@@ -253,7 +253,7 @@ class RepoMetadataFileViewSet(NamedModelViewSet,
 
     """
 
-    endpoint_name = 'repo_metadata_files'
+    endpoint_name = 'content/rpm/repo_metadata_files'
     queryset = RepoMetadataFile.objects.all()
     serializer_class = RepoMetadataFileSerializer
 


### PR DESCRIPTION
This defines the viewsets at `/pulp/api/v3/content/rpm/distribution_trees/` and `/pulp/api/v3/content/rpm/repo_metadata_files/`.

Required PR: https://github.com/pulp/pulpcore/pull/319

refs #5533