### PR TITLE
Do not dump data back to a string

### DIFF
--- a/CHANGES/5699.bugfix
+++ b/CHANGES/5699.bugfix
@@ -1,0 +1,1 @@
+Resolve the issue which disallowed users to publish uploaded content

--- a/pulp_rpm/app/shared_utils.py
+++ b/pulp_rpm/app/shared_utils.py
@@ -1,5 +1,4 @@
 import createrepo_c
-import json
 import os
 import tempfile
 import shutil
@@ -12,8 +11,7 @@ def _prepare_package(artifact, filename):
     Helper function for creating package.
 
     Copy file to a temp directory under
-    the user provided filename and
-    parsing it into a saveable format.
+    the user provided filename.
 
     Returns: artifact model as dict
 
@@ -30,13 +28,4 @@ def _prepare_package(artifact, filename):
         package = Package.createrepo_to_dict(cr_pkginfo)
 
     package['location_href'] = filename
-
-    # parsing it into a saveable format
-    new_pkg = {}
-    for key, value in package.items():
-        if isinstance(value, list):
-            new_pkg[key] = json.dumps(value)
-        else:
-            new_pkg[key] = value
-
-    return new_pkg
+    return package


### PR DESCRIPTION
Data can be now stored as a JSON binary. Therefore, it is not requried to dump data back to the string format.

closes #5699
https://pulp.plan.io/issues/5699