### PR TITLE
Problem: pulp_use_system_wide_pkgs is often overlooked

### DIFF
--- a/CHANGES/5992.doc
+++ b/CHANGES/5992.doc
@@ -1,0 +1,1 @@
+Remove the pulp_use_system_wide_pkgs installer variable from the docs. We now set it in the pulp_rpm_prerequisites role. Users can safely leave it in their installer variables for the foreseeable future though.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -20,7 +20,7 @@ Only Fedora 29+ and CentOS 7 (with epel repository and python36) are supported.
 Create ``playbook.yml`` as example you can use ``example-use/playbook.yml`` from ``ansible-pulp`` directory.
 Do not forget about ``group_vars`` as dependency in same directory.
 
-Add ``pulp_use_system_wide_pkgs: true`` and ``pulp_rpm`` plugin with prereq role downloaded above under the ``vars``.
+Add the ``pulp_rpm`` plugin with the ``prereq_role`` downloaded to ``pulp_install_plugins`` under ``vars``.
 
 Final ``playbook.yml`` can looks like:
 
@@ -29,7 +29,6 @@ Final ``playbook.yml`` can looks like:
     ---
     - hosts: all
       vars:
-        pulp_use_system_wide_pkgs: true
         pulp_install_plugins:
           pulp-rpm:
             prereq_role: "pulp.pulp_rpm_prerequisites"

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -33,8 +33,6 @@ Do not forget to set up ``prereq_role`` to previously installed ``pulp.pulp_rpm_
         prereq_role: "pulp.pulp_rpm_prerequisites"
       pulp-file: {}
 
-    # Uncomment if using pulp-rpm
-    pulp_use_system_wide_pkgs: true
     pulp_settings:
       secret_key: "unsafe_default"
 


### PR DESCRIPTION
during pulp_rpm install.

Solution: Remove it from the docs. We now set it in the
pulp_rpm_prerequisites role via include_vars on the vars/main.yml

re: #5992
https://pulp.plan.io/issues/5992
ansible-pulp rpm plugin: Failed building wheel for PyGObject Failed building wheel for pycairo

[noissue]