### PR TITLE
Remove extraneous coding= from tests - Python3 is always UTF8.

### DIFF
--- a/CHANGES/8223.misc
+++ b/CHANGES/8223.misc
@@ -1,0 +1,1 @@
+Removed extraneous coding= directive from test-files.

--- a/pulp_rpm/tests/functional/__init__.py
+++ b/pulp_rpm/tests/functional/__init__.py
@@ -1,2 +1,1 @@
-# coding=utf-8
 """Tests for file plugin."""

--- a/pulp_rpm/tests/functional/api/__init__.py
+++ b/pulp_rpm/tests/functional/api/__init__.py
@@ -1,2 +1,1 @@
-# coding=utf-8
 """Tests that communicate with file plugin via the v3 API."""

--- a/pulp_rpm/tests/functional/api/test_advisory_upload.py
+++ b/pulp_rpm/tests/functional/api/test_advisory_upload.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 """Tests that perform actions over advisory content unit upload."""
 import os
 import json

--- a/pulp_rpm/tests/functional/api/test_character_encoding.py
+++ b/pulp_rpm/tests/functional/api/test_character_encoding.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 """Tests for Pulp's characters encoding."""
 from urllib.parse import urljoin
 

--- a/pulp_rpm/tests/functional/api/test_consume_content.py
+++ b/pulp_rpm/tests/functional/api/test_consume_content.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 """Verify whether package manager, yum/dnf, can consume content from Pulp."""
 import unittest
 import itertools

--- a/pulp_rpm/tests/functional/api/test_copy.py
+++ b/pulp_rpm/tests/functional/api/test_copy.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 """Tests that sync rpm plugin repositories."""
 from random import choice
 from requests.exceptions import HTTPError

--- a/pulp_rpm/tests/functional/api/test_crud_content_unit.py
+++ b/pulp_rpm/tests/functional/api/test_crud_content_unit.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 """Tests that perform actions over content unit."""
 import requests
 

--- a/pulp_rpm/tests/functional/api/test_crud_remotes.py
+++ b/pulp_rpm/tests/functional/api/test_crud_remotes.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 """Tests that CRUD rpm remotes."""
 from random import choice
 

--- a/pulp_rpm/tests/functional/api/test_distribution_tree.py
+++ b/pulp_rpm/tests/functional/api/test_distribution_tree.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 """Tests distribution trees."""
 
 from pulp_smash import config

--- a/pulp_rpm/tests/functional/api/test_download_content.py
+++ b/pulp_rpm/tests/functional/api/test_download_content.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 """Tests that verify download of content served by Pulp."""
 import hashlib
 from random import choice

--- a/pulp_rpm/tests/functional/api/test_download_policies.py
+++ b/pulp_rpm/tests/functional/api/test_download_policies.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 """Tests for Pulp`s download policies."""
 from pulp_smash.pulp3.bindings import PulpTestCase, monitor_task
 from pulp_smash.pulp3.utils import gen_repo, get_added_content_summary, get_content_summary

--- a/pulp_rpm/tests/functional/api/test_fips_workflow.py
+++ b/pulp_rpm/tests/functional/api/test_fips_workflow.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 """Tests that create/sync/distribute/publish MANY rpm plugin repositories."""
 import os
 import re

--- a/pulp_rpm/tests/functional/api/test_publish.py
+++ b/pulp_rpm/tests/functional/api/test_publish.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 """Tests that publish rpm plugin repositories."""
 import gzip
 import os

--- a/pulp_rpm/tests/functional/api/test_pulp_to_pulp.py
+++ b/pulp_rpm/tests/functional/api/test_pulp_to_pulp.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 """Tests that verify download of content served by Pulp."""
 from pulp_smash.pulp3.bindings import PulpTestCase, monitor_task
 from pulp_smash.pulp3.constants import ON_DEMAND_DOWNLOAD_POLICIES

--- a/pulp_rpm/tests/functional/api/test_pulpexport.py
+++ b/pulp_rpm/tests/functional/api/test_pulpexport.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 """
 Tests PulpExporter and PulpExport functionality.
 

--- a/pulp_rpm/tests/functional/api/test_retention_policy.py
+++ b/pulp_rpm/tests/functional/api/test_retention_policy.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 """Tests for the retention policy feature of repositories."""
 
 from collections import defaultdict

--- a/pulp_rpm/tests/functional/api/test_sync.py
+++ b/pulp_rpm/tests/functional/api/test_sync.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 """Tests that sync rpm plugin repositories."""
 import os
 import unittest

--- a/pulp_rpm/tests/functional/api/test_upload.py
+++ b/pulp_rpm/tests/functional/api/test_upload.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 """Tests that perform actions over content unit."""
 import os
 from tempfile import NamedTemporaryFile

--- a/pulp_rpm/tests/functional/constants.py
+++ b/pulp_rpm/tests/functional/constants.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 """Constants for Pulp RPM plugin tests."""
 from urllib.parse import urljoin
 

--- a/pulp_rpm/tests/functional/utils.py
+++ b/pulp_rpm/tests/functional/utils.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 """Utilities for tests for the rpm plugin."""
 import os
 import requests

--- a/pulp_rpm/tests/performance/test_publish.py
+++ b/pulp_rpm/tests/performance/test_publish.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 """Tests that publish rpm plugin repositories."""
 import unittest
 from datetime import datetime

--- a/pulp_rpm/tests/performance/test_pulp_to_pulp.py
+++ b/pulp_rpm/tests/performance/test_pulp_to_pulp.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 """Tests that verify download of content served by Pulp."""
 import unittest
 

--- a/pulp_rpm/tests/performance/test_sync.py
+++ b/pulp_rpm/tests/performance/test_sync.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 """Tests that sync rpm plugin repositories."""
 import os
 import unittest


### PR DESCRIPTION
fixes #8223
[nocoverage]