### PR TITLE
Split performance tests into more jobs to avoid travis timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,7 +80,11 @@ jobs:
       if: tag IS present
     - stage: daily-performance-test
       env:
-        - TEST=performance
+        - TEST=sync-performance
+      if: type = cron
+    - stage: daily-performance-test
+      env:
+        - TEST=publish-performance
       if: type = cron
 notifications: None
 

--- a/.travis/before_script.sh
+++ b/.travis/before_script.sh
@@ -31,7 +31,7 @@ else
     sed "s/localhost/$(hostname)/g" ../pulpcore/.travis/pulp-smash-config.json > ~/.config/pulp_smash/settings.json
 fi
 
-if [[ "$TEST" == 'pulp' || "$TEST" == 'performance' ]]; then
+if [[ "$TEST" == 'pulp' || "$TEST" == 'sync-performance' || "$TEST" == 'publish-performance' ]]; then
     # Many tests require pytest/mock, but users do not need them at runtime
     # (or to add plugins on top of pulpcore or pulp container images.)
     # So install it here, rather than in the image Dockerfile.

--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -110,9 +110,15 @@ export PYTHONPATH=$TRAVIS_BUILD_DIR:$TRAVIS_BUILD_DIR/../pulpcore:${PYTHONPATH}
 
 set -u
 
-if [[ "$TEST" == "performance" ]]; then
-  echo "--- Performance Tests ---"
-  pytest -vv -r sx --color=yes --pyargs --capture=no --durations=0 pulp_rpm.tests.performance || show_logs_and_return_non_zero
+if [[ "$TEST" == "sync-performance" ]]; then
+  echo "--- Sync Performance Tests ---"
+  pytest -vv -r sx --color=yes --pyargs --capture=no --durations=0 pulp_rpm.tests.performance.test_sync || show_logs_and_return_non_zero
+  exit
+fi
+
+if [[ "$TEST" == "publish-performance" ]]; then
+  echo "--- Publish Performance Tests ---"
+  pytest -vv -r sx --color=yes --pyargs --capture=no --durations=0 pulp_rpm.tests.performance.test_publish || show_logs_and_return_non_zero
   exit
 fi
 


### PR DESCRIPTION
We just run many tests and each of them doesn't take very long but
the travis job is limited to 50 mins and may sync and publish operations
summed up together take more than that.

[no issue]