### PR TITLE
Rename module-defaults content endpoint

### DIFF
--- a/CHANGES/5680.removal
+++ b/CHANGES/5680.removal
@@ -1,0 +1,5 @@
+Rename module-defaults content endpoint for consistency
+
+Endpoints removed -> added:
+
+/pulp/api/v3/content/rpm/modulemd-defaults/ -> /pulp/api/v3/content/rpm/modulemd_defaults/

--- a/pulp_rpm/app/viewsets.py
+++ b/pulp_rpm/app/viewsets.py
@@ -321,6 +321,6 @@ class ModulemdDefaultsViewSet(SingleArtifactContentUploadViewSet):
     ViewSet for Modulemd.
     """
 
-    endpoint_name = 'modulemd-defaults'
+    endpoint_name = 'modulemd_defaults'
     queryset = ModulemdDefaults.objects.all()
     serializer_class = ModulemdDefaultsSerializer


### PR DESCRIPTION
For consistency, now
module-defaults -> module_defaults

closes #5680
https://pulp.plan.io/issues/5680