### PR TITLE
Building changelog for 3.5.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,24 @@ Changelog
 
 .. towncrier release notes start
 
+3.5.1 (2020-08-11)
+==================
+
+
+Bugfixes
+--------
+
+- Handle optimize=True and mirror=True on sync correctly.
+  `#7228 <https://pulp.plan.io/issues/7228>`_
+- Fix copy with depsolving for packageenvironments.
+  `#7248 <https://pulp.plan.io/issues/7248>`_
+- Taught copy that empty-content means 'copy nothing'.
+  `#7284 <https://pulp.plan.io/issues/7284>`_
+
+
+----
+
+
 3.5.0 (2020-07-24)
 ==================
 

--- a/CHANGES/7228.bugfix
+++ b/CHANGES/7228.bugfix
@@ -1,1 +1,0 @@
-Handle optimize=True and mirror=True on sync correctly.

--- a/CHANGES/7248.bugfix
+++ b/CHANGES/7248.bugfix
@@ -1,1 +1,0 @@
-Fix copy with depsolving for packageenvironments.

--- a/CHANGES/7284.bugfix
+++ b/CHANGES/7284.bugfix
@@ -1,1 +1,0 @@
-Taught copy that empty-content means 'copy nothing'.


### PR DESCRIPTION
[noissue]

(cherry picked from commit d0ccd33fc7ad82a615c5e605187646d9a4f609a9)