### PR TITLE
Skip comment lines in mirrorlist

### DIFF
--- a/CHANGES/7354.bugfix
+++ b/CHANGES/7354.bugfix
@@ -1,0 +1,1 @@
+Fix sync from mirrorlist with comments (like fedora's mirrorlist).

--- a/coverage.md
+++ b/coverage.md
@@ -16,6 +16,7 @@ Manual Coverage
 | As a user, I can sync and skip specific type (srpm) | NO |  |
 | As a user, I can sync opensuse repository | NO |  |
 | As a user, I can sync from a mirror list | YES |  |
+| As a user, I can sync from a mirror list with comments | YES |  |
 | As a user, I can sync from CDN using certificates | YES |  |
 | **Duplicates** |  |  |
 | As a user, I have only one advisory with the same id in a repo version | YES |  |

--- a/pulp_rpm/app/tasks/synchronizing.py
+++ b/pulp_rpm/app/tasks/synchronizing.py
@@ -121,6 +121,8 @@ def fetch_mirror(remote):
     with open(result.path) as mirror_list_file:
         for mirror in mirror_list_file:
             match = re.match(url_pattern, mirror)
+            if not match:
+                continue
             repodata_exists = get_repomd_file(remote, match.group(2))
             if match and repodata_exists:
                 return match.group(2)

--- a/pulp_rpm/tests/functional/constants.py
+++ b/pulp_rpm/tests/functional/constants.py
@@ -359,6 +359,7 @@ CENTOS8_BASEOS_URL = "http://mirror.linux.duke.edu/pub/centos/8/BaseOS/x86_64/os
 EPEL7_URL = "https://dl.fedoraproject.org/pub/epel/7/x86_64/"
 RPM_CDN_APPSTREAM_URL = "https://cdn.redhat.com/content/dist/rhel8/8.2/x86_64/appstream/os/"
 RPM_CDN_BASEOS_URL = "https://cdn.redhat.com/content/dist/rhel8/8.2/x86_64/baseos/os/"
+EPEL8_MIRRORLIST_URL = "https://mirrors.fedoraproject.org/mirrorlist?repo=epel-8&arch=x86_64"
 
 PULP_TYPE_ADVISORY = 'rpm.advisory'
 PULP_TYPE_PACKAGE = 'rpm.package'

--- a/pulp_rpm/tests/performance/test_sync.py
+++ b/pulp_rpm/tests/performance/test_sync.py
@@ -29,6 +29,7 @@ from pulp_rpm.tests.functional.constants import (
     CENTOS8_BASEOS_URL,
     CENTOS8_KICKSTART_APP_URL,
     CENTOS8_KICKSTART_BASEOS_URL,
+    EPEL8_MIRRORLIST_URL,
 )
 from pulp_rpm.tests.functional.utils import (
     gen_rpm_client,
@@ -167,6 +168,10 @@ class SyncTestCase(unittest.TestCase):
     def test_centos8_kickstart_appstream_on_demand(self):
         """Kickstart Sync CentOS 8 AppStream."""
         self.rpm_sync(url=CENTOS8_KICKSTART_APP_URL)
+
+    def test_epel8_mirrorlist_with_comment(self):
+        """Kickstart Sync EPEL 8 (which includes a comment line)."""
+        self.rpm_sync(url=EPEL8_MIRRORLIST_URL)
 
 
 class CDNTestCase(unittest.TestCase):


### PR DESCRIPTION
fixes #7354
https://pulp.plan.io/issues/7354

The fedora mirrorlists have a comment at the top. For example:

https://mirrors.fedoraproject.org/mirrorlist?repo=epel-8&arch=x86_64&country=US
```
# repo = epel-8 arch = x86_64 country = US 
```

The `fetch_mirror` function's docstring says it skips  non-matching lines, but the task dies trying to access `.group(2)` on `None`.
```
        "error": {
            "description": "'NoneType' object has no attribute 'group'",
            "traceback": "  File \"/usr/local/lib/pulp/lib64/python3.6/site-packages/rq/worker.py\", line 934, in perform_job\n    rv = job.perform()\n  File \"/usr/local/lib/pulp/lib64/python3.6/site-packages/rq/job.py\", line 686, in perform\n    self._result = self._execute()\n  File \"/usr/local/lib/pulp/lib64/python3.6/site-packages/rq/job.py\", line 692, in _execute\n    return self.func(*self.args, **self.kwargs)\n  File \"/usr/local/lib/pulp/lib64/python3.6/site-packages/pulp_rpm/app/tasks/synchronizing.py\", line 211, in synchronize\n    remote_url = fetch_remote_url(remote)\n  File \"/usr/local/lib/pulp/lib64/python3.6/site-packages/pulp_rpm/app/tasks/synchronizing.py\", line 138, in fetch_remote_url\n    return fetch_mirror(remote)\n  File \"/usr/local/lib/pulp/lib64/python3.6/site-packages/pulp_rpm/app/tasks/synchronizing.py\", line 124, in fetch_mirror\n    repodata_exists = get_repomd_file(remote, match.group(2))\n"
        },
```

So, this PR skips lines that don't match the URL regex. I tested it by hotpatching my test installation and restarting the workers.