### PR TITLE
Document that sync must complete before attempting publish

### DIFF
--- a/CHANGES/5006.doc
+++ b/CHANGES/5006.doc
@@ -1,0 +1,1 @@
+Document that sync must complete before kicking off a publish

--- a/docs/workflows/create_sync_publish.rst
+++ b/docs/workflows/create_sync_publish.rst
@@ -127,6 +127,8 @@ RepositoryVersion GET response (when sync task complete):
 Create a Publication
 --------------------
 
+A publication can only be created once a sync task completes.
+
 .. literalinclude:: ../_scripts/publication.sh
    :language: bash
 


### PR DESCRIPTION
Sync must complete before you can kick off a publish task,
now that is documented.

fixes #5006
https://pulp.plan.io/issues/5006