### PR TITLE
Make 'last_sync_revision_number' nullable in all migrations

### DIFF
--- a/CHANGES/6861.bugfix
+++ b/CHANGES/6861.bugfix
@@ -1,0 +1,1 @@
+Make 'last_sync_revision_number' nullable in all migrations.

--- a/pulp_rpm/app/migrations/0005_optimize_sync.py
+++ b/pulp_rpm/app/migrations/0005_optimize_sync.py
@@ -25,6 +25,6 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='rpmrepository',
             name='last_sync_revision_number',
-            field=models.CharField(max_length=20),
+            field=models.CharField(max_length=20, null=True),
         ),
     ]

--- a/pulp_rpm/app/migrations/0009_revision_null.py
+++ b/pulp_rpm/app/migrations/0009_revision_null.py
@@ -13,6 +13,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='rpmrepository',
             name='last_sync_revision_number',
-            field=models.CharField(max_length=20),
+            field=models.CharField(max_length=20, null=True),
         ),
     ]


### PR DESCRIPTION
closes: #6861
https://pulp.plan.io/issues/6861