### PR TITLE
Drop --local-sqlite for createrepo_c to avoid thrashing /tmp

### DIFF
--- a/plugins/pulp_rpm/plugins/distributors/yum/publish.py
+++ b/plugins/pulp_rpm/plugins/distributors/yum/publish.py
@@ -1186,7 +1186,7 @@ class GenerateSqliteForRepoStep(platform_steps.PluginStep):
         Call out to createrepo command line in order to process the files.
         """
         checksum_type = self.parent.get_checksum_type()
-        pipe = subprocess.Popen('sqliterepo_c --local-sqlite -f '
+        pipe = subprocess.Popen('sqliterepo_c -f '
                                 '--checksum %(checksum_type)s '
                                 '%(content_dir)s' %
                                 {'checksum_type': checksum_type,

--- a/plugins/test/unit/plugins/distributors/yum/test_publish.py
+++ b/plugins/test/unit/plugins/distributors/yum/test_publish.py
@@ -1492,7 +1492,7 @@ class GenerateSqliteForRepoStepTests(BaseYumDistributorPublishStepTests):
         step.parent = mock.MagicMock()
         step.parent.get_checksum_type.return_value = 'sha1'
         step.process_main()
-        Popen.assert_called_once_with('sqliterepo_c --local-sqlite -f '
+        Popen.assert_called_once_with('sqliterepo_c -f '
                                       '--checksum sha1 '
                                       '/foo',
                                       shell=True, stderr=mock.ANY, stdout=mock.ANY)


### PR DESCRIPTION
This PR reverts commit ca24ae299 which has been introduced in https://pulp.plan.io/issues/1157 as internal (and no longer valid)
need for the former RCM team.

Currently, the _--local-sqlite_ causes _createrepo_c_ to write to _TMPDIR_ instead of its usual output directory, which causes huge sqlite files to be left under /tmp after cancelled or failed Pulp tasks. /tmp is oftentimes fairly small and this may cause the filesystem to fill up quickly. Pulp already has the concept of creating a temporary working directory for each task under /var/lib/pulp/working and cleaning it up at the end.

Redmine issue for this PR: https://pulp.plan.io/issues/7505

cc @midnightercz, @rohanpm, @ipanova, @goosemania 