### PR TITLE
Add a test case for syncing centos7 with the immediate policy

### DIFF
--- a/CHANGES/6297.misc
+++ b/CHANGES/6297.misc
@@ -1,0 +1,1 @@
+Added a test case for syncing the centos7 repository with the immediate policy

--- a/pulp_rpm/tests/performance/test_sync.py
+++ b/pulp_rpm/tests/performance/test_sync.py
@@ -133,6 +133,10 @@ class SyncTestCase(unittest.TestCase):
         """Sync CentOS 7."""
         self.rpm_sync(url=CENTOS7_URL)
 
+    def test_centos7_immediate(self):
+        """Sync CentOS 7 with the immediate policy."""
+        self.rpm_sync(url=CENTOS7_URL, policy='immediate')
+
     def test_centos8_baseos_on_demand(self):
         """Sync CentOS 8 BaseOS."""
         self.rpm_sync(url=CENTOS8_BASEOS_URL)


### PR DESCRIPTION
closes #6297
https://pulp.plan.io/issues/6297