### PR TITLE
Insure that makedirs() results in directories group can write to.

### DIFF
--- a/handlers/pulp_rpm/handlers/repo_file.py
+++ b/handlers/pulp_rpm/handlers/repo_file.py
@@ -3,6 +3,7 @@ import shutil
 
 from iniparse import ConfigParser
 from pulp.common.util import encode_unicode
+from pulp.plugins.util import misc
 
 
 class Repo(dict):
@@ -409,7 +410,7 @@ class RepoKeyFiles(object):
         # If there are any keys to write, create the directory for the repo's keys
         # and write each of them out
         if len(self.keys) > 0:
-            os.makedirs(self.repo_keys_dir)
+            misc.mkdir(self.repo_keys_dir)
 
             for filename in self.keys:
                 f = open(filename, 'w')
@@ -459,7 +460,7 @@ class CertFiles(object):
         if not self.clientcert:
             return None
 
-        self.__mkdir()
+        misc.mkdir(self.rootdir)
         path = os.path.join(self.rootdir, self.CLIENT)
         f = open(path, 'w')
         f.write(self.clientcert)
@@ -468,10 +469,6 @@ class CertFiles(object):
 
     def __nocerts(self):
         return not self.clientcert
-
-    def __mkdir(self):
-        if not os.path.exists(self.rootdir):
-            os.makedirs(self.rootdir)
 
     def __clear(self):
         if os.path.exists(self.rootdir):

--- a/plugins/pulp_rpm/plugins/distributors/export_distributor/generate_iso.py
+++ b/plugins/pulp_rpm/plugins/distributors/export_distributor/generate_iso.py
@@ -7,6 +7,7 @@ import tempfile
 import hashlib
 from stat import ST_SIZE
 from pulp.server.util import md5 as pulp_md5
+from pulp.plugins.util import misc
 
 from pulp_rpm.yum_plugin.util import getLogger
 
@@ -77,7 +78,7 @@ def _make_iso(file_list, target_dir, output_dir, filename):
 
     # If the output directory doesn't exist, make it
     if not os.path.isdir(output_dir):
-        os.makedirs(output_dir)
+        misc.mkdir(output_dir)
 
     # Create a pathspec file using the files in this image.
     pathspec_file = _get_pathspec_file(file_list, target_dir)

--- a/plugins/pulp_rpm/plugins/distributors/yum/metadata/metadata.py
+++ b/plugins/pulp_rpm/plugins/distributors/yum/metadata/metadata.py
@@ -4,6 +4,8 @@ import os
 import traceback
 from gettext import gettext as _
 
+from pulp.plugins.util import misc
+
 from pulp_rpm.yum_plugin import util
 
 _LOG = util.getLogger(__name__)
@@ -119,10 +121,8 @@ class MetadataFileContext(object):
         if not os.path.exists(self.metadata_file_path):
 
             parent_dir = os.path.dirname(self.metadata_file_path)
-
             if not os.path.exists(parent_dir):
-                os.makedirs(parent_dir, mode=0770)
-
+                misc.mkdir(parent_dir, mode=0770)
             elif not os.access(parent_dir, os.R_OK | os.W_OK | os.X_OK):
                 msg = _('Insufficient permissions to write metadata file in directory [%(d)s]')
                 raise RuntimeError(msg % {'d': parent_dir})

--- a/plugins/pulp_rpm/plugins/distributors/yum/publish.py
+++ b/plugins/pulp_rpm/plugins/distributors/yum/publish.py
@@ -240,7 +240,7 @@ class ExportRepoGroupPublisher(platform_steps.PluginStep):
             publisher.description = _("Exporting Repo: %s") % repo.id
             self.add_child(publisher)
         if empty_repos:
-            os.makedirs(realized_dir)
+            plugin_misc.mkdir(realized_dir)
             self.add_child(GenerateListingFileStep(realized_dir, realized_dir))
 
         # If we aren't exporting to a directory add the ISO create & publish steps
@@ -782,8 +782,7 @@ class PublishRpmAndDrpmStepIncremental(platform_steps.UnitModelPluginStep):
         Its existence is required by the CopyDirectoryStep.
         """
         super(PublishRpmAndDrpmStepIncremental, self).initialize()
-        if not os.path.exists(self.get_working_dir()):
-            os.makedirs(self.get_working_dir())
+        plugin_misc.mkdir(self.get_working_dir())
 
     @property
     def unit_querysets(self):

--- a/plugins/pulp_rpm/plugins/importers/yum/parse/treeinfo.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/parse/treeinfo.py
@@ -13,6 +13,8 @@ from mongoengine import NotUniqueError, Q
 from nectar.listener import AggregatingEventListener
 from nectar.request import DownloadRequest
 
+from pulp.plugins.util import misc
+
 from pulp.server.db.model import LazyCatalogEntry, RepositoryContentUnit
 from pulp.server.exceptions import PulpCodedValidationException
 from pulp.server.controllers import repository as repo_controller
@@ -358,8 +360,7 @@ class DistSync(object):
         """
         destination = os.path.join(tmp_dir, file_dict[RELATIVE_PATH])
         # make directories such as "images"
-        if not os.path.exists(os.path.dirname(destination)):
-            os.makedirs(os.path.dirname(destination))
+        misc.mkdir(os.path.dirname(destination))
         return DownloadRequest(
             os.path.join(self.feed, file_dict[RELATIVE_PATH]),
             destination,


### PR DESCRIPTION
Tracked down a lot of makedirs() calls and replaced them with misc.mkdir()

Note: required-PR is needed to fix the permission problem, but the code
will build/work without it.

fixes #7653
Required PR: https://github.com/pulp/pulp/pull/4000