### PR TITLE
Fix low performance on migration 0048

### DIFF
--- a/plugins/pulp_rpm/plugins/migrations/0048_correct_is_modular_field.py
+++ b/plugins/pulp_rpm/plugins/migrations/0048_correct_is_modular_field.py
@@ -96,9 +96,9 @@ def migrate_modulemd_artifacts(modulemd):
                                'release': pkg_nevra[3],
                                'arch': pkg_nevra[4]})
 
-        if rpms_to_update:
-            search_criteria = {"$or": rpms_to_update}
-            units_rpm_collection.update_many(search_criteria, {'$set': delta})
+    if rpms_to_update:
+        search_criteria = {"$or": rpms_to_update}
+        units_rpm_collection.update_many(search_criteria, {'$set': delta})
 
 
 def migrate(*args, **kwargs):


### PR DESCRIPTION
units_rpm_collection is updated many times unnecessarily.
The update should be done only once for each modulemd to
set is_modular for all rpms in its artifacts.