### PR TITLE
Reboot suggested for advisory

### DIFF
--- a/CHANGES/5737.feature
+++ b/CHANGES/5737.feature
@@ -1,0 +1,1 @@
+Advisory now support reboot_suggested info.

--- a/pulp_rpm/app/constants.py
+++ b/pulp_rpm/app/constants.py
@@ -94,7 +94,8 @@ CR_UPDATE_RECORD_ATTRS = SimpleNamespace(
     SOLUTION='solution',
     RELEASE='release',
     RIGHTS='rights',
-    PUSHCOUNT='pushcount'
+    PUSHCOUNT='pushcount',
+    REBOOT_SUGGESTED='reboot_suggested'
 )
 
 CR_UPDATE_COLLECTION_ATTRS = SimpleNamespace(

--- a/pulp_rpm/app/models/advisory.py
+++ b/pulp_rpm/app/models/advisory.py
@@ -141,7 +141,9 @@ class UpdateRecord(Content):
             PULP_UPDATE_RECORD_ATTRS.RELEASE: getattr(update, CR_UPDATE_RECORD_ATTRS.RELEASE) or '',
             PULP_UPDATE_RECORD_ATTRS.RIGHTS: getattr(update, CR_UPDATE_RECORD_ATTRS.RIGHTS) or '',
             PULP_UPDATE_RECORD_ATTRS.PUSHCOUNT: getattr(
-                update, CR_UPDATE_RECORD_ATTRS.PUSHCOUNT) or ''
+                update, CR_UPDATE_RECORD_ATTRS.PUSHCOUNT) or '',
+            PULP_UPDATE_RECORD_ATTRS.REBOOT_SUGGESTED: getattr(
+                update, CR_UPDATE_RECORD_ATTRS.REBOOT_SUGGESTED) or False
         }
 
     def to_createrepo_c(self, collections=[]):
@@ -167,6 +169,7 @@ class UpdateRecord(Content):
         rec.rights = self.rights
         rec.summary = self.summary
         rec.description = self.description
+        rec.reboot_suggested = self.reboot_suggested
 
         if not collections:
             collections = self.collections.all()


### PR DESCRIPTION
Added reboot_suggested to methods which interacts with createrepo_c to
can be get and published with this info.

closes #5737
https://pulp.plan.io/issues/5737