### PR TITLE
Cherry pick of "Remove duplicated Repository.new_version() method"

### DIFF
--- a/CHANGES/7844.bugfix
+++ b/CHANGES/7844.bugfix
@@ -1,0 +1,1 @@
+Fixed duplicate key error after incomplete sync task.

--- a/pulp_rpm/app/models/repository.py
+++ b/pulp_rpm/app/models/repository.py
@@ -6,10 +6,7 @@ from logging import getLogger
 from aiohttp.web_response import Response
 from django.conf import settings
 from django.contrib.postgres.fields import JSONField
-from django.db import (
-    models,
-    transaction,
-)
+from django.db import models, transaction
 from pulpcore.plugin.download import DownloaderFactory
 from pulpcore.plugin.models import (
     Artifact,
@@ -164,6 +161,10 @@ class RpmRepository(Repository):
 
         """
         with transaction.atomic():
+            latest_version = self.versions.latest()
+            if not latest_version.complete:
+                latest_version.delete()
+
             version = RepositoryVersion(
                 repository=self,
                 number=int(self.next_version),


### PR DESCRIPTION
Remove duplicated Repository.new_version() method

Required PR: https://github.com/pulp/pulpcore/pull/902/

[nocoverage]

related to #6463
https://pulp.plan.io/issues/6463

fixes #7844

(cherry picked from commit ef7033b640a0dc26cc20c7e341cac7b42c13a771)