### PR TITLE
Add remaining RPM-entities to import/export.

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -81,7 +81,7 @@ VARSYAML
 fi
 
 cat >> vars/main.yaml << VARSYAML
-pulp_settings: null
+pulp_settings: {"allowed_export_paths": ["/tmp"], "allowed_import_paths": ["/tmp"]}
 VARSYAML
 
 if [[ "$TEST" == "pulp" || "$TEST" == "performance" || "$TEST" == "s3" ]]; then

--- a/.travis/release.py
+++ b/.travis/release.py
@@ -37,13 +37,14 @@ def validate_redmine_data(redmine_query_url, redmine_issues):
         status = redmine_issue.status.name
         if "CLOSE" not in status and status != "MODIFIED":
             stats["status_not_modified"].append(issue)
+        milestone_id = None
         try:
             milestone = redmine_issue.fixed_version.name
             milestone_id = redmine_issue.fixed_version.id
             stats[f"milestone_{milestone}"].append(issue)
         except ResourceAttrError:
             stats["without_milestone"].append(issue)
-
+    if milestone_id is not None:
         milestone_url = f"RedmineMilestone: {REDMINE_URL}/versions/{milestone_id}.json\n[noissue]"
 
     print(f"\n\nRedmine stats: {json.dumps(stats, indent=2)}")
@@ -166,7 +167,7 @@ short_sha = git.rev_parse(sha, short=7)
 # Third commit: bump to .dev
 with open(f"{plugin_path}/requirements.txt", "wt") as setup_file:
     for line in setup_lines:
-        if "pulpcore" in line and "pulpcore" not in release_path:
+        if "pulpcore" in line and "pulpcore" not in release_path and release_type != "patch":
             line = f"pulpcore>={lower_pulpcore_version}\n"
 
         setup_file.write(line)

--- a/.travis/settings.py.j2
+++ b/.travis/settings.py.j2
@@ -1,7 +1,10 @@
 CONTENT_ORIGIN = "http://pulp:80"
 ANSIBLE_API_HOSTNAME = "http://pulp:80"
 ANSIBLE_CONTENT_HOSTNAME = "http://pulp:80/pulp/content"
-TOKEN_AUTH_DISABLED = True
+PRIVATE_KEY_PATH = "/etc/pulp/certs/token_private_key.pem"
+PUBLIC_KEY_PATH = "/etc/pulp/certs/token_public_key.pem"
+TOKEN_SERVER = "http://pulp:80/token"
+TOKEN_SIGNATURE_ALGORITHM = "ES256"
 
 {% if pulp_settings %}
 {% for key, value in pulp_settings.items() %}

--- a/.travis/start_container.yaml
+++ b/.travis/start_container.yaml
@@ -81,6 +81,14 @@
           command: "docker logs pulp"
           failed_when: true
 
+    - name: "Set pulp password in .netrc"
+      copy:
+        dest: "~/.netrc"
+        content: |
+          machine pulp
+          login admin
+          password password
+
 - hosts: pulp
   gather_facts: false
   tasks:

--- a/CHANGES/6815.feature
+++ b/CHANGES/6815.feature
@@ -1,0 +1,1 @@
+Added import/export support for remaining advisory-related entities.

--- a/coverage.md
+++ b/coverage.md
@@ -48,4 +48,5 @@ Manual Coverage
 | As a user, I can use dnf to install all the content served by Pulp | PART | only covers rpm installation |
 | **Retention** |  |  |
 | As a user, I can have a repository option that retains the latest N packages of the same name | PART | No coverage of packages with differing arch in same repo (src, i686, x86_64), no coverage of non-sync repo modifications, no coverage of modular RPMs being exempted. |
-
+| As a user, I can export RPM-repository content to be consumed by a downstream Pulp3 instance. | PART | basic pulp-export succeeds |
+| As a user, I can import RPM-repository content exported from an upstream Pulp3 instance. | PART | basic pulp-import succeeds |

--- a/pulp_rpm/tests/functional/api/test_pulpexport.py
+++ b/pulp_rpm/tests/functional/api/test_pulpexport.py
@@ -1,0 +1,139 @@
+# coding=utf-8
+"""
+Tests PulpExporter and PulpExport functionality.
+
+NOTE: assumes ALLOWED_EXPORT_PATHS setting contains "/tmp" - all tests will fail if this is not
+the case.
+"""
+from pulp_smash import api, cli, config
+from pulp_smash.utils import uuid4
+from pulp_smash.pulp3.bindings import PulpTestCase, monitor_task
+
+from pulp_smash.pulp3.utils import (
+    delete_orphans,
+    gen_repo,
+)
+
+from pulp_rpm.tests.functional.utils import (
+    gen_rpm_client,
+    gen_rpm_remote,
+)
+
+from pulpcore.client.pulpcore import (
+    ApiClient as CoreApiClient,
+    ExportersPulpApi,
+    ExportersCoreExportsApi,
+)
+
+from pulpcore.client.pulp_rpm import (
+    RepositoriesRpmApi,
+    RpmRepositorySyncURL,
+    RemotesRpmApi,
+)
+
+
+class BaseExporterCase(PulpTestCase):
+    """
+    Base functionality for Exporter and Export test classes.
+
+    The export process isn't possible without repositories having been sync'd - arranging for
+    that to happen once per-class (instead of once-per-test) is the primary purpose of this parent
+    class.
+    """
+
+    @classmethod
+    def _setup_repositories(cls):
+        """Create and sync a number of repositories to be exported."""
+        # create and remember a set of repo
+        repos = []
+        remotes = []
+        a_repo = cls.repo_api.create(gen_repo())
+        # give it a remote and sync it
+        body = gen_rpm_remote()
+        remote = cls.remote_api.create(body)
+        repository_sync_data = RpmRepositorySyncURL(remote=remote.pulp_href)
+        sync_response = cls.repo_api.sync(a_repo.pulp_href, repository_sync_data)
+        monitor_task(sync_response.task)
+        # remember it
+        repos.append(a_repo)
+        remotes.append(remote)
+        return a_repo, remote
+
+    @classmethod
+    def setUpClass(cls):
+        """Create class-wide variables."""
+        cls.cfg = config.get_config()
+        cls.client = api.Client(cls.cfg, api.json_handler)
+        cls.core_client = CoreApiClient(configuration=cls.cfg.get_bindings_config())
+        cls.rpm_client = gen_rpm_client()
+
+        cls.repo_api = RepositoriesRpmApi(cls.rpm_client)
+        cls.remote_api = RemotesRpmApi(cls.rpm_client)
+        cls.exporter_api = ExportersPulpApi(cls.core_client)
+        cls.exports_api = ExportersCoreExportsApi(cls.core_client)
+
+        (cls.repo, cls.remote) = cls._setup_repositories()
+
+    @classmethod
+    def tearDownClass(cls):
+        """Clean up after ourselves."""
+        cls.remote_api.delete(cls.remote.pulp_href)
+        cls.repo_api.delete(cls.repo.pulp_href)
+        delete_orphans(cls.cfg)
+
+    def _delete_exporter(self, exporter):
+        """
+        Utility routine to delete an exporter.
+
+        Delete even with existing last_export should now Just Work
+        (as of https://pulp.plan.io/issues/6555)
+        """
+        cli_client = cli.Client(self.cfg)
+        cmd = ("rm", "-rf", exporter.path)
+        cli_client.run(cmd, sudo=True)
+
+        self.exporter_api.delete(exporter.pulp_href)
+
+    def _create_exporter(self, cleanup=True):
+        """
+        Utility routine to create an exporter for the available repositories.
+        """
+        body = {
+            "name": uuid4(),
+            "path": "/tmp/{}/".format(uuid4()),
+            "repositories": [self.repo.pulp_href],
+        }
+        exporter = self.exporter_api.create(body)
+        if cleanup:
+            self.addCleanup(self._delete_exporter, exporter)
+        return exporter, body
+
+
+class PulpExportRpmTestCase(BaseExporterCase):
+    """Test PulpExport CRDL methods (Update is not allowed)."""
+
+    def _gen_export(self, exporter, body={}):
+        """Create and read back an export for the specified PulpExporter."""
+        export_response = self.exports_api.create(exporter.pulp_href, body)
+        monitor_task(export_response.task)
+        task = self.client.get(export_response.task)
+        resources = task["created_resources"]
+        self.assertEqual(1, len(resources))
+        export_href = resources[0]
+        export = self.exports_api.read(export_href)
+        self.assertIsNotNone(export)
+        return export
+
+    def test_export(self):
+        """Issue and evaluate a PulpExport (tests both Create and Read)."""
+        (exporter, body) = self._create_exporter(cleanup=False)
+        try:
+            export = self._gen_export(exporter)
+            self.assertIsNotNone(export)
+            self.assertEqual(len(exporter.repositories), len(export.exported_resources))
+            self.assertIsNotNone(export.output_file_info)
+            for an_export_filename in export.output_file_info.keys():
+                self.assertFalse("//" in an_export_filename)
+
+        finally:
+            self._delete_exporter(exporter)

--- a/pulp_rpm/tests/functional/api/test_pulpimport.py
+++ b/pulp_rpm/tests/functional/api/test_pulpimport.py
@@ -1,0 +1,214 @@
+"""
+Tests PulpImporter and PulpImport functionality.
+
+NOTE: assumes ALLOWED_EXPORT_PATHS and ALLOWED_IMPORT_PATHS settings contain "/tmp" - all tests
+will fail if this is not the case.
+"""
+from pulp_smash import api, cli, config
+from pulp_smash.utils import uuid4
+from pulp_smash.pulp3.bindings import PulpTestCase, monitor_task
+from pulp_smash.pulp3.utils import (
+    delete_orphans,
+    gen_repo,
+)
+
+from pulp_rpm.tests.functional.utils import (
+    gen_rpm_client,
+    gen_rpm_remote,
+)
+
+from pulpcore.tests.functional.utils import monitor_task_group
+
+from pulpcore.client.pulpcore import (
+    ApiClient as CoreApiClient,
+    ExportersPulpApi,
+    ExportersCoreExportsApi,
+    ImportersPulpApi,
+    ImportersCoreImportsApi,
+)
+
+from pulpcore.client.pulp_rpm import (
+    RepositoriesRpmApi,
+    RpmRepositorySyncURL,
+    RemotesRpmApi,
+)
+
+NUM_REPOS = 2
+
+
+class PulpImportTestCase(PulpTestCase):
+    """
+    Base functionality for PulpImporter and PulpImport test classes.
+    """
+
+    @classmethod
+    def _setup_repositories(cls):
+        """Create and sync a number of repositories to be exported."""
+        # create and remember a set of repo
+        import_repos = []
+        export_repos = []
+        remotes = []
+        for r in range(NUM_REPOS):
+            import_repo = cls.repo_api.create(gen_repo())
+            export_repo = cls.repo_api.create(gen_repo())
+            body = gen_rpm_remote()
+            remote = cls.remote_api.create(body)
+            repository_sync_data = RpmRepositorySyncURL(remote=remote.pulp_href)
+            sync_response = cls.repo_api.sync(
+                export_repo.pulp_href, repository_sync_data
+            )
+            monitor_task(sync_response.task)
+            # remember it
+            export_repos.append(export_repo)
+            import_repos.append(import_repo)
+            remotes.append(remote)
+        return import_repos, export_repos, remotes
+
+    @classmethod
+    def _create_exporter(cls, cleanup=True):
+        body = {
+            "name": uuid4(),
+            "repositories": [r.pulp_href for r in cls.export_repos],
+            "path": "/tmp/{}".format(uuid4()),
+        }
+        exporter = cls.exporter_api.create(body)
+        return exporter
+
+    @classmethod
+    def _create_export(cls):
+        export_response = cls.exports_api.create(cls.exporter.pulp_href, {})
+        monitor_task(export_response.task)
+        task = cls.client.get(export_response.task)
+        resources = task["created_resources"]
+        export_href = resources[0]
+        export = cls.exports_api.read(export_href)
+        return export
+
+    @classmethod
+    def _create_chunked_export(cls):
+        export_response = cls.exports_api.create(
+            cls.exporter.pulp_href, {"chunk_size": "5KB"}
+        )
+        monitor_task(export_response.task)
+        task = cls.client.get(export_response.task)
+        resources = task["created_resources"]
+        export_href = resources[0]
+        export = cls.exports_api.read(export_href)
+        return export
+
+    @classmethod
+    def setUpClass(cls):
+        """Create class-wide variables."""
+        cls.cfg = config.get_config()
+        cls.client = api.Client(cls.cfg, api.json_handler)
+        cls.core_client = CoreApiClient(configuration=cls.cfg.get_bindings_config())
+        cls.rpm_client = gen_rpm_client()
+
+        cls.repo_api = RepositoriesRpmApi(cls.rpm_client)
+        cls.remote_api = RemotesRpmApi(cls.rpm_client)
+        cls.exporter_api = ExportersPulpApi(cls.core_client)
+        cls.exports_api = ExportersCoreExportsApi(cls.core_client)
+        cls.importer_api = ImportersPulpApi(cls.core_client)
+        cls.imports_api = ImportersCoreImportsApi(cls.core_client)
+
+        (cls.import_repos, cls.export_repos, cls.remotes) = cls._setup_repositories()
+        cls.exporter = cls._create_exporter()
+        cls.export = cls._create_export()
+        cls.chunked_export = cls._create_chunked_export()
+
+    @classmethod
+    def _delete_exporter(cls):
+        """
+        Utility routine to delete an exporter.
+
+        Also removes the export-directory and all its contents.
+        """
+        cli_client = cli.Client(cls.cfg)
+        cmd = ("rm", "-rf", cls.exporter.path)
+        cli_client.run(cmd, sudo=True)
+        cls.exporter_api.delete(cls.exporter.pulp_href)
+
+    @classmethod
+    def tearDownClass(cls):
+        """Clean up."""
+        for remote in cls.remotes:
+            cls.remote_api.delete(remote.pulp_href)
+        for repo in cls.export_repos:
+            cls.repo_api.delete(repo.pulp_href)
+        for repo in cls.import_repos:
+            cls.repo_api.delete(repo.pulp_href)
+
+        cls._delete_exporter()
+        delete_orphans(cls.cfg)
+
+    def _create_importer(self, name=None, cleanup=True):
+        """Create an importer."""
+        mapping = {}
+        if not name:
+            name = uuid4()
+
+        for idx, repo in enumerate(self.export_repos):
+            mapping[repo.name] = self.import_repos[idx].name
+
+        body = {
+            "name": name,
+            "repo_mapping": mapping,
+        }
+
+        importer = self.importer_api.create(body)
+
+        if cleanup:
+            self.addCleanup(self.importer_api.delete, importer.pulp_href)
+
+        return importer
+
+    def _perform_import(self, importer, chunked=False):
+        """Perform an import with importer."""
+        if chunked:
+            filenames = [
+                f
+                for f in list(self.chunked_export.output_file_info.keys())
+                if f.endswith("json")
+            ]
+            import_response = self.imports_api.create(
+                importer.pulp_href, {"toc": filenames[0]}
+            )
+        else:
+            filenames = [
+                f
+                for f in list(self.export.output_file_info.keys())
+                if f.endswith("tar.gz")
+            ]
+            import_response = self.imports_api.create(
+                importer.pulp_href, {"path": filenames[0]}
+            )
+        monitor_task(import_response.task)
+        task = self.client.get(import_response.task)
+        resources = task["created_resources"]
+        task_group_href = resources[1]
+        task_group = monitor_task_group(task_group_href)
+
+        return task_group
+
+    def test_import(self):
+        """Test an import."""
+        importer = self._create_importer()
+        task_group = self._perform_import(importer)
+        self.assertEqual(len(self.import_repos), task_group.completed)
+        for repo in self.import_repos:
+            repo = self.repo_api.read(repo.pulp_href)
+            self.assertEqual(f"{repo.pulp_href}versions/1/", repo.latest_version_href)
+
+    def test_double_import(self):
+        """Test two imports of our export."""
+        importer = self._create_importer()
+        self._perform_import(importer)
+        self._perform_import(importer)
+
+        imports = self.imports_api.list(importer.pulp_href).results
+        self.assertEqual(len(imports), 2)
+
+        for repo in self.import_repos:
+            repo = self.repo_api.read(repo.pulp_href)
+            # still only one version as pulp won't create a new version if nothing changed
+            self.assertEqual(f"{repo.pulp_href}versions/1/", repo.latest_version_href)

--- a/template_config.yml
+++ b/template_config.yml
@@ -22,7 +22,11 @@ plugin_dash: pulp-rpm
 plugin_dash_short: rpm
 plugin_name: pulp_rpm
 plugin_snake: pulp_rpm
-pulp_settings: null
+pulp_settings:
+  allowed_export_paths:
+  - /tmp
+  allowed_import_paths:
+  - /tmp
 pulpcore_branch: master
 pulpcore_pip_version_specifier: null
 pydocstyle: true
@@ -37,5 +41,5 @@ test_performance:
 test_s3: true
 travis_addtl_services: []
 travis_notifications: None
-update_redmine: true 
+update_redmine: true
 


### PR DESCRIPTION
Includes UpdateReference, UpdateCollection, and UpdateCollectionPackage.

Added basic test-skeleton for import/export of pulp_rpm.

fixes #6815