### PR TITLE
Adds fields from inherited serializer to comps types display

### DIFF
--- a/CHANGES/5857.bugfix
+++ b/CHANGES/5857.bugfix
@@ -1,0 +1,1 @@
+Adds fields from the inherited serializer to comps.xml content types' displayed fields

--- a/pulp_rpm/app/serializers.py
+++ b/pulp_rpm/app/serializers.py
@@ -720,7 +720,7 @@ class PackageGroupSerializer(NoArtifactContentSerializer):
     )
 
     class Meta:
-        fields = (
+        fields = NoArtifactContentSerializer.Meta.fields + (
             'id', 'default', 'user_visible', 'display_order',
             'name', 'description', 'packages', 'biarch_only',
             'desc_by_lang', 'name_by_lang', 'digest', 'related_packages'
@@ -774,7 +774,7 @@ class PackageCategorySerializer(NoArtifactContentSerializer):
     )
 
     class Meta:
-        fields = (
+        fields = NoArtifactContentSerializer.Meta.fields + (
             'id', 'name', 'description', 'display_order',
             'group_ids', 'desc_by_lang', 'name_by_lang', 'digest',
             'packagegroups'
@@ -840,7 +840,7 @@ class PackageEnvironmentSerializer(NoArtifactContentSerializer):
     )
 
     class Meta:
-        fields = (
+        fields = NoArtifactContentSerializer.Meta.fields + (
             'id', 'name', 'description', 'display_order',
             'group_ids', 'option_ids', 'desc_by_lang', 'name_by_lang',
             'digest', 'packagegroups', 'optionalgroups'
@@ -863,7 +863,7 @@ class PackageLangpacksSerializer(NoArtifactContentSerializer):
     )
 
     class Meta:
-        fields = (
+        fields = NoArtifactContentSerializer.Meta.fields + (
             'matches', 'digest'
         )
         model = PackageLangpacks


### PR DESCRIPTION
'pulp_href' and other fields beyond those in the comps types themselves
are now displayed.

fixes #5857
https://pulp.plan.io/issues/5857