### PR TITLE
Handle missing trailing slash on kickstart tree fetching

### DIFF
--- a/CHANGES/5677.bugfix
+++ b/CHANGES/5677.bugfix
@@ -1,0 +1,1 @@
+Handling missing trailing slashes on kickstart tree fetching

--- a/pulp_rpm/app/tasks/utils.py
+++ b/pulp_rpm/app/tasks/utils.py
@@ -12,9 +12,10 @@ def get_kickstart_data(remote):
 
     """
     kickstart = {}
+    remote_url = remote.url if remote.url[-1] == "/" else f"{remote.url}/"
     namespaces = [".treeinfo", "treeinfo"]
     for namespace in namespaces:
-        downloader = remote.get_downloader(url=urljoin(remote.url, namespace))
+        downloader = remote.get_downloader(url=urljoin(remote_url, namespace))
 
         try:
             result = downloader.fetch()


### PR DESCRIPTION
https://pulp.plan.io/issues/5677
closes #5677