### PR TITLE
Fix 404: repo remote URL is without trailing slash

### DIFF
--- a/CHANGES/5655.bugfix
+++ b/CHANGES/5655.bugfix
@@ -1,0 +1,1 @@
+Fix 404 when repo remote URL is without trailing slash.

--- a/pulp_rpm/app/tasks/synchronizing.py
+++ b/pulp_rpm/app/tasks/synchronizing.py
@@ -291,6 +291,7 @@ class RpmFirstStage(Stage):
         errata_pb.save()
 
         remote_url = self.new_url or self.remote.url
+        remote_url = remote_url if remote_url[-1] == "/" else f"{remote_url}/"
 
         progress_data = dict(message='Downloading Metadata Files', code='downloading.metadata')
         with ProgressReport(**progress_data) as metadata_pb:


### PR DESCRIPTION
https://pulp.plan.io/issues/5655
closes #5655