### PR TITLE
remove custom fixture url

### DIFF
--- a/.ci/ansible/smash-config.json
+++ b/.ci/ansible/smash-config.json
@@ -29,8 +29,5 @@
         }
       }
     }
-  ],
-  "custom": {
-    "fixtures_origin": "http://pulp-fixtures:8080/"
-  }
+  ]
 }


### PR DESCRIPTION
We are not build fixtures but using hosted.

[noissue]
[nocoverage]