### PR TITLE
Fix sync of a repo which contains modules and advisories

### DIFF
--- a/CHANGES/5652.bugfix
+++ b/CHANGES/5652.bugfix
@@ -1,0 +1,1 @@
+Fix sync of a repo which contains modules and advisories.

--- a/pulp_rpm/app/tasks/synchronizing.py
+++ b/pulp_rpm/app/tasks/synchronizing.py
@@ -11,6 +11,8 @@ from urllib.parse import urljoin
 
 import createrepo_c as cr
 
+from django.db import transaction
+
 from pulpcore.plugin.models import Artifact, ProgressReport, Remote, Repository
 
 from pulpcore.plugin.stages import (
@@ -632,7 +634,8 @@ class RpmContentSaver(ContentSaver):
             elif isinstance(declarative_content.content, Package):
                 for modulemd in declarative_content.extra_data['modulemd_relation']:
                     try:
-                        modulemd.content.packages.add(declarative_content.content)
+                        with transaction.atomic():
+                            modulemd.content.packages.add(declarative_content.content)
                     except ValueError:
                         pass
 


### PR DESCRIPTION
Add inner transaction to properly handle exceptions inside outer transaction.
Django recommended way https://docs.djangoproject.com/en/2.2/topics/db/transactions/#django.db.transaction.atomic

closes #5652
https://pulp.plan.io/issues/5652