### PR TITLE
Stop testing CentOS 6 because it's no longer available.

### DIFF
--- a/pulp_rpm/tests/functional/constants.py
+++ b/pulp_rpm/tests/functional/constants.py
@@ -356,7 +356,6 @@ RPM_CUSTOM_REPO_METADATA_CHANGED_FIXTURE_URL = urljoin(
     PULP_FIXTURES_BASE_URL, "rpm-repo-metadata-changed/"
 )
 
-CENTOS6_URL = "http://mirror.centos.org/centos-6/6.10/os/x86_64/"
 CENTOS7_URL = "http://mirror.linux.duke.edu/pub/centos/7/os/x86_64/"
 CENTOS8_KICKSTART_APP_URL = "http://mirror.linux.duke.edu/pub/centos/8/AppStream/x86_64/kickstart/"
 CENTOS8_KICKSTART_BASEOS_URL = "http://mirror.linux.duke.edu/pub/centos/8/BaseOS/x86_64/kickstart/"

--- a/pulp_rpm/tests/performance/test_publish.py
+++ b/pulp_rpm/tests/performance/test_publish.py
@@ -23,7 +23,6 @@ from pulp_rpm.tests.functional.constants import (
     RPM_PUBLICATION_PATH,
     RPM_REMOTE_PATH,
     RPM_REPO_PATH,
-    CENTOS6_URL,
     CENTOS7_URL,
     CENTOS8_APPSTREAM_URL,
     CENTOS8_BASEOS_URL,
@@ -154,10 +153,6 @@ class PublishTestCase(unittest.TestCase):
     def test_epel7(self):
         """Publish EPEL 7."""
         self.rpm_publish(url=EPEL7_URL)
-
-    def test_centos6(self):
-        """Publish CentOS 6."""
-        self.rpm_publish(url=CENTOS6_URL)
 
     def test_centos7(self):
         """Publish CentOS 7."""


### PR DESCRIPTION
The CentOS 6 repos have now only the readme file http://mirror.centos.org/centos-6/6/readme in them.

[noissue]