### PR TITLE
Fix pulp depsolv issue when copy rpms with recursive config 2/2

### DIFF
--- a/plugins/pulp_rpm/plugins/importers/yum/pulp_solv.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/pulp_solv.py
@@ -302,7 +302,7 @@ def rpm_dependency_conversion(solvable, unit, attr_name, dependency_key=None):
         unit_name = unit_name.encode('utf-8')
 
     unit_flags = unit.get('flags')
-    unit_evr = libsolv_formatted_evr(unit.get('epoch'), unit.get('version'), unit.get('arch'))
+    unit_evr = libsolv_formatted_evr(unit.get('epoch'), unit.get('version'), unit.get('release'))
 
     # e.g SOLVABLE_PROVIDES, SOLVABLE_REQUIRES...
     keyname = dependency_key or getattr(solv, 'SOLVABLE_{}'.format(attr_name.upper()))


### PR DESCRIPTION
This completes the commit d62c61f where pulp solves wrong dependencies
because wrong evr is parsed to the solvable unit.

closes: #8110
https://pulp.plan.io/issues/8110

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>