### PR TITLE
Comps and dist_trees removal

### DIFF
--- a/CHANGES/7431.bugfix
+++ b/CHANGES/7431.bugfix
@@ -1,0 +1,1 @@
+User should not be able to remove distribution trees, custom repository metadata and comps if they are used in repository.

--- a/coverage.md
+++ b/coverage.md
@@ -46,6 +46,7 @@ Manual Coverage
 | Dependencies can be solved for RPM packages which depend on specific files (such as /usr/bin/bash) present only in filelists.xml | NO | needs a fixture change/improvement |
 | **Remove** |  |  |
 | As a user, when a module is removed, its packages are removed as well ( not referenced by other modules) | NO |  |
+| As a user, I can't remove content when it is used in a repository | PART | covered list in test_crud_content |
 | **Consumer cases** |  |  |
 | As a user, I can use dnf to install all the content served by Pulp | PART | only covers rpm installation |
 | **Retention** |  |  |

--- a/pulp_rpm/app/viewsets.py
+++ b/pulp_rpm/app/viewsets.py
@@ -2,7 +2,7 @@ from django_filters import CharFilter
 from gettext import gettext as _
 
 from drf_spectacular.utils import extend_schema
-from rest_framework import viewsets, mixins
+from rest_framework import viewsets
 from rest_framework.decorators import action
 from rest_framework.serializers import ValidationError as DRFValidationError
 
@@ -321,8 +321,7 @@ class CopyViewSet(viewsets.ViewSet):
         return result, repos
 
 
-class PackageGroupViewSet(ReadOnlyContentViewSet,
-                          mixins.DestroyModelMixin):
+class PackageGroupViewSet(ReadOnlyContentViewSet):
     """
     PackageGroup ViewSet.
     """
@@ -332,8 +331,7 @@ class PackageGroupViewSet(ReadOnlyContentViewSet,
     serializer_class = PackageGroupSerializer
 
 
-class PackageCategoryViewSet(ReadOnlyContentViewSet,
-                             mixins.DestroyModelMixin):
+class PackageCategoryViewSet(ReadOnlyContentViewSet):
     """
     PackageCategory ViewSet.
     """
@@ -343,8 +341,7 @@ class PackageCategoryViewSet(ReadOnlyContentViewSet,
     serializer_class = PackageCategorySerializer
 
 
-class PackageEnvironmentViewSet(ReadOnlyContentViewSet,
-                                mixins.DestroyModelMixin):
+class PackageEnvironmentViewSet(ReadOnlyContentViewSet):
     """
     PackageEnvironment ViewSet.
     """
@@ -354,8 +351,7 @@ class PackageEnvironmentViewSet(ReadOnlyContentViewSet,
     serializer_class = PackageEnvironmentSerializer
 
 
-class PackageLangpacksViewSet(ReadOnlyContentViewSet,
-                              mixins.DestroyModelMixin):
+class PackageLangpacksViewSet(ReadOnlyContentViewSet):
     """
     PackageLangpacks ViewSet.
     """
@@ -365,8 +361,7 @@ class PackageLangpacksViewSet(ReadOnlyContentViewSet,
     serializer_class = PackageLangpacksSerializer
 
 
-class DistributionTreeViewSet(ReadOnlyContentViewSet,
-                              mixins.DestroyModelMixin):
+class DistributionTreeViewSet(ReadOnlyContentViewSet):
     """
     Distribution Tree Viewset.
 
@@ -377,8 +372,7 @@ class DistributionTreeViewSet(ReadOnlyContentViewSet,
     serializer_class = DistributionTreeSerializer
 
 
-class RepoMetadataFileViewSet(ReadOnlyContentViewSet,
-                              mixins.DestroyModelMixin):
+class RepoMetadataFileViewSet(ReadOnlyContentViewSet):
     """
     RepoMetadataFile Viewset.
 

--- a/pulp_rpm/tests/functional/api/test_copy.py
+++ b/pulp_rpm/tests/functional/api/test_copy.py
@@ -19,7 +19,6 @@ from pulp_rpm.tests.functional.constants import (
     PULP_TYPE_PACKAGE,
     PULP_TYPE_PACKAGE_CATEGORY,
     PULP_TYPE_PACKAGE_GROUP,
-    RPM_KICKSTART_CONTENT_NAME,
     RPM_FIXTURE_SUMMARY,
     RPM_KICKSTART_FIXTURE_URL,
     RPM_KICKSTART_FIXTURE_SUMMARY,
@@ -69,9 +68,6 @@ class BaseCopy(PulpTestCase):
                          f"{source_repo['pulp_href']}versions/0/")
         sync(self.cfg, remote, source_repo)
         source_repo = self.client.get(source_repo['pulp_href'])
-
-        for kickstart_content in get_content(source_repo).get(RPM_KICKSTART_CONTENT_NAME, []):
-            self.addCleanup(self.client.delete, kickstart_content['pulp_href'])
 
         # Check that we have the correct content counts.
         self.assertDictEqual(get_content_summary(source_repo), summary)

--- a/pulp_rpm/tests/functional/constants.py
+++ b/pulp_rpm/tests/functional/constants.py
@@ -292,6 +292,9 @@ RPM_ADVISORY_TEST_REMOVE_COUNT = 3
 RPM_ADVISORY_TEST_ADDED_COUNT = 6
 
 
+RPM_REPO_METADATA_FIXTURE_URL = urljoin(PULP_FIXTURES_BASE_URL, 'rpm-repo-metadata/')
+"""The URL to RPM repository with custom repository metadata."""
+
 RPM_UPDATERECORD_RPM_NAME = 'gorilla'
 """The name of the RPM named by :data:`RPM_UPDATERECORD_ID`."""
 


### PR DESCRIPTION
User should not be able to remove distribution trees and comps if they are used in repository.
If they are not in repo they will be removed with orphan cleanup as other content.

closes: #7431
https://pulp.plan.io/issues/7431