### PR TITLE
Advisory version is taken to consideration

### DIFF
--- a/CHANGES/5739.feature
+++ b/CHANGES/5739.feature
@@ -1,0 +1,1 @@
+Advisory version is considered at conflict resolution time.

--- a/pulp_rpm/app/shared_utils.py
+++ b/pulp_rpm/app/shared_utils.py
@@ -32,24 +32,34 @@ def _prepare_package(artifact, filename):
     return package
 
 
-def is_previous_revision(revision, target_revision):
+def is_previous_version(version, target_version):
     """
-    Compare revision with a target revision.
-    """
-    if revision.isdigit() and target_revision.isdigit():
-        return int(revision) <= int(target_revision)
+    Compare version with a target version.
 
-    if "." in revision and len(revision.split(".")) == len(target_revision.split(".")):
-        rev = revision.split(".")
-        for index, target in enumerate(target_revision.split(".")):
-            is_digit = rev[index].isdigit() and target.isdigit()
-            if is_digit and int(rev[index]) < int(target):
+    Able to compare versions with integers only.
+
+    Args:
+        version(str): version to compare
+        target_version(str): version to compare with
+
+    Returns:
+        bool: True if versions are the same or if the version is older than the target version.
+
+    """
+    if version.isdigit() and target_version.isdigit():
+        return int(version) <= int(target_version)
+
+    if "." in version and len(version.split(".")) == len(target_version.split(".")):
+        ver = version.split(".")
+        for index, target in enumerate(target_version.split(".")):
+            is_digit = ver[index].isdigit() and target.isdigit()
+            if is_digit and int(ver[index]) < int(target):
                 return True
 
         if is_digit:
-            return int(rev[index]) <= int(target)
+            return int(ver[index]) <= int(target)
 
-    if revision:
-        return revision == target_revision
+    if version:
+        return version == target_version
 
     return False

--- a/pulp_rpm/app/tasks/synchronizing.py
+++ b/pulp_rpm/app/tasks/synchronizing.py
@@ -72,7 +72,7 @@ from pulp_rpm.app.modulemd import (
 from pulp_rpm.app.kickstart.treeinfo import get_treeinfo_data
 
 from pulp_rpm.app.comps import strdict_to_dict, dict_digest
-from pulp_rpm.app.shared_utils import is_previous_revision
+from pulp_rpm.app.shared_utils import is_previous_version
 
 import gi
 gi.require_version('Modulemd', '2.0')
@@ -343,7 +343,7 @@ class RpmFirstStage(Stage):
                  self.repository.latest_version().number) and
                 (self.remote.pulp_last_updated <=
                  self.repository.latest_version().pulp_created) and
-                is_previous_revision(repomd.revision, self.repository.last_sync_revision_number)
+                is_previous_version(repomd.revision, self.repository.last_sync_revision_number)
             ):
                 optimize_data = dict(message='Optimizing Sync', code='optimizing.sync')
                 with ProgressReport(**optimize_data) as optimize_pb:


### PR DESCRIPTION
during sync when updated_dates are the same Pulp will check
versions and if there is newer version it is added instead the old one.

closes #5739
https://pulp.plan.io/issues/5739