### PR TITLE
Update docs for new prereq_role dictionary variable

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -42,9 +42,8 @@ Do not forget to set ``pulp_use_system_wide_pkgs`` to ``true``.
        pulp_use_system_wide_pkgs: true
        pulp_install_plugins:
          pulp-rpm:
-           app_label: "rpm"
+           prereq_role: "pulp.pulp_rpm_prerequisites"
      roles:
-       - pulp.pulp_rpm_prerequisites
        - pulp-database
        - pulp-workers
        - pulp-resource-manager

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -25,9 +25,8 @@ Create your pulp_rpm.yaml playbook with these contents:
        pulp_default_admin_password: password
        pulp_install_plugins:
          pulp-rpm:
-           app_label: "rpm"
+           prereq_role: "pulp.pulp_rpm_prerequisites"
      roles:
-       - pulp.pulp_rpm_prerequisites
        - pulp-database
        - pulp-workers
        - pulp-resource-manager


### PR DESCRIPTION
And to remove the no longer-used app-label.

re: #5518
Problem: Running include_roles with pulp-rpm-prerequisites causes it to fail
https://pulp.plan.io/issues/5518

[noissue]