### PR TITLE
Fixtures URL fix

### DIFF
--- a/CHANGES/6656.doc
+++ b/CHANGES/6656.doc
@@ -1,0 +1,1 @@
+Change fixtures URL in the docs scripts.

--- a/docs/_scripts/artifact.sh
+++ b/docs/_scripts/artifact.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Get an RPM package
-curl -O https://repos.fedorapeople.org/pulp/pulp/fixtures/rpm-signed/squirrel-0.1-1.noarch.rpm
+curl -O https://fixtures.pulpproject.org/rpm-unsigned/squirrel-0.1-1.noarch.rpm
 export PKG="squirrel-0.1-1.noarch.rpm"
 
 # Upload it as an Artifact

--- a/docs/_scripts/remote.sh
+++ b/docs/_scripts/remote.sh
@@ -4,7 +4,7 @@
 echo "Creating a remote that points to an external source of files."
 http POST $BASE_ADDR/pulp/api/v3/remotes/rpm/rpm/ \
     name='bar' \
-    url='https://repos.fedorapeople.org/pulp/pulp/fixtures/rpm-unsigned/' \
+    url='https://fixtures.pulpproject.org/rpm-unsigned/' \
     policy='on_demand'
 
 echo "Export an environment variable for the new remote URI."

--- a/docs/workflows/create_sync_publish.rst
+++ b/docs/workflows/create_sync_publish.rst
@@ -54,7 +54,7 @@ Remote GET response:
         "pulp_href": "/pulp/api/v3/remotes/rpm/rpm/2ceb5262-a5b2-4297-afdf-a31f7e46dfc5/",
         "pulp_last_updated": "2019-11-27T13:30:29.199187Z",
         "tls_validation": true,
-        "url": "https://repos.fedorapeople.org/pulp/pulp/fixtures/rpm/"
+        "url": "https://fixtures.pulpproject.org/rpm-unsigned/"
     }
 
 .. _versioned-repo-created:


### PR DESCRIPTION
Reflect change of fixtures URL.
Tests base_url is inherited from pulp_smash so change will be reflected
after pulp_smash will be changed.

closes: #6656
https://pulp.plan.io/issues/6656