### PR TITLE
Update tests to not rely on version always incrementing

### DIFF
--- a/CHANGES/3308.misc
+++ b/CHANGES/3308.misc
@@ -1,0 +1,1 @@
+ Updated tests to support repository version not incrementing when content hasn't changed.

--- a/pulp_rpm/tests/functional/api/test_download_policies.py
+++ b/pulp_rpm/tests/functional/api/test_download_policies.py
@@ -69,12 +69,8 @@ class SyncPublishDownloadPolicyTestCase(unittest.TestCase):
         4. Assert that repository version is not None.
         5. Assert that the correct number of possible units to be downloaded
            were shown.
-        6. Sync the remote one more time in order to create another repository
-           version.
-        7. Assert that repository version is different from the previous one.
-        8. Assert that the same number of units are shown, and after the
-           second sync no extra units should be shown, since the same remote
-           was synced again.
+        6. Sync the remote one more time.
+        7. Assert that repository version is the same as the previous latest version.
         """
         repo = self.client.post(RPM_REPO_PATH, gen_repo())
         self.addCleanup(self.client.delete, repo['pulp_href'])
@@ -102,9 +98,8 @@ class SyncPublishDownloadPolicyTestCase(unittest.TestCase):
         sync(self.cfg, remote, repo)
         repo = self.client.get(repo['pulp_href'])
 
-        self.assertNotEqual(latest_version_href, repo['latest_version_href'])
+        self.assertEqual(latest_version_href, repo['latest_version_href'])
         self.assertDictEqual(get_content_summary(repo), RPM_FIXTURE_SUMMARY)
-        self.assertDictEqual(get_added_content_summary(repo), {})
 
     def do_publish(self, download_policy):
         """Publish repository synced with lazy ``download_policy``."""

--- a/pulp_rpm/tests/functional/api/test_publish.py
+++ b/pulp_rpm/tests/functional/api/test_publish.py
@@ -82,7 +82,7 @@ class PublishAnyRepoVersionTestCase(unittest.TestCase):
         for rpm_content in get_content(repo)[RPM_PACKAGE_CONTENT_NAME]:
             self.client.post(
                 urljoin(repo['pulp_href'], 'modify/'),
-                {'add_content_units': [rpm_content['pulp_href']]}
+                {'remove_content_units': [rpm_content['pulp_href']]}
             )
         version_hrefs = tuple(ver['pulp_href'] for ver in get_versions(repo))
         non_latest = choice(version_hrefs[:-1])

--- a/pulp_rpm/tests/functional/api/test_sync.py
+++ b/pulp_rpm/tests/functional/api/test_sync.py
@@ -68,9 +68,7 @@ class BasicSyncTestCase(unittest.TestCase):
         5. Assert that the correct number of units were added and are present
            in the repo.
         6. Sync the remote one more time.
-        7. Assert that repository version is different from the previous one.
-        8. Assert that the same number of are present and that no units were
-           added.
+        7. Assert that repository version is the same as the previous one.
         """
         repo = self.client.post(RPM_REPO_PATH, gen_repo())
         self.addCleanup(self.client.delete, repo['pulp_href'])
@@ -98,9 +96,7 @@ class BasicSyncTestCase(unittest.TestCase):
         repo = self.client.get(repo['pulp_href'])
 
         # Check that nothing has changed since the last sync.
-        self.assertNotEqual(latest_version_href, repo['latest_version_href'])
-        self.assertDictEqual(get_content_summary(repo), RPM_FIXTURE_SUMMARY)
-        self.assertDictEqual(get_added_content_summary(repo), {})
+        self.assertEqual(latest_version_href, repo['latest_version_href'])
 
 
 class KickstartSyncTestCase(unittest.TestCase):
@@ -135,9 +131,8 @@ class KickstartSyncTestCase(unittest.TestCase):
         5. Assert that the correct number of units were added and are present
            in the repo.
         6. Sync the remote one more time.
-        7. Assert that repository version is different from the previous one.
-        8. Assert that the same number of are present and that no units were
-           added.
+        7. Assert that repository version is the same the previous one.
+        8. Assert that the same number of packages are present.
         """
         repo = self.client.post(RPM_REPO_PATH, gen_repo())
         self.addCleanup(self.client.delete, repo['pulp_href'])
@@ -173,11 +168,10 @@ class KickstartSyncTestCase(unittest.TestCase):
         self.assertEqual(artifacts['count'], 3, artifacts)
 
         # Check that nothing has changed since the last sync.
-        self.assertNotEqual(latest_version_href, repo['latest_version_href'])
+        self.assertEqual(latest_version_href, repo['latest_version_href'])
         self.assertDictEqual(
             get_content_summary(repo), RPM_KICKSTART_FIXTURE_SUMMARY
         )
-        self.assertDictEqual(get_added_content_summary(repo), {})
 
     def test_rpm_kickstart_on_demand(self):
         """Sync repositories with the rpm plugin.
@@ -200,9 +194,8 @@ class KickstartSyncTestCase(unittest.TestCase):
         5. Assert that the correct number of units were added and are present
            in the repo.
         6. Sync the remote one more time.
-        7. Assert that repository version is different from the previous one.
-        8. Assert that the same number of are present and that no units were
-           added.
+        7. Assert that repository version is the same as the previous one.
+        8. Assert that the same number of packages are present
         """
         delete_orphans(self.cfg)
         repo = self.client.post(RPM_REPO_PATH, gen_repo())
@@ -241,11 +234,10 @@ class KickstartSyncTestCase(unittest.TestCase):
         self.assertEqual(artifacts['count'], 0, artifacts)
 
         # Check that nothing has changed since the last sync.
-        self.assertNotEqual(latest_version_href, repo['latest_version_href'])
+        self.assertEqual(latest_version_href, repo['latest_version_href'])
         self.assertDictEqual(
             get_content_summary(repo), RPM_KICKSTART_FIXTURE_SUMMARY
         )
-        self.assertDictEqual(get_added_content_summary(repo), {})
 
 
 class FileDescriptorsTestCase(unittest.TestCase):


### PR DESCRIPTION
Required PR: https://github.com/pulp/pulpcore/pull/380

re: #3308
https://pulp.plan.io/issues/3308