### PR TITLE
Fixes how DistributionTrees (kickstart repos) are published.

### DIFF
--- a/CHANGES/6568.bugfix
+++ b/CHANGES/6568.bugfix
@@ -1,0 +1,1 @@
+Fixed CentOS 8 kickstart repository publications. 

--- a/functest_requirements.txt
+++ b/functest_requirements.txt
@@ -1,2 +1,3 @@
 git+https://github.com/pulp/pulp-smash.git#egg=pulp-smash
 django
+productmd>=1.25

--- a/pulp_rpm/app/tasks/synchronizing.py
+++ b/pulp_rpm/app/tasks/synchronizing.py
@@ -177,7 +177,8 @@ def synchronize(remote_pk, repository_pk, mirror, skip_types, optimize):
             )
             if created:
                 sub_repo.save()
-            treeinfo["repositories"].update({repodata: str(sub_repo.pk)})
+            directory = treeinfo["repo_map"][repodata]
+            treeinfo["repositories"].update({directory: str(sub_repo.pk)})
             path = f"{repodata}/"
             new_url = urljoin(remote_url, path)
             if repodata_exists(remote, new_url):
@@ -990,7 +991,7 @@ class RpmContentSaver(ContentSaver):
 
             resources = ["addons", "variants"]
             for resource_name in resources:
-                for resource in treeinfo_data[resource_name]:
+                for resource_id, resource in treeinfo_data[resource_name].items():
                     key = resource["repository"]
                     del resource["repository"]
                     resource["repository_id"] = treeinfo_data["repositories"][key]
@@ -1000,7 +1001,7 @@ class RpmContentSaver(ContentSaver):
             images = []
             variants = []
 
-            for addon in treeinfo_data["addons"]:
+            for addon_id, addon in treeinfo_data["addons"].items():
                 instance = Addon(**addon)
                 instance.distribution_tree = distribution_tree
                 addons.append(instance)
@@ -1015,7 +1016,7 @@ class RpmContentSaver(ContentSaver):
                 instance.distribution_tree = distribution_tree
                 images.append(instance)
 
-            for variant in treeinfo_data["variants"]:
+            for variant_id, variant in treeinfo_data["variants"].items():
                 instance = Variant(**variant)
                 instance.distribution_tree = distribution_tree
                 variants.append(instance)


### PR DESCRIPTION
This patch fixes the layout of sub-repos in publications. This patch also generates a TreeInfo file that
contains repository and packages paths that represent the publish structure of an RPM Publication that
contains a DistributionTree.

This patch refactors the TreeInfoData object. The variants and addons properties have been converted from
List to Dict. This enables easier access to their properties when generating the new TreeInfo file.

fixes: #6568
https://pulp.plan.io/issues/6568