### PR TITLE
Cherrypick: Fixed error on adding modular content to a repository

### DIFF
--- a/CHANGES/5746.bugfix
+++ b/CHANGES/5746.bugfix
@@ -1,0 +1,1 @@
+Fix error when adding/removing modules to/from a repository.


### PR DESCRIPTION
The problem was use of values_list() which isn't meant for many-to-many
relationships. Instead, build a set of packages.

fixes #5746
https://pulp.plan.io/issues/5746