### PR TITLE
Performance test dist tree removal fix

### DIFF
--- a/CHANGES/7807.misc
+++ b/CHANGES/7807.misc
@@ -1,0 +1,1 @@
+Update sync and publish performance tests to be up to date with latest changes.

--- a/pulp_rpm/tests/performance/test_publish.py
+++ b/pulp_rpm/tests/performance/test_publish.py
@@ -13,13 +13,11 @@ from pulp_smash.pulp3.utils import (
     delete_orphans,
     gen_repo,
     get_added_content_summary,
-    get_content,
     get_content_summary,
 )
 
 from pulp_rpm.tests.functional.constants import (
     RPM_DISTRIBUTION_PATH,
-    RPM_KICKSTART_CONTENT_NAME,
     RPM_PACKAGE_CONTENT_NAME,
     RPM_KICKSTART_FIXTURE_URL,
     RPM_PUBLICATION_PATH,
@@ -121,8 +119,6 @@ class PublishTestCase(unittest.TestCase):
         ))
 
         repo = self.client.get(repo['pulp_href'])
-        for kickstart_content in get_content(repo)[RPM_KICKSTART_CONTENT_NAME]:
-            self.addCleanup(self.client.delete, kickstart_content['pulp_href'])
 
         # Check that we have the correct content counts.
         self.assertIsNotNone(repo['latest_version_href'])

--- a/pulp_rpm/tests/performance/test_sync.py
+++ b/pulp_rpm/tests/performance/test_sync.py
@@ -19,7 +19,6 @@ from pulp_rpm.tests.functional.constants import (
     PULP_TYPE_REPOMETADATA,
     RPM_CDN_APPSTREAM_URL,
     RPM_CDN_BASEOS_URL,
-    RPM_KICKSTART_CONTENT_NAME,
     RPM_KICKSTART_FIXTURE_SUMMARY,
     RPM_KICKSTART_FIXTURE_URL,
     RPM_REMOTE_PATH,
@@ -111,8 +110,6 @@ class SyncTestCase(unittest.TestCase):
         ))
 
         repo = self.client.get(repo['pulp_href'])
-        for kickstart_content in get_content(repo)[RPM_KICKSTART_CONTENT_NAME]:
-            self.addCleanup(self.client.delete, kickstart_content['pulp_href'])
 
         # Check that we have the correct content counts.
         self.assertIsNotNone(repo['latest_version_href'])


### PR DESCRIPTION
Distribution trees can't be removed directly with api call,
orphan_cleanup must be used

closes: #7807
https://pulp.plan.io/issues/7807