### PR TITLE
Specify features released as tech preview

### DIFF
--- a/CHANGES/5753.doc
+++ b/CHANGES/5753.doc
@@ -1,0 +1,1 @@
+Update docs to include Tech Preview section

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,6 +17,14 @@ Features
 * Host content either `locally or on S3 <https://docs.pulpproject.org/en/3.0/nightly/installation/
   storage.html>`_
 
+Tech Preview
+------------
+
+Some additional features are being supplied as a tech preview.  There is a possibility that
+backwards incompatible changes will be introduced for these particular features.  For a list of
+features currently being supplied as tech previews only, see the :doc:`tech preview page
+<tech-preview>`.
+
 Requirements
 ------------
 
@@ -57,6 +65,7 @@ Table of Contents
    workflows/index
    bindings
    changes
+   tech-preview
    contributing
 
 

--- a/docs/tech-preview.rst
+++ b/docs/tech-preview.rst
@@ -1,0 +1,8 @@
+Tech previews
+=============
+
+The following features are currently being released as part of a tech preview.
+
+* Distribution (Kickstart) Trees sync support
+* Advisory upload by providing a file containing JSON or providing an href of an existing artifact
+  in Pulp


### PR DESCRIPTION
Add Tech Preview section to the docs, reference it on main page as warning.

fixes #5753
https://pulp.plan.io/issues/5753