### PR TITLE
Problem: Users following docs cannot build

### DIFF
--- a/CHANGES/5841.doc
+++ b/CHANGES/5841.doc
@@ -1,0 +1,1 @@
+Document python build dependencies that must be installed on CentOS / RHEL.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -112,6 +112,17 @@ You should get ``include-system-site-packages = true``.
 This is a necessary prerequisite for ``libmodulemd`` and ``libcomps`` along with the build dependencies listed
 above for ``createrepo_c``.
 
+Install Python build dependencies (CentOS / RHEL only)
+######################################################
+
+Users on CentOS or RHEL must manually install the Python build dependencies for createrepo_c and libcomps.
+
+.. code-block:: bash
+
+   sudo -u pulp -i
+   source ~/pulpvenv/bin/activate
+   pip install scikit-build nose
+
 Install ``pulp_rpm``
 ********************
 


### PR DESCRIPTION
libcomps or createrepo_c on CentOS 7 / RHEL 7 (and most likely 8.)

Solution: Document python build dependencies that must be installed.

(I cannot find the exact bug, but when you use system-wide packages,
upgrading the venv pip will not suffice. It still tries to use the
system-wide old pip for some functions anyway, and auto-installing
build deps will fail.)

fixes: #5841
Document how to install libcomps and dependencies
https://pulp.plan.io/issues/5841

(cherry picked from commit 49bffd44ff728a7182739070499be3b8ac0c2ee5)