### PR TITLE
[WIP] Bring Quickstart page up to date, including links

### DIFF
--- a/CHANGES/5754.doc
+++ b/CHANGES/5754.doc
@@ -1,0 +1,1 @@
+Update Quickstart page

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -4,9 +4,7 @@ Quickstart
 Run Pulplift
 ------------
 
-Use pulplift to try out Pulp. From `their quickstart <https://github.com/pulp/pulplift#quickstart>`_
-pulplift uses `Vagrant <https://www.vagrantup.com/docs/installation/>`_ so you'll need to have that
-installed.
+Use pulplift to try out Pulp. Pulplift uses `Vagrant <https://www.vagrantup.com/docs/installation/>`_ so you'll need to have that installed.
 
 Download pulplift and RPM plugin prerequisite role.
 
@@ -17,7 +15,7 @@ Download pulplift and RPM plugin prerequisite role.
     ansible-galaxy install pulp.pulp_rpm_prerequisites -p ./ansible-pulp/roles/
 
 
-Use ``example.user-config.yml`` as a template for you config yaml file or directly edit that one.
+Use ``example.user-config.yml`` as a template for your config yaml file or directly edit that one.
 
 ::
 
@@ -47,6 +45,13 @@ Start your box and ssh to it
 
     vagrant up pulp3-sandbox-fedora30
     vagrant ssh pulp3-sandbox-fedora30
+
+
+Be sure you are running your pulp environment
+
+::
+
+    workon pulp
 
 
 Check Pulp's Status


### PR DESCRIPTION
Removed broken link to pulplift quickstart, and made a few minor changes
including adding instructions to run the pulp environment.

Calling this WIP until I'm at a stopping point in my other work for
actually starting a new vagrant so I can walk through the steps.

fixes #5754
https://pulp.plan.io/issues/5754