### PR TITLE
Skip unsupported repodata

### DIFF
--- a/CHANGES/6034.featrure
+++ b/CHANGES/6034.featrure
@@ -1,0 +1,1 @@
+Skip unsupported repodata.

--- a/pulp_rpm/app/constants.py
+++ b/pulp_rpm/app/constants.py
@@ -77,7 +77,7 @@ PACKAGE_DB_REPODATA = ['primary_db', 'filelists_db', 'other_db']
 UPDATE_REPODATA = ['updateinfo']
 MODULAR_REPODATA = ['modules']
 COMPS_REPODATA = ['group']
-SKIP_REPODATA = ['group_gz']
+SKIP_REPODATA = ['group_gz', 'prestodelta']
 
 CR_UPDATE_RECORD_ATTRS = SimpleNamespace(
     ID='id',

--- a/pulp_rpm/app/tasks/synchronizing.py
+++ b/pulp_rpm/app/tasks/synchronizing.py
@@ -351,6 +351,9 @@ class RpmFirstStage(Stage):
                 elif record.type in SKIP_REPODATA:
                     continue
 
+                elif '_zck' in record.type:
+                    continue
+
                 elif record.type in MODULAR_REPODATA:
                     modules_url = urljoin(remote_url, record.location_href)
                     modulemd_downloader = self.remote.get_downloader(url=modules_url)


### PR DESCRIPTION
To prevent broken repos, skip any unsupported repodata: all zchunked
metadata, gzipped comps.xml, and prestodelta.xml

fixes #6034
https://pulp.plan.io/issues/6034