### PR TITLE
Rename endpoints for content to be in plural form

### DIFF
--- a/CHANGES/5679.removal
+++ b/CHANGES/5679.removal
@@ -1,0 +1,8 @@
+Rename endpoints for content to be in plural form consistently
+
+Endpoints removed -> added:
+
+/pulp/api/v3/content/rpm/modulemd/ -> /pulp/api/v3/content/rpm/modulemds/
+/pulp/api/v3/content/rpm/packagecategory/ -> /pulp/api/v3/content/rpm/packagecategories/
+/pulp/api/v3/content/rpm/packageenvironment/ -> /pulp/api/v3/content/rpm/packageenvironments/
+/pulp/api/v3/content/rpm/packagegroup/ -> /pulp/api/v3/content/rpm/packagegroups/

--- a/pulp_rpm/app/serializers.py
+++ b/pulp_rpm/app/serializers.py
@@ -618,7 +618,7 @@ class PackageCategorySerializer(NoArtifactContentSerializer):
         required=False,
         queryset=PackageGroup.objects.all(),
         many=True,
-        view_name='content-rpm/packagegroup-detail'
+        view_name='content-rpm/packagegroups-detail'
     )
 
     class Meta:
@@ -676,7 +676,7 @@ class PackageEnvironmentSerializer(NoArtifactContentSerializer):
         required=False,
         queryset=PackageGroup.objects.all(),
         many=True,
-        view_name='content-rpm/packagegroup-detail'
+        view_name='content-rpm/packagegroups-detail'
     )
     optionalgroups = RelatedField(
         help_text=_("Groups optionally related to this Environment."),
@@ -684,7 +684,7 @@ class PackageEnvironmentSerializer(NoArtifactContentSerializer):
         required=False,
         queryset=PackageGroup.objects.all(),
         many=True,
-        view_name='content-rpm/packagegroup-detail'
+        view_name='content-rpm/packagegroups-detail'
     )
 
     class Meta:

--- a/pulp_rpm/app/viewsets.py
+++ b/pulp_rpm/app/viewsets.py
@@ -244,7 +244,7 @@ class PackageGroupViewSet(ReadOnlyContentViewSet,
     PackageGroup ViewSet.
     """
 
-    endpoint_name = 'packagegroup'
+    endpoint_name = 'packagegroups'
     queryset = PackageGroup.objects.all()
     serializer_class = PackageGroupSerializer
 
@@ -255,7 +255,7 @@ class PackageCategoryViewSet(ReadOnlyContentViewSet,
     PackageCategory ViewSet.
     """
 
-    endpoint_name = 'packagecategory'
+    endpoint_name = 'packagecategories'
     queryset = PackageCategory.objects.all()
     serializer_class = PackageCategorySerializer
 
@@ -266,7 +266,7 @@ class PackageEnvironmentViewSet(ReadOnlyContentViewSet,
     PackageEnvironment ViewSet.
     """
 
-    endpoint_name = 'packageenvironment'
+    endpoint_name = 'packageenvironments'
     queryset = PackageEnvironment.objects.all()
     serializer_class = PackageEnvironmentSerializer
 
@@ -311,7 +311,7 @@ class ModulemdViewSet(SingleArtifactContentUploadViewSet):
     ViewSet for Modulemd.
     """
 
-    endpoint_name = 'modulemd'
+    endpoint_name = 'modulemds'
     queryset = Modulemd.objects.all()
     serializer_class = ModulemdSerializer
 


### PR DESCRIPTION
For consistency, now:
modulemd -> modulemds
packageenvironmwent -> packageenvironments
packagecategory -> packagecategories
packagegroup -> packagegroups

closes #5679
https://pulp.plan.io/issues/5679