### PR TITLE
Sync through proxy fix

### DIFF
--- a/CHANGES/7321.bugfix
+++ b/CHANGES/7321.bugfix
@@ -1,0 +1,1 @@
+Fix sync using proxy server.

--- a/pulp_rpm/app/downloaders.py
+++ b/pulp_rpm/app/downloaders.py
@@ -84,7 +84,7 @@ class RpmDownloader(HttpDownloader):
         else:
             url = self.url
 
-        async with self.session.get(url) as response:
+        async with self.session.get(url, proxy=self.proxy, auth=self.auth) as response:
             self.raise_for_status(response)
             to_return = await self._handle_response(response)
             await response.release()


### PR DESCRIPTION
Fix sync using proxy server.
Custom downloader doesn't passed proxy info.

[nocoverage]

closes: #7321
https://pulp.plan.io/issues/7321