### PR TITLE
Use `BaseModel` instead of `Model`

### DIFF
--- a/CHANGES/5693.misc
+++ b/CHANGES/5693.misc
@@ -1,0 +1,1 @@
+Use `BaseModel` instead of `Model`.

--- a/pulp_rpm/app/models/advisory.py
+++ b/pulp_rpm/app/models/advisory.py
@@ -7,8 +7,8 @@ from django.db import models
 from django.utils.dateparse import parse_datetime
 
 from pulpcore.plugin.models import (
+    BaseModel,
     Content,
-    Model,
 )
 
 from pulp_rpm.app.constants import (
@@ -198,7 +198,7 @@ class UpdateRecord(Content):
         default_related_name = "%(app_label)s_%(model_name)s"
 
 
-class UpdateCollection(Model):
+class UpdateCollection(BaseModel):
     """
     A collection of UpdateCollectionPackages with an associated nametag.
 
@@ -275,7 +275,7 @@ class UpdateCollection(Model):
         return col
 
 
-class UpdateCollectionPackage(Model):
+class UpdateCollectionPackage(BaseModel):
     """
     Part of an UpdateCollection, representing a package.
 
@@ -383,7 +383,7 @@ class UpdateCollectionPackage(Model):
         return pkg
 
 
-class UpdateReference(Model):
+class UpdateReference(BaseModel):
     """
     A reference to the additional information about the problem solved by an update.
 

--- a/pulp_rpm/app/models/distribution.py
+++ b/pulp_rpm/app/models/distribution.py
@@ -3,9 +3,9 @@ from logging import getLogger
 from django.db import models
 
 from pulpcore.plugin.models import (
+    BaseModel,
     Content,
     ContentArtifact,
-    Model,
     Repository,
 )
 
@@ -107,7 +107,7 @@ class DistributionTree(Content):
         )
 
 
-class Checksum(Model):
+class Checksum(BaseModel):
     """
     Distribution Tree Checksum.
 
@@ -139,7 +139,7 @@ class Checksum(Model):
         )
 
 
-class Image(Model):
+class Image(BaseModel):
     """
     Distribution Tree Image.
 
@@ -189,7 +189,7 @@ class Image(Model):
         )
 
 
-class Addon(Model):
+class Addon(BaseModel):
     """
     Distribution Tree Addon.
 
@@ -237,7 +237,7 @@ class Addon(Model):
         )
 
 
-class Variant(Model):
+class Variant(BaseModel):
     """
     Distribution Tree Variant.
 


### PR DESCRIPTION
pulpcore changed the name of `Model` to `BaseModel`. This PR updated
pulp_rpm to do the same.

Required PR: https://github.com/pulp/pulpcore/pull/421

https://pulp.plan.io/issues/5693
closes #5693