### PR TITLE
Removing reference to copy.sh

### DIFF
--- a/docs/_scripts/docs_check_upload.sh
+++ b/docs/_scripts/docs_check_upload.sh
@@ -18,7 +18,6 @@ source artifact.sh
 source package.sh
 source add_remove.sh
 source advisory.sh
-source copy.sh
 
 source publication.sh
 source distribution.sh "$DIST_NAME"


### PR DESCRIPTION
Removing reference to `copy.sh`
as it was removed on https://github.com/pulp/pulp_rpm/pull/1706

Just realized it after merging my PR:
https://travis-ci.com/github/pulp/pulp_rpm/jobs/338084356