### PR TITLE
add nectar uln downloader

### DIFF
--- a/plugins/pulp_rpm/plugins/importers/yum/repomd/nectar_factory.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/repomd/nectar_factory.py
@@ -10,6 +10,7 @@ from gettext import gettext as _
 
 from nectar.downloaders.local import LocalFileDownloader
 from nectar.downloaders.threaded import HTTPThreadedDownloader
+from nectar.downloaders.ulnthreaded import ULNHTTPThreadedDownloader
 
 
 # Mapping from scheme string to downloader class to instantiate
@@ -17,6 +18,7 @@ SCHEME_DOWNLOADERS = {
     'file': LocalFileDownloader,
     'http': HTTPThreadedDownloader,
     'https': HTTPThreadedDownloader,
+    'uln': ULNHTTPThreadedDownloader,
 }
 
 


### PR DESCRIPTION
This is the 2nd PR to add oracle uln repos (`uln://channel_label`) to pulp_rpm and Katello.
Based on the PR https://github.com/pulp/nectar/pull/71 this adds `uln://`repos to the netcar_factory.