### PR TITLE
Assuring the right pulpcore version

### DIFF
--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -70,7 +70,7 @@ sed -i -e 's/localhost:24817/pulp/g' generate.sh
 sed -i -e 's/:24817/pulp/g' generate.sh
 cd ..
 
-git clone --depth=1 https://github.com/pulp/pulpcore.git --branch master
+git clone --depth=1 https://github.com/pulp/pulpcore.git --branch 3.5
 
 cd pulpcore
 if [ -n "$PULPCORE_PR_NUMBER" ]; then

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -53,7 +53,7 @@ image:
   tag: "${TAG}"
 plugins:
   - name: pulpcore
-    source: pulpcore
+    source: pulpcore>=3.4,<3.6
   - name: pulp_rpm
     source: ./pulp_rpm
 services:

--- a/template_config.yml
+++ b/template_config.yml
@@ -23,8 +23,8 @@ plugin_dash_short: rpm
 plugin_name: pulp_rpm
 plugin_snake: pulp_rpm
 pulp_settings: null
-pulpcore_branch: master
-pulpcore_pip_version_specifier: null
+pulpcore_branch: "3.5"
+pulpcore_pip_version_specifier: ">=3.4,<3.6"
 pydocstyle: true
 pypi_username: pulp
 redmine_project: pulp_rpm
@@ -37,5 +37,5 @@ test_performance:
 test_s3: true
 travis_addtl_services: []
 travis_notifications: None
-update_redmine: true 
+update_redmine: true
 


### PR DESCRIPTION
It would get the wrong pulpcore version and it would break the CI due to OpenAPI change.
We've updated the release guide:
https://pulp.plan.io/projects/pulp/wiki/Pulp3_Release_Guide#Preparing-a-Y-release

[noissue]
[nocoverage]