### PR TITLE
Teach advisory-merge to avoid package-collection name collisions.

### DIFF
--- a/CHANGES/5740.feature
+++ b/CHANGES/5740.feature
@@ -1,0 +1,1 @@
+Taught advisory-merge to proactively avoid package-collection-name collisions.

--- a/pulp_rpm/tests/functional/api/test_retention_policy.py
+++ b/pulp_rpm/tests/functional/api/test_retention_policy.py
@@ -99,7 +99,7 @@ class RetentionPolicyTestCase(PulpTestCase):
         )
         self.assertDictEqual(
             versions_for_packages,
-            {'duck': ['0.7', '0.6'], 'kangaroo': ['0.2'], 'walrus': ['0.71']},
+            {'duck': ['0.6', '0.7'], 'kangaroo': ['0.2'], 'walrus': ['0.71']},
             versions_for_packages
         )
         # TODO: Test that modular RPMs unaffected?
@@ -135,6 +135,9 @@ class RetentionPolicyTestCase(PulpTestCase):
 
         for package in packages:
             packages_by_version[package['name']].append(package['version'])
+
+        for pkg_list in packages_by_version.values():
+            pkg_list.sort()
 
         return packages_by_version
 


### PR DESCRIPTION
Closes a hole in a very specific edge case in advisory-merge during
a copy operation. Requires two advisories that have:

  * same id
  * same update-date
  * package-collections with the same name
    * whose package-lists do NOT intersect

Changes one sych collection's name to insure name-uniqueness.

Also, fixed a test_retention test to stop failing due to postgres
non-determinism.

closes #5740
[nocoverage]