### PR TITLE
Alphabetical directory structure by default

### DIFF
--- a/CHANGES/4445.feature
+++ b/CHANGES/4445.feature
@@ -1,0 +1,1 @@
+Default publish type is alphabetical directory structure under 'Packages' folder.

--- a/CHANGES/6399.bugfix
+++ b/CHANGES/6399.bugfix
@@ -1,0 +1,1 @@
+Fixed repository metadata that was pointing to wrong file locations.

--- a/docs/_scripts/download.sh
+++ b/docs/_scripts/download.sh
@@ -16,4 +16,4 @@ if [[ "${DISTRIBUTION_BASE_URL:0:1}" = "/" ]]; then
 fi
 
 # Download a package from the distribution
-http -d $DISTRIBUTION_BASE_URL/$PKG
+http -d $DISTRIBUTION_BASE_URL/Packages/f/$PKG

--- a/functest_requirements.txt
+++ b/functest_requirements.txt
@@ -1,1 +1,2 @@
 git+https://github.com/pulp/pulp-smash.git#egg=pulp-smash
+django

--- a/pulp_rpm/app/constants.py
+++ b/pulp_rpm/app/constants.py
@@ -232,3 +232,5 @@ PULP_ENVIRONMENT_ATTRS = SimpleNamespace(
     DESC_BY_LANG='desc_by_lang',
     NAME_BY_LANG='name_by_lang'
 )
+
+PACKAGES_DIRECTORY = "Packages"

--- a/pulp_rpm/tests/functional/api/test_download_content.py
+++ b/pulp_rpm/tests/functional/api/test_download_content.py
@@ -10,6 +10,7 @@ from pulp_smash.pulp3.utils import download_content_unit, gen_distribution, gen_
 
 from pulp_rpm.tests.functional.constants import RPM_UNSIGNED_FIXTURE_URL
 from pulp_rpm.tests.functional.utils import (
+    get_package_repo_path,
     gen_rpm_client,
     get_rpm_package_paths,
     gen_rpm_remote,
@@ -98,7 +99,8 @@ class DownloadContentTestCase(unittest.TestCase):
         ).hexdigest()
 
         # …and Pulp.
-        content = download_content_unit(cfg, distribution.to_dict(), unit_path)
+        pkg_path = get_package_repo_path(unit_path)
+        content = download_content_unit(cfg, distribution.to_dict(), pkg_path)
         pulp_hash = hashlib.sha256(content).hexdigest()
 
         self.assertEqual(fixture_hash, pulp_hash)

--- a/pulp_rpm/tests/functional/utils.py
+++ b/pulp_rpm/tests/functional/utils.py
@@ -18,6 +18,8 @@ from pulp_smash.pulp3.utils import (
     require_pulp_plugins
 )
 
+from pulp_rpm.app.constants import PACKAGES_DIRECTORY
+
 from pulp_rpm.tests.functional.constants import (
     PRIVATE_GPG_KEY_URL,
     RPM_COPY_PATH,
@@ -272,3 +274,18 @@ def progress_reports(task_href):
         return task.progress_reports
 
     return []
+
+
+def get_package_repo_path(package_filename):
+    """Get package repo path with directory structure.
+
+    Args:
+        package_filename(str): filename of RPM package
+
+    Returns:
+        (str): full path of RPM package in published repository
+
+    """
+    return os.path.join(
+        PACKAGES_DIRECTORY, package_filename.lower()[0], package_filename
+    )


### PR DESCRIPTION
Publish repository with directory structure sorter by first letter under
'Packages' directory.

Adjust docs' scripts and tests to reflect the change.

```
/Packages/[a-z]/*.rpm
/repodata
```

closes: #4445
closes: #6399

https://pulp.plan.io/issues/4445
https://pulp.plan.io/issues/6399