### PR TITLE
Bump the pulpcore requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 requirements = [
     'createrepo_c~=0.13',
     'productmd',
-    'pulpcore~=3.0rc8',
+    'pulpcore>=3.0.0rc8,<3.2',
 ]
 
 with open('README.rst') as f:


### PR DESCRIPTION
Right now, pulpcore master is at 3.1.x which means pulp_rpm won't work
with it.

[noissue]