### PR TITLE
Speed up the erratum pkglists query by adding a repo_id index

### DIFF
--- a/plugins/pulp_rpm/plugins/db/models.py
+++ b/plugins/pulp_rpm/plugins/db/models.py
@@ -1353,6 +1353,7 @@ class ErratumPkglist(AutoRetryDocument):
     meta = {'collection': 'erratum_pkglists',
             'allow_inheritance': False,
             'indexes': ['errata_id',
+                        'repo_id',
                         {'fields': model_key_fields, 'unique': True}]}
 
     @property


### PR DESCRIPTION
Based on Pavel tests, adding the repo_id index to the erratum_pkglists contributed 20% performance improvement to the regenerate applicability patch.

re #6334
https://pulp.plan.io/issues/6334