### PR TITLE
Fix RPM copy w/ depsolving when packages depend on a particular file

### DIFF
--- a/CHANGES/7202.bugfix
+++ b/CHANGES/7202.bugfix
@@ -1,0 +1,1 @@
+Fixed a bug where dependency solving did not work correctly with packages that depend on files, e.g. depending on /usr/bin/bash.

--- a/coverage.md
+++ b/coverage.md
@@ -35,7 +35,7 @@ Manual Coverage
 | **Copy** |  |  |
 | As a user, I can copy any content by adding it to a repository with modify/ endpoint (but nothing is copied automatically, and invalid repositories will fail to validate for some definition of “invalid”) | NO |  |
 | As a user, I can copy any content by href using Copy API | PART |  |
-| As a user, I can copy RPM package and its dependencies (if depsolving=True) | Yes | to empty and non-empty repository |
+| As a user, I can copy RPM package and its dependencies (if depsolving=True) | YES | to empty and non-empty repository |
 | As a user, I can copy Advisory and packages it refers to (and their dependencies if depsolving=True) by copying the Advisory | PART |  |
 | As a user, I can copy PackageCategories, PackageEnvironments and PackageGroups (and their dependencies) | PART | no packageenvironment test |
 | As a user, I can copy Modulemd and its artifacts by copying the Modulemd | NO |  |
@@ -43,6 +43,7 @@ Manual Coverage
 | As a user, if the default Modulemd is copied, its module-default is copied as well (and vice-versa) | NO |  |
 | As a user, I can copy content with dep solving on and specify multiple repositories to copy from/to | NO |  |
 | As a user, all content that I directly specify to be copied should always be copied (obviously, but we need to test it, there have been dependency solving bugs where it didn’t happen for various reasons) | NO |  |
+| Dependencies can be solved for RPM packages which depend on specific files (such as /usr/bin/bash) present only in filelists.xml | NO | needs a fixture change/improvement |
 | **Remove** |  |  |
 | As a user, when a module is removed, its packages are removed as well ( not referenced by other modules) | NO |  |
 | **Consumer cases** |  |  |


### PR DESCRIPTION
Packages can depend on files e.g. /usr/bin/bash rather than "bash".
We're creating the file list metadata improperly in libsolv so this
wasn't being respected, and the problems would only be apparent in
debug log mode. During the period when we want to catch all these
bugs, "warning" would be more appropriate so that they are highly
visible.

closes: #7202
https://pulp.plan.io/issues/7202