### PR TITLE
RPM tests using bindings

### DIFF
--- a/CHANGES/6061.feature
+++ b/CHANGES/6061.feature
@@ -1,0 +1,1 @@
+Functional test using bindings.

--- a/flake8.cfg
+++ b/flake8.cfg
@@ -1,6 +1,6 @@
 [flake8]
 exclude = ./docs/*,*/migrations/*
-ignore = Q000,D100,D104,D106,D200,D401,D402
+ignore = W503,Q000,D100,D104,D106,D200,D401,D402,E203
 max-line-length = 100
 
 # Flake8-quotes extension codes
@@ -9,9 +9,11 @@ max-line-length = 100
 
 # Flake8-docstring extension codes
 # --------------------------------
+# W503: This enforces operators before line breaks which is not pep8 or black compatible.
 # D100: missing docstring in public module
 # D104: missing docstring in public package
 # D106: missing docstring in public nested class (complains about "class Meta:" and documenting those is silly)
 # D200: one-line docstring should fit on one line with quotes
 # D401: first line should be imperative (nitpicky)
 # D402: first line should not be the function’s “signature” (false positives)
+# E203: no whitespace around ':'. disabled until https://github.com/PyCQA/pycodestyle/issues/373 is fixed

--- a/pulp_rpm/tests/functional/api/test_crud_content_unit.py
+++ b/pulp_rpm/tests/functional/api/test_crud_content_unit.py
@@ -1,35 +1,25 @@
 # coding=utf-8
-"""Tests that CRUD rpm content units."""
-import copy
+"""Tests that perform actions over content unit."""
 import unittest
 
-from requests.exceptions import HTTPError
-
-from pulp_smash import api, config, utils
-from pulp_smash.exceptions import TaskReportError
-from pulp_smash.pulp3.constants import ARTIFACTS_PATH
 from pulp_smash.pulp3.utils import delete_orphans, gen_repo
 
-from pulp_rpm.tests.functional.constants import (
-    RPM_CONTENT_PATH,
-    RPM_PACKAGE_DATA,
-    RPM_PACKAGE_FILENAME,
-    RPM_SIGNED_URL,
-    RPM_SIGNED_URL2,
-    RPM_UNSIGNED_URL,
-)
 from pulp_rpm.tests.functional.utils import (
     gen_artifact,
     gen_rpm_client,
+    gen_rpm_content_attrs,
     monitor_task,
     skip_if,
 )
+from pulp_rpm.tests.functional.constants import (
+    RPM_SIGNED_URL,
+    RPM_PACKAGE_FILENAME,
+    RPM_PACKAGE_FILENAME2,
+    RPM_SIGNED_URL2
+)
 from pulp_rpm.tests.functional.utils import set_up_module as setUpModule  # noqa:F401
 
-from pulpcore.client.pulp_rpm import (
-    RepositoriesRpmApi,
-    ContentPackagesApi,
-)
+from pulpcore.client.pulp_rpm import ContentPackagesApi, RepositoriesRpmApi
 
 
 class ContentUnitTestCase(unittest.TestCase):
@@ -45,147 +35,96 @@ class ContentUnitTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """Create class-wide variable."""
-        cls.cfg = config.get_config()
-        delete_orphans(cls.cfg)
+        delete_orphans()
         cls.content_unit = {}
-        cls.client = api.Client(cls.cfg, api.json_handler)
-        files = {'file': utils.http_get(RPM_SIGNED_URL)}
-        cls.artifact = cls.client.post(ARTIFACTS_PATH, files=files)
+        cls.rpm_content_api = ContentPackagesApi(gen_rpm_client())
+        cls.artifact = gen_artifact(RPM_SIGNED_URL)
 
     @classmethod
     def tearDownClass(cls):
         """Clean class-wide variable."""
-        delete_orphans(cls.cfg)
+        delete_orphans()
 
     def test_01_create_content_unit(self):
         """Create content unit."""
-        self.content_unit.update(
-            self.client.using_handler(api.task_handler).post(RPM_CONTENT_PATH, {
-                'artifact': self.artifact['pulp_href'],
-                'relative_path': RPM_PACKAGE_FILENAME
-            })
-        )
-        for key, val in RPM_PACKAGE_DATA.items():
+        attrs = gen_rpm_content_attrs(self.artifact, RPM_PACKAGE_FILENAME)
+        response = self.rpm_content_api.create(**attrs)
+        # rpm package doesn't keep relative_path but the location href
+        del attrs['relative_path']
+        created_resources = monitor_task(response.task)
+        content_unit = self.rpm_content_api.read(created_resources[0])
+        self.content_unit.update(content_unit.to_dict())
+        for key, val in attrs.items():
             with self.subTest(key=key):
                 self.assertEqual(self.content_unit[key], val)
 
-    @skip_if(bool, 'content_unit', False)
+    @skip_if(bool, "content_unit", False)
     def test_02_read_content_unit(self):
         """Read a content unit by its href."""
-        content_unit = self.client.get(self.content_unit['pulp_href'])
+        content_unit = self.rpm_content_api.read(self.content_unit["pulp_href"]).to_dict()
         for key, val in self.content_unit.items():
             with self.subTest(key=key):
                 self.assertEqual(content_unit[key], val)
 
-    @skip_if(bool, 'content_unit', False)
+    @skip_if(bool, "content_unit", False)
     def test_02_read_content_units(self):
-        """Read a content unit by its pkgId."""
-        page = self.client.get(RPM_CONTENT_PATH, params={
-            'pkgId': self.content_unit['pkgId']
-        })
-        self.assertEqual(len(page['results']), 1)
+        """Read a content unit by its pkg_id."""
+        page = self.rpm_content_api.list(pkg_id=self.content_unit["pkg_id"])
+        self.assertEqual(len(page.results), 1)
         for key, val in self.content_unit.items():
             with self.subTest(key=key):
-                self.assertEqual(page['results'][0][key], val)
+                self.assertEqual(page.results[0].to_dict()[key], val)
 
-    @skip_if(bool, 'content_unit', False)
+    @skip_if(bool, "content_unit", False)
     def test_03_partially_update(self):
         """Attempt to update a content unit using HTTP PATCH.
 
         This HTTP method is not supported and a HTTP exception is expected.
         """
-        attrs = copy.deepcopy(RPM_PACKAGE_DATA)
-        attrs.update({'name': utils.uuid4()})
-        with self.assertRaises(HTTPError) as exc:
-            self.client.patch(self.content_unit['pulp_href'], attrs)
-        self.assertEqual(exc.exception.response.status_code, 405)
+        attrs = gen_rpm_content_attrs(self.artifact, RPM_PACKAGE_FILENAME2)
+        with self.assertRaises(AttributeError) as exc:
+            self.rpm_content_api.partial_update(self.content_unit["pulp_href"], attrs)
+        msg = "object has no attribute 'partial_update'"
+        self.assertIn(msg, exc.exception.args[0])
 
-    @skip_if(bool, 'content_unit', False)
+    @skip_if(bool, "content_unit", False)
     def test_03_fully_update(self):
         """Attempt to update a content unit using HTTP PUT.
 
         This HTTP method is not supported and a HTTP exception is expected.
         """
-        attrs = copy.deepcopy(RPM_PACKAGE_DATA)
-        attrs.update({'name': utils.uuid4()})
-        with self.assertRaises(HTTPError) as exc:
-            self.client.put(self.content_unit['pulp_href'], attrs)
-        self.assertEqual(exc.exception.response.status_code, 405)
+        attrs = gen_rpm_content_attrs(self.artifact, RPM_PACKAGE_FILENAME2)
+        with self.assertRaises(AttributeError) as exc:
+            self.rpm_content_api.update(self.content_unit["pulp_href"], attrs)
+        msg = "object has no attribute 'update'"
+        self.assertIn(msg, exc.exception.args[0])
 
-    @skip_if(bool, 'content_unit', False)
+    @skip_if(bool, "content_unit", False)
     def test_04_delete(self):
         """Attempt to delete a content unit using HTTP DELETE.
 
         This HTTP method is not supported and a HTTP exception is expected.
         """
-        with self.assertRaises(HTTPError) as exc:
-            self.client.delete(self.content_unit['pulp_href'])
-        self.assertEqual(exc.exception.response.status_code, 405)
+        with self.assertRaises(AttributeError) as exc:
+            self.rpm_content_api.delete(self.content_unit["pulp_href"])
+        msg = "object has no attribute 'delete'"
+        self.assertIn(msg, exc.exception.args[0])
 
+    @skip_if(bool, "content_unit", False)
+    def test_05_duplicate_raise_error(self):
+        """Attempt to create duplicate package."""
+        attrs = gen_rpm_content_attrs(self.artifact, RPM_PACKAGE_FILENAME)
+        response = self.rpm_content_api.create(**attrs)
+        task_result = monitor_task(response.task)
+        msg = "There is already a package with"
+        self.assertTrue(msg in task_result['error']['description'])
 
-class DuplicateContentUnit(unittest.TestCase):
-    """Attempt to create a duplicate content unit.
-
-    This test targets the following issues:
-
-    *  `Pulp #4125 <https://pulp.plan.io/issue/4125>`_
-    """
-
-    @classmethod
-    def setUpClass(cls):
-        """Create class-wide variables."""
-        cls.cfg = config.get_config()
-        cls.client = api.Client(cls.cfg, api.json_handler)
-
-    @classmethod
-    def tearDownClass(cls):
-        """Clean created resources."""
-        delete_orphans(cls.cfg)
-
-    def test_raise_error(self):
-        """Create a duplicate content unit using same artifact and filename."""
-        delete_orphans(self.cfg)
-        files = {'file': utils.http_get(RPM_UNSIGNED_URL)}
-        artifact = self.client.post(ARTIFACTS_PATH, files=files)
-        attrs = {
-            'artifact': artifact['pulp_href'],
-            'relative_path': RPM_PACKAGE_FILENAME
-        }
-
-        # create first content unit.
-        self.client.using_handler(api.task_handler).post(RPM_CONTENT_PATH, attrs)
-
-        with self.assertRaises(TaskReportError) as ctx:
-            # using the same attrs used to create the first content unit.
-            api.Client(self.cfg, api.task_handler).post(
-                RPM_CONTENT_PATH,
-                attrs
-            )
-
-        keywords = (
-            'name',
-            'epoch',
-            'version',
-            'release',
-            'arch',
-            'checksum_type',
-            'pkgId',
-        )
-
-        for key in keywords:
-            self.assertIn(
-                key.lower(),
-                ctx.exception.task['error']['description'].lower(),
-                ctx.exception.task['error']
-            )
-
-    def test_second_unit_raises_error(self):
+    def test_06_second_unit_raises_error(self):
         """
         Create a duplicate content unit with different ``artifacts`` and same ``repo_key_fields``.
         """
         delete_orphans()
         client = gen_rpm_client()
-        packages_api = ContentPackagesApi(client)
         repo_api = RepositoriesRpmApi(client)
 
         repo = repo_api.create(gen_repo())
@@ -195,7 +134,7 @@ class DuplicateContentUnit(unittest.TestCase):
 
         # create first content unit.
         content_attrs = {"artifact": artifact["pulp_href"], "relative_path": "test_package"}
-        response = packages_api.create(**content_attrs)
+        response = self.rpm_content_api.create(**content_attrs)
         monitor_task(response.task)
 
         artifact = gen_artifact(url=RPM_SIGNED_URL2)
@@ -203,10 +142,10 @@ class DuplicateContentUnit(unittest.TestCase):
         # create second content unit.
         second_content_attrs = {"artifact": artifact["pulp_href"]}
         second_content_attrs["relative_path"] = content_attrs["relative_path"]
-        response = packages_api.create(**second_content_attrs)
+        response = self.rpm_content_api.create(**second_content_attrs)
         monitor_task(response.task)
 
-        data = {"add_content_units": [c.pulp_href for c in packages_api.list().results]}
+        data = {"add_content_units": [c.pulp_href for c in self.rpm_content_api.list().results]}
         response = repo_api.modify(repo.pulp_href, data)
         task = monitor_task(response.task)
 

--- a/pulp_rpm/tests/functional/api/test_download_policies.py
+++ b/pulp_rpm/tests/functional/api/test_download_policies.py
@@ -2,31 +2,33 @@
 """Tests for Pulp`s download policies."""
 import unittest
 
-from pulp_smash import api, config
-from pulp_smash.pulp3.utils import (
-    delete_orphans,
-    gen_repo,
-    get_added_content_summary,
-    get_content_summary,
-    sync,
-)
+from pulp_smash.pulp3.utils import gen_repo, get_added_content_summary, get_content_summary
 
 from pulp_rpm.tests.functional.constants import (
     RPM_FIXTURE_SUMMARY,
-    RPM_REMOTE_PATH,
-    RPM_REPO_PATH,
+    DOWNLOAD_POLICIES,
 )
 from pulp_rpm.tests.functional.utils import (
+    gen_rpm_client,
     gen_rpm_remote,
-    publish,
+    monitor_task,
+    skip_if,
 )
 from pulp_rpm.tests.functional.utils import set_up_module as setUpModule  # noqa:F401
 
+from pulpcore.client.pulp_rpm import (
+    RepositoriesRpmApi,
+    RpmRepositorySyncURL,
+    RemotesRpmApi,
+    RpmRpmPublication,
+    PublicationsRpmApi
+)
+
 
 class SyncPublishDownloadPolicyTestCase(unittest.TestCase):
-    """Sync/Publish a repository with different download policies.
+    """Sync a repository with different download policies.
 
-    This test targets the following issues:
+    This test targets the following issue:
 
     `Pulp #4126 <https://pulp.plan.io/issues/4126>`_
     `Pulp #4213 <https://pulp.plan.io/issues/4213>`_
@@ -35,85 +37,77 @@ class SyncPublishDownloadPolicyTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        """Create class-wide variables, and clean orphan units."""
-        cls.cfg = config.get_config()
-        delete_orphans(cls.cfg)
-        cls.client = api.Client(cls.cfg, api.page_handler)
+        """Create class-wide variables."""
+        cls.client = gen_rpm_client()
+        cls.DP_ON_DEMAND = "on_demand" in DOWNLOAD_POLICIES
+        cls.DP_STREAMED = "streamed" in DOWNLOAD_POLICIES
 
+    @skip_if(bool, "DP_ON_DEMAND", False)
     def test_on_demand(self):
-        """Sync/Publish with ``on_demand`` download policy.
+        """Sync with ``on_demand`` download policy. See :meth:`do_test`."""
+        self.do_test("on_demand")
 
-        See :meth:`do_sync`.
-        See :meth:`do_publish`.
-        """
-        self.do_sync('on_demand')
-        self.do_publish('on_demand')
-
+    @skip_if(bool, "DP_STREAMED", False)
     def test_streamed(self):
-        """Sync/Publish with ``streamend`` download policy.
+        """Sync with ``streamend`` download policy.  See :meth:`do_test`."""
+        self.do_test("streamed")
 
-        See :meth:`do_sync`.
-        See :meth:`do_publish`.
-        """
-        self.do_sync('streamed')
-        self.do_publish('streamed')
-
-    def do_sync(self, download_policy):
+    def do_test(self, download_policy):
         """Sync repositories with the different ``download_policy``.
 
         Do the following:
 
         1. Create a repository, and a remote.
-        2. Assert that repository version is None.
-        3. Sync the remote.
-        4. Assert that repository version is not None.
-        5. Assert that the correct number of possible units to be downloaded
+        2. Sync the remote.
+        3. Assert that repository version is not None.
+        4. Assert that the correct number of possible units to be downloaded
            were shown.
-        6. Sync the remote one more time.
-        7. Assert that repository version is the same as the previous latest version.
+        5. Sync the remote one more time in order to create another repository
+           version.
+        6. Assert that repository version is different from the previous one.
+        7. Assert that the same number of units are shown, and after the
+           second sync no extra units should be shown, since the same remote
+           was synced again.
+        8. Publish repository synced with lazy ``download_policy``.
         """
-        repo = self.client.post(RPM_REPO_PATH, gen_repo())
-        self.addCleanup(self.client.delete, repo['pulp_href'])
+        repo_api = RepositoriesRpmApi(self.client)
+        remote_api = RemotesRpmApi(self.client)
+        publications = PublicationsRpmApi(self.client)
 
-        remote = self.client.post(
-            RPM_REMOTE_PATH,
-            gen_rpm_remote(policy=download_policy)
-        )
-        self.addCleanup(self.client.delete, remote['pulp_href'])
+        repo = repo_api.create(gen_repo())
+        self.addCleanup(repo_api.delete, repo.pulp_href)
+
+        body = gen_rpm_remote(**{"policy": download_policy})
+        remote = remote_api.create(body)
+        self.addCleanup(remote_api.delete, remote.pulp_href)
 
         # Sync the repository.
-        self.assertEqual(repo["latest_version_href"], f"{repo['pulp_href']}versions/0/")
-        sync(self.cfg, remote, repo)
-        repo = self.client.get(repo['pulp_href'])
+        self.assertEqual(repo.latest_version_href, f"{repo.pulp_href}versions/0/")
+        repository_sync_data = RpmRepositorySyncURL(remote=remote.pulp_href)
+        sync_response = repo_api.sync(repo.pulp_href, repository_sync_data)
+        monitor_task(sync_response.task)
+        repo = repo_api.read(repo.pulp_href)
 
-        self.assertIsNotNone(repo['latest_version_href'])
-        self.assertDictEqual(get_content_summary(repo), RPM_FIXTURE_SUMMARY)
-        self.assertDictEqual(
-            get_added_content_summary(repo),
-            RPM_FIXTURE_SUMMARY
-        )
+        self.assertDictEqual(get_content_summary(repo.to_dict()), RPM_FIXTURE_SUMMARY)
+        self.assertDictEqual(get_added_content_summary(repo.to_dict()), RPM_FIXTURE_SUMMARY)
 
         # Sync the repository again.
-        latest_version_href = repo['latest_version_href']
-        sync(self.cfg, remote, repo)
-        repo = self.client.get(repo['pulp_href'])
+        latest_version_href = repo.latest_version_href
+        sync_response = repo_api.sync(repo.pulp_href, repository_sync_data)
+        monitor_task(sync_response.task)
+        repo = repo_api.read(repo.pulp_href)
 
-        self.assertEqual(latest_version_href, repo['latest_version_href'])
-        self.assertDictEqual(get_content_summary(repo), RPM_FIXTURE_SUMMARY)
+        self.assertEqual(latest_version_href, repo.latest_version_href)
+        self.assertDictEqual(get_content_summary(repo.to_dict()), RPM_FIXTURE_SUMMARY)
 
-    def do_publish(self, download_policy):
-        """Publish repository synced with lazy ``download_policy``."""
-        repo = self.client.post(RPM_REPO_PATH, gen_repo())
-        self.addCleanup(self.client.delete, repo['pulp_href'])
+        # Publish
+        publish_data = RpmRpmPublication(repository=repo.pulp_href)
+        publish_response = publications.create(publish_data)
+        created_resources = monitor_task(publish_response.task)
+        publication_href = created_resources[0]
 
-        remote = self.client.post(
-            RPM_REMOTE_PATH,
-            gen_rpm_remote(policy=download_policy)
-        )
-        self.addCleanup(self.client.delete, remote['pulp_href'])
+        self.addCleanup(publications.delete, publication_href)
 
-        sync(self.cfg, remote, repo)
-        repo = self.client.get(repo['pulp_href'])
-
-        publication = publish(self.cfg, repo)
-        self.assertIsNotNone(publication['repository_version'], publication)
+        publication = publications.read(publication_href)
+        self.assertIsNotNone(publication.repository)
+        self.assertIsNotNone(publication.repository_version)

--- a/pulp_rpm/tests/functional/api/test_upload.py
+++ b/pulp_rpm/tests/functional/api/test_upload.py
@@ -1,103 +1,86 @@
 # coding=utf-8
-"""Tests that verify upload of content to Pulp."""
-import hashlib
+"""Tests that perform actions over content unit."""
+import os
 import unittest
+from tempfile import NamedTemporaryFile
 
-from pulp_smash import api, config, utils
-from pulp_smash.exceptions import TaskReportError
-from pulp_smash.pulp3.constants import ARTIFACTS_PATH
-from pulp_smash.pulp3.utils import (
-    delete_orphans,
-    gen_repo,
+from pulp_smash.pulp3.utils import delete_orphans
+from pulp_smash.utils import http_get
+
+from pulp_rpm.tests.functional.utils import (
+    core_client,
+    gen_rpm_client,
+    monitor_task
 )
-
 from pulp_rpm.tests.functional.constants import (
-    RPM_CONTENT_PATH,
+    RPM_UNSIGNED_FIXTURE_URL,
     RPM_PACKAGE_FILENAME,
-    RPM_REPO_PATH,
-    RPM_SINGLE_REQUEST_UPLOAD,
-    RPM_UNSIGNED_URL,
+    RPM_WITH_NON_ASCII_URL
 )
 from pulp_rpm.tests.functional.utils import set_up_module as setUpModule  # noqa:F401
 
+from pulpcore.client.pulpcore import TasksApi
+from pulpcore.client.pulp_rpm import ContentPackagesApi
 
-class SingleRequestUploadTestCase(unittest.TestCase):
-    """Test whether one can upload a RPM using a single request.
+
+class ContentUnitTestCase(unittest.TestCase):
+    """CRUD content unit.
 
     This test targets the following issues:
 
-    `Pulp #4087 <https://pulp.plan.io/issues/4087>`_
-    `Pulp #4285 <https://pulp.plan.io/issues/4285>`_
-    """
-
-    def test_single_request_upload(self):
-        """Test single request upload."""
-        cfg = config.get_config()
-        # Pulp does not support single request upload for a RPM already present
-        # in Pulp.
-        delete_orphans(cfg)
-        file = {'file': utils.http_get(RPM_UNSIGNED_URL)}
-        client = api.Client(cfg, api.page_handler)
-        repo = client.post(RPM_REPO_PATH, gen_repo())
-        self.addCleanup(client.delete, repo['pulp_href'])
-        client.using_handler(api.task_handler).post(
-            RPM_SINGLE_REQUEST_UPLOAD,
-            files=file,
-            data={'repository': repo['pulp_href'], "relative_path": RPM_PACKAGE_FILENAME}
-        )
-        repo = client.get(repo['pulp_href'])
-
-        # Assertion about repo version.
-        self.assertIsNotNone(repo['latest_version_href'], repo)
-
-        # Assertions about artifcats.
-        artifact = client.get(ARTIFACTS_PATH)
-        self.assertEqual(len(artifact), 1, artifact)
-        self.assertEqual(
-            artifact[0]['sha256'],
-            hashlib.sha256(file['file']).hexdigest(),
-            artifact
-        )
-
-        # Assertion about content unit.
-        content = client.get(RPM_CONTENT_PATH)
-        self.assertEqual(len(content), 1, content)
-
-
-class SingleRequestUploadDuplicateTestCase(unittest.TestCase):
-    """Attempt to use single request upload for unit already in Pulp.
-
-    This test targets the following issue:
-
-    * `Pulp #4536 <https://pulp.plan.io/issues/4536>`_
+    * `Pulp #2872 <https://pulp.plan.io/issues/2872>`_
+    * `Pulp #3445 <https://pulp.plan.io/issues/3445>`_
+    * `Pulp Smash #870 <https://github.com/pulp/pulp-smash/issues/870>`_
     """
 
     @classmethod
     def setUpClass(cls):
-        """Create class-wide variables."""
-        cls.cfg = config.get_config()
-        delete_orphans(cls.cfg)
-        cls.client = api.Client(cls.cfg, api.page_handler)
-        cls.file = {'file': utils.http_get(RPM_UNSIGNED_URL)}
+        """Create class-wide variable."""
+        delete_orphans()
+        rpm_client = gen_rpm_client()
+        cls.tasks_api = TasksApi(core_client)
+        cls.content_api = ContentPackagesApi(rpm_client)
+        cls.file_to_use = os.path.join(RPM_UNSIGNED_FIXTURE_URL, RPM_PACKAGE_FILENAME)
 
-    def test_duplicate_unit(self):
-        """Test single request upload for unit already present in Pulp."""
-        repo = self.client.post(RPM_REPO_PATH, gen_repo())
-        self.addCleanup(self.client.delete, repo['pulp_href'])
-        self.single_request_upload(repo)
-        with self.assertRaises(TaskReportError) as ctx:
-            self.single_request_upload(repo)
-        for key in RPM_PACKAGE_FILENAME.split("-")[:-1]:
-            self.assertIn(
-                key,
-                ctx.exception.task['error']['description'].lower(),
-                ctx.exception.task['error']
+    def tearDown(self):
+        """TearDown."""
+        delete_orphans()
+
+    def test_singe_request_unit_and_duplicate_unit(self):
+        """Test single request upload unit.
+
+        1. Upload a unit
+        2. Attempt to upload same unit
+        """
+        # Single unit upload
+        upload = self.do_test(self.file_to_use)
+        content = monitor_task(upload.task)[0]
+        package = self.content_api.read(content)
+        self.assertTrue(package.location_href == RPM_PACKAGE_FILENAME)
+
+        # Duplicate unit
+        upload = self.do_test(self.file_to_use)
+        monitor_task(upload.task)
+        task_report = self.tasks_api.read(upload.task)
+        msg = 'There is already a package with'
+        self.assertTrue(msg in task_report.error['description'])
+
+    def test_upload_non_ascii(self):
+        """Test whether one can upload an RPM with non-ascii metadata."""
+        packages_count = self.content_api.list().count
+        upload = self.do_test(RPM_WITH_NON_ASCII_URL)
+        monitor_task(upload.task)
+        new_packages_count = self.content_api.list().count
+        self.assertTrue((packages_count + 1) == new_packages_count)
+
+    def do_test(self, remote_path):
+        """Upload a Package and return Task of upload."""
+        with NamedTemporaryFile() as file_to_upload:
+            file_to_upload.write(
+                http_get(remote_path)
             )
-
-    def single_request_upload(self, repo):
-        """Create single request upload."""
-        self.client.using_handler(api.task_handler).post(
-            RPM_SINGLE_REQUEST_UPLOAD,
-            files=self.file,
-            data={'repository': repo['pulp_href'], "relative_path": RPM_PACKAGE_FILENAME}
-        )
+            upload_attrs = {
+                'file': file_to_upload.name,
+                'relative_path': RPM_PACKAGE_FILENAME
+            }
+            return self.content_api.create(**upload_attrs)

--- a/pulp_rpm/tests/functional/constants.py
+++ b/pulp_rpm/tests/functional/constants.py
@@ -17,6 +17,11 @@ RPM_COPY_PATH = urljoin(BASE_PATH, 'rpm/copy/')
 
 PULP_FIXTURES_BASE_URL = config.get_config().get_fixtures_url()
 
+DOWNLOAD_POLICIES = ["immediate", "on_demand", "streamed"]
+
+DRPM_UNSIGNED_FIXTURE_URL = urljoin(PULP_FIXTURES_BASE_URL, 'drpm-unsigned/')
+"""The URL to a repository with unsigned DRPM packages."""
+
 RPM_PACKAGE_CONTENT_NAME = 'rpm.package'
 
 RPM_PACKAGECATEGORY_CONTENT_NAME = 'rpm.packagecategory'
@@ -79,6 +84,8 @@ RPM_SINGLE_REQUEST_UPLOAD = urljoin(BASE_PATH, 'content/rpm/packages/')
 
 RPM_UNSIGNED_FIXTURE_URL = urljoin(PULP_FIXTURES_BASE_URL, 'rpm-unsigned/')
 """The URL to a repository with unsigned RPM packages."""
+
+RPM_INVALID_FIXTURE_URL = urljoin(PULP_FIXTURES_BASE_URL, 'rpm-missing-filelists/')
 
 RPM_PACKAGE_COUNT = 35
 """The number of packages available at


### PR DESCRIPTION
Refactor funcional tests to use bindings.

- missing sync test
 - SyncDiffChecksumPackagesTestCase
 - SyncMutatedUpdateRecordTestCase
 - SyncMutatedPackagesTestCase
 - KickstartSyncTestCase

re: #6061
https://pulp.plan.io/issues/6061