### PR TITLE
Using the /associate endpoint in a way that pulls modules

### DIFF
--- a/plugins/pulp_rpm/plugins/importers/yum/associate.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/associate.py
@@ -467,7 +467,13 @@ def _associate_unit(dest_repo, unit, config):
     elif isinstance(unit, models.RPM):
         # copy will happen in one batch
         return unit
-    elif isinstance(unit, (models.YumMetadataFile, models.ModulemdDefaults)):
+    elif isinstance(unit, models.YumMetadataFile):
+        return associate_copy_for_repo(unit, dest_repo, True)
+    elif isinstance(unit, models.ModulemdDefaults):
+        # new modulemd-default needs a checksum
+        if not unit.checksum:
+            with open(unit.storage_path, 'r+') as fp:
+                unit.checksum = unit.calculate_checksum(fp)
         return associate_copy_for_repo(unit, dest_repo, True)
     elif isinstance(unit, (models.DRPM, models.SRPM)):
             if rpm_parse.signature_enabled(config):


### PR DESCRIPTION
into the destination breaks at publish-time due to missing
checksum on the resulting ModulemdDefaults unit.

Fixed by noticing and fixing the problem at associate-time.

closes #6096
https://pulp.plan.io/issues/6096