### PR TITLE
Assuring pulpcore 3.6.z

### DIFF
--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -70,7 +70,7 @@ sed -i -e 's/localhost:24817/pulp/g' generate.sh
 sed -i -e 's/:24817/pulp/g' generate.sh
 cd ..
 
-git clone --depth=1 https://github.com/pulp/pulpcore.git --branch master
+git clone --depth=1 https://github.com/pulp/pulpcore.git --branch 3.6
 
 cd pulpcore
 if [ -n "$PULPCORE_PR_NUMBER" ]; then

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -53,7 +53,7 @@ image:
   tag: "${TAG}"
 plugins:
   - name: pulpcore
-    source: pulpcore
+    source: pulpcore>=3.6,<3.7
   - name: pulp_rpm
     source: ./pulp_rpm
 services:

--- a/template_config.yml
+++ b/template_config.yml
@@ -27,8 +27,8 @@ pulp_settings:
   - /tmp
   allowed_import_paths:
   - /tmp
-pulpcore_branch: master
-pulpcore_pip_version_specifier: null
+pulpcore_branch: "3.6"
+pulpcore_pip_version_specifier: ">=3.6,<3.7"
 pydocstyle: true
 pypi_username: pulp
 redmine_project: pulp_rpm


### PR DESCRIPTION
We've added the step 6:
https://pulp.plan.io/projects/pulp/wiki/Pulp3_Release_Guide#Preparing-a-Y-release