### PR TITLE
PkgEnv copy depsolving bugfix

### DIFF
--- a/CHANGES/7248.bugfix
+++ b/CHANGES/7248.bugfix
@@ -1,0 +1,1 @@
+Fix copy with depsolving for packageenvironments.

--- a/pulp_rpm/app/tasks/copy.py
+++ b/pulp_rpm/app/tasks/copy.py
@@ -91,7 +91,7 @@ def find_children_of_content(content, src_repo_version):
             packagegroups = packagegroups.union(category_package_groups)
 
     for packageenvironment in packageenvironments.iterator():
-        for env_package_group in packageenvironment.packagegroups:
+        for env_package_group in packageenvironment.group_ids:
             env_package_groups = PackageGroup.objects.filter(
                 name=env_package_group['name'], pk__in=src_repo_version.content
             )
@@ -99,7 +99,7 @@ def find_children_of_content(content, src_repo_version):
                 [envgroup.pk for envgroup in env_package_groups]
             )
             packagegroups = packagegroups.union(env_package_groups)
-        for optional_env_package_group in packageenvironment.optionalgroups:
+        for optional_env_package_group in packageenvironment.option_ids:
             opt_env_package_groups = PackageGroup.objects.filter(
                 name=optional_env_package_group['name'], pk__in=src_repo_version.content
             )


### PR DESCRIPTION
PkgEnv copy depsolving still used removed relations.
Now using group_ids and option_ids.

closes: #7248
https://pulp.plan.io/issues/7248

[nocoverage]

To test this new fixtures needed. Issue filled: https://pulp.plan.io/issues/7253