### PR TITLE
Implement .repo file for RPM repositories

### DIFF
--- a/CHANGES/5356.feature
+++ b/CHANGES/5356.feature
@@ -1,0 +1,1 @@
+Distributions now serves a config.repo, and when signing is enabled also a public.key, in the base_path.

--- a/docs/workflows/metadata_signing.rst
+++ b/docs/workflows/metadata_signing.rst
@@ -26,6 +26,9 @@ The publication will automatically contain a detached ascii-armored signature an
 Both, the detached signature and the public key, are used by package managers during the process of
 verification.
 
+.. note::
+  The public key **must** be stored as public.key to prevent any path issues.
+
 Installing Packages
 -------------------
 

--- a/docs/workflows/use_pulp_repo.rst
+++ b/docs/workflows/use_pulp_repo.rst
@@ -41,20 +41,14 @@ Download GET response:
 
 Install a package from Pulp
 ---------------------------
+Download the config.repo file from the server at distribution's
+base_path and store it in /etc/yum.repos.d::
 
-Open /etc/yum.repos.d/foo.repo and add the following:
+  curl http://localhost:24816/pulp/content/foo/config.repo > /etc/yum.repos.d/foo.repo
 
-.. code::
+Now use dnf to install a package::
 
-  [foo]
-  name = foo
-  baseurl = http://localhost:24816/pulp/content/foo/
-  gpgcheck = 0
-
-
-Now use dnf to install a package:
-
-``$ sudo dnf install walrus``
+  sudo dnf install walrus
 
 List and Install applicable Advisories
 --------------------------------------

--- a/pulp_rpm/tests/functional/content_handler/test_config_repo.py
+++ b/pulp_rpm/tests/functional/content_handler/test_config_repo.py
@@ -1,0 +1,75 @@
+import unittest
+import requests
+
+from pulp_smash import api, config
+from pulp_smash.pulp3.utils import (
+    gen_distribution,
+    gen_repo,
+)
+
+from pulp_rpm.tests.functional.utils import (
+    gen_rpm_client,
+    monitor_task,
+)
+
+from pulpcore.client.pulp_rpm import (
+    DistributionsRpmApi,
+    RepositoriesRpmApi,
+    PublicationsRpmApi,
+    RpmRpmPublication,
+)
+
+
+class ContentHandlerTests(unittest.TestCase):
+    """Whether the RpmDistribution.content_handler* methods work."""
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        """Clean up after testing."""
+        for f, x in cls.cleanUp:
+            f(x)
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        """Set up the class."""
+        cls.cfg = config.get_config()
+        cls.api_client = api.Client(cls.cfg, api.json_handler)
+        cls.client = gen_rpm_client()
+        cls.repo_api = RepositoriesRpmApi(cls.client)
+        cls.publications_api = PublicationsRpmApi(cls.client)
+        cls.distributions_api = DistributionsRpmApi(cls.client)
+
+        cls.cleanUp = list()
+
+        repo = cls.repo_api.create(gen_repo())
+        cls.cleanUp.append((cls.repo_api.delete, repo.pulp_href))
+
+        publish_data = RpmRpmPublication(repository=repo.pulp_href)
+        publish_response = cls.publications_api.create(publish_data)
+        created_resources = monitor_task(publish_response.task)
+        publication_href = created_resources[0]
+        cls.cleanUp.append((cls.publications_api.delete, publication_href))
+
+        dist_data = gen_distribution(publication=publication_href)
+        dist_response = cls.distributions_api.create(dist_data)
+        created_resources = monitor_task(dist_response.task)
+        cls.dist = cls.distributions_api.read(created_resources[0])
+        cls.cleanUp.append((cls.distributions_api.delete, cls.dist.pulp_href))
+
+    def testConfigRepoInListingUnsigned(self):
+        """Whether the served resources are in the directory listing."""
+        resp = requests.get(self.dist.base_url)
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn(b'config.repo', resp.content)
+        self.assertNotIn(b'public.key', resp.content)
+
+    def testConfigRepoUnsigned(self):
+        """Whether config.repo can be downloaded and has the right content."""
+        resp = requests.get(f'{self.dist.base_url}config.repo')
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn(bytes(f'[{self.dist.name}]\n', 'utf-8'), resp.content)
+        self.assertIn(bytes(f'baseurl={self.dist.base_url}\n', 'utf-8'), resp.content)
+        self.assertIn(bytes(f'gpgcheck=0\n', 'utf-8'), resp.content)
+        self.assertIn(bytes(f'repo_gpgcheck=0', 'utf-8'), resp.content)


### PR DESCRIPTION
Closes #5356
https://pulp.plan.io/issues/5356

Opened early for review, this needs tests and docs.

Basically, this PR makes the content server serve config.repo files at `$CONTENT_PATH_PREFIX/rpm/$BASE_PATH/config.repo` that look something like this:

```
[foo]
enabled=1
baseurl=http://localhost:24816/pulp/content/base_path
gpgcheck=0
gpgrepocheck=0
```

Or, when a metadata signing service is enabled:

```
[bar]
enabled=1
baseurl=http://localhost:24816/pulp/content/bar
gpgcheck=0
gpgrepocheck=1
gpgkey=http://localhost:24816/pulp/content/rpm/bar/public.key
```

Additionally, when the signing service is enabled, theres also a public key served at `$CONTENT_PATH_PREFIX/rpm/$BASE_PATH/public.key`.

@dkliban mentions in the issue:

> the new handler should handle a route that looks like this: settings.RPM_CONTENT_PATH_PREFIX + '{path:.+}'. This is a slight variation on what pulpcore already provides[1].

However, the RPM repos did not have this prefix yet. Should the content for RPM always be prefixed with this or shall I remove it from this PR, pending a discussion on this?