### PR TITLE
Rest API link

### DIFF
--- a/CHANGES/5749.doc
+++ b/CHANGES/5749.doc
@@ -1,0 +1,1 @@
+Add 'Rest API' to menu.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,11 +30,6 @@ Community contributions are encouraged.
   <https://pulp.plan.io/projects/pulp_rpm/issues>`_.
 
 
-REST API
---------
-
-REST API documentation for the RPM plugin can be found `here <restapi.html>`_
-
 Table of Contents
 -----------------
 
@@ -45,6 +40,7 @@ Table of Contents
    quickstart
    workflows/index
    bindings
+   restapi
    changes
    contributing
 

--- a/docs/restapi.rst
+++ b/docs/restapi.rst
@@ -1,0 +1,9 @@
+REST API
+========
+
+Pulpcore Reference: `pulpcore API documentation <https://docs.pulpproject.org/en/3.0/nightly/restapi.html>`_.
+
+Pulp RPM API
+----------------
+
+See the `pulp_rpm API documentation <../restapi.html>`_


### PR DESCRIPTION
Add REST API docs to the top-level menu

closes #5749
https://pulp.plan.io/issues/5749