### PR TITLE
Problem: pulp_rpm does not declare its dependency on libcomps & PyGObject

### DIFF
--- a/CHANGES/5853.doc
+++ b/CHANGES/5853.doc
@@ -1,0 +1,1 @@
+Declare dependency on libcomps & PyGObject in setup.py.

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,10 @@ from setuptools import setup, find_packages
 
 requirements = [
     'createrepo_c~=0.13',
+    'libcomps~=0.1.11',
     'productmd',
     'pulpcore>=3.0.0rc8,<3.2',
+    'PyGObject~=3.22',
 ]
 
 with open('README.rst') as f:


### PR DESCRIPTION
Solution: Specify them with them in setup.py

Required PR: https://github.com/pulp/pulpcore/pull/437

Fixes: #5853
