### PR TITLE
Specify installation methods of rpm plugin

### DIFF
--- a/CHANGES/5228.doc
+++ b/CHANGES/5228.doc
@@ -1,0 +1,1 @@
+Add requirements to docs.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,6 +17,17 @@ Features
 * Host content either `locally or on S3 <https://docs.pulpproject.org/en/3.0/nightly/installation/
   storage.html>`_
 
+Requirements
+------------
+
+``pulp_rpm`` plugin requires some dependencies such as ``libsolv`` and ``libmodulemd``
+which is provided only by RedHat family distributions like Fedora.
+
+``pulp_rpm`` plugin requires either to be:
+
+* install on Fedora 29+, CentOS 7+ (with EPEL repository enabled)
+* install inside a container with ``pulplift``
+
 Get Started
 -----------
 


### PR DESCRIPTION
Add 'Requirements' to the docs as rpm plugin can be installed only on
specific distributions.

closes #5228
https://pulp.plan.io/issues/5228