### PR TITLE
Fix duplicated advisory case when only its metadata changed.

### DIFF
--- a/CHANGES/6604.bugfix
+++ b/CHANGES/6604.bugfix
@@ -1,0 +1,1 @@
+Fixed the duplicated advisory case when only auxiliary fields were updated but not any timestamp or version.

--- a/coverage.md
+++ b/coverage.md
@@ -14,7 +14,7 @@ Manual Coverage
 | As a user, I can sync opensuse repository | NO |  |
 | As a user, I can sync from a mirror list | NO | not merged yet |
 | **Duplicates** |  |  |
-| As a user, I have only one advisory with the same id in a repo version | PART | https://pulp.plan.io/issues/6604 |
+| As a user, I have only one advisory with the same id in a repo version | YES |  |
 | As a user, I have only one module with the same NSVCA in a repo version | NO |  |
 | As a user, I have only one [S]RPM with the same NEVRA in a repo version | YES |  |
 | As a user, I have only one distribution tree, custom metadata of a certain type in a repo version | NO |  |

--- a/pulp_rpm/app/advisory.py
+++ b/pulp_rpm/app/advisory.py
@@ -143,6 +143,11 @@ def resolve_advisory_conflict(previous_advisory, added_advisory):
                                      'timestamp but different and intersecting package lists. '
                                      'At least one of them is wrong. '
                                      f'Advisory id: {previous_advisory.id}'))
+        elif previous_pkglist == added_pkglist:
+            # it means some advisory metadata changed without bumping the updated_date or version.
+            # There is no way to find out which one is newer, and a user can't fix it,
+            # so we are choosing the incoming advisory.
+            to_remove.append(previous_advisory.pk)
     elif (not same_dates and not pkgs_intersection) or \
             (same_dates and not same_version and not pkgs_intersection):
         raise AdvisoryConflict(_('Incoming and existing advisories have the same id but '

--- a/pulp_rpm/tests/functional/api/test_sync.py
+++ b/pulp_rpm/tests/functional/api/test_sync.py
@@ -394,11 +394,8 @@ class BasicSyncTestCase(unittest.TestCase):
         self.assertEqual(added_content[0]['checksum_type'], 'sha512')
         self.assertEqual(removed_content[0]['checksum_type'], 'sha256')
 
-    @unittest.skip(
-        'FIXME: Enable this test after we can throw out duplicate UpdateRecords'
-    )
-    def test_mutated_update_records(self):
-        """Sync two copies of the same UpdateRecords.
+    def test_mutated_advisory_metadata(self):
+        """Sync two copies of the same Advisory (only description is updated).
 
         Make sure we end up with only one copy.
 
@@ -443,6 +440,9 @@ class BasicSyncTestCase(unittest.TestCase):
 
         # sync the repository again
         repo, remote = self.do_test(repo, remote)
+
+        # add the second remote to clean up
+        self.addCleanup(self.remote_api.delete, remote.pulp_href)
 
         self.assertDictEqual(get_content_summary(repo.to_dict()), RPM_FIXTURE_SUMMARY)
         self.assertEqual(


### PR DESCRIPTION
There are cases when updated datetime or version are not updated but only some auxiliary fields are.
In this case we can't decide which one is newer and we just pick the incoming one.

closes #6604
https://pulp.plan.io/issues/6604