### PR TITLE
treeinfo download fix

### DIFF
--- a/CHANGES/7691.bugfix
+++ b/CHANGES/7691.bugfix
@@ -1,0 +1,1 @@
+Added handling of HTTP 403 Forbidden during DistributionTree detection.

--- a/pulp_rpm/app/downloaders.py
+++ b/pulp_rpm/app/downloaders.py
@@ -58,7 +58,7 @@ class RpmDownloader(HttpDownloader):
         Raise error if aiohttp response status is >= 400 and not silenced.
 
         Raises:
-            FileNotFoundError: If aiohttp response status is 404 and silenced.
+            FileNotFoundError: If aiohttp response status is 403 or 404 and silenced.
             aiohttp.ClientResponseError: If the response status is 400 or higher and not silenced.
 
         """
@@ -67,7 +67,7 @@ class RpmDownloader(HttpDownloader):
         if not silenced:
             response.raise_for_status()
 
-        if response.status == 404:
+        if response.status in (404, 403):
             raise FileNotFoundError()
 
     async def _run(self, extra_data=None):

--- a/pulp_rpm/app/kickstart/treeinfo.py
+++ b/pulp_rpm/app/kickstart/treeinfo.py
@@ -22,7 +22,7 @@ def get_treeinfo_data(remote, remote_url):
     namespaces = [".treeinfo", "treeinfo"]
     for namespace in namespaces:
         downloader = remote.get_downloader(
-            url=urljoin(remote_url, namespace), silence_errors_for_response_status_codes={404}
+            url=urljoin(remote_url, namespace), silence_errors_for_response_status_codes={403, 404}
         )
 
         try:


### PR DESCRIPTION
When .treeinfo file is missing, server returns HTTP 403 instead of HTTP 404 if the autoindex is disabled on the server.

closes: #7691
https://pulp.plan.io/issues/7691

[nocoverage]