### PR TITLE
Add transaction.atomic for Modulemd content

### DIFF
--- a/CHANGES/5663.misc
+++ b/CHANGES/5663.misc
@@ -1,0 +1,1 @@
+Added transaction.atomic for syncing Modulemd content

--- a/pulp_rpm/app/tasks/synchronizing.py
+++ b/pulp_rpm/app/tasks/synchronizing.py
@@ -628,7 +628,8 @@ class RpmContentSaver(ContentSaver):
             elif isinstance(declarative_content.content, Modulemd):
                 for pkg in declarative_content.extra_data['package_relation']:
                     try:
-                        declarative_content.content.packages.add(pkg.content)
+                        with transaction.atomic():
+                            declarative_content.content.packages.add(pkg.content)
                     except ValueError:
                         pass
 


### PR DESCRIPTION
This allows for syncing of repos such as the CentOS 8 AppStream repo.  Fixes #5663