### PR TITLE
Fix a mistake when producing RPM dependencies.

### DIFF
--- a/CHANGES/8114.bugfix
+++ b/CHANGES/8114.bugfix
@@ -1,0 +1,1 @@
+Fixed a mistake in dependency calculation code which could result in incorrect copy results and errors.

--- a/pulp_rpm/app/depsolving.py
+++ b/pulp_rpm/app/depsolving.py
@@ -153,7 +153,7 @@ def rpm_to_solvable(solv_repo, unit):
     name = unit.get("name")
     solvable.name = name
 
-    evr = libsolv_formatted_evr(unit.get("epoch"), unit.get("version"), unit.get("arch"))
+    evr = libsolv_formatted_evr(unit.get("epoch"), unit.get("version"), unit.get("release"))
     solvable.evr = evr
 
     arch = unit.get("arch", "noarch")


### PR DESCRIPTION
Mistake copied from Pulp 2.

re: #8110
https://pulp.plan.io/issues/8110