### PR TITLE
Improve the performance of syncing repository

### DIFF
--- a/plugins/pulp_rpm/plugins/controllers/errata.py
+++ b/plugins/pulp_rpm/plugins/controllers/errata.py
@@ -16,8 +16,11 @@ def create_or_update_pkglist(erratum, repo_id):
     new_pkglist = ErratumPkglist(errata_id=erratum.errata_id,
                                  repo_id=repo_id,
                                  collections=erratum.pkglist)
+
+    has_changed = False
     try:
         new_pkglist.save()
+        has_changed = True
     except mongoengine.NotUniqueError:
         # check if erratum unit exists or should be updated, if so - update its pkglist
         existing_erratum = Errata.objects.filter(**erratum.unit_key).first()
@@ -26,5 +29,7 @@ def create_or_update_pkglist(erratum, repo_id):
             existing_pkglist = ErratumPkglist.objects.filter(**new_pkglist.model_key).first()
             existing_pkglist.collections = new_pkglist.collections
             existing_pkglist.save()
+            has_changed = True
     # pkglist is saved to a separate collection, we no longer need it in the erratum unit itself
     erratum.pkglist = []
+    return has_changed

--- a/plugins/pulp_rpm/plugins/importers/yum/existing.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/existing.py
@@ -125,10 +125,11 @@ def check_all_and_associate(wanted, conduit, config, download_deferred, catalog)
     sorted_units = _sort_by_type(wanted.iterkeys())
     for unit_type, values in sorted_units.iteritems():
         model = plugin_api.get_unit_model_by_id(unit_type)
-        # FIXME "fields" does not get used, but it should
-        # fields = model.unit_key_fields + ('_storage_path',)
+        extra_fields = ('_storage_path', 'filename', '_content_type_id', 'id', 'downloaded',
+                        '_last_updated',)
+        fields = model.unit_key_fields + extra_fields
         unit_generator = (model(**unit_tuple._asdict()) for unit_tuple in values.copy())
-        for unit in units_controller.find_units(unit_generator):
+        for unit in units_controller.find_units(unit_generator, fields=fields):
             is_rpm_drpm_srpm = unit_type in rpm_drpm_srpm
             file_exists = unit._storage_path is not None and os.path.isfile(unit._storage_path)
             if is_rpm_drpm_srpm:

--- a/plugins/pulp_rpm/plugins/importers/yum/repomd/group.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/repomd/group.py
@@ -61,6 +61,13 @@ def process_group_element(repo_id, element):
     return unit
 
 
+def process_group_element_id_only(repo_id, element):
+    unit = models.PackageGroup()
+    unit.package_group_id = element.find('id').text
+    unit.repo_id = repo_id
+    return unit
+
+
 def process_category_element(repo_id, element):
     """
     Process one XML block from comps.xml and return a models.PackageCategory instance
@@ -88,6 +95,13 @@ def process_category_element(repo_id, element):
     unit.repo_id = repo_id
     unit.translated_description = translated_description
     unit.translated_name = translated_name
+    return unit
+
+
+def process_category_element_id_only(repo_id, element):
+    unit = models.PackageCategory()
+    unit.package_category_id = element.find('id').text
+    unit.repo_id = repo_id
     return unit
 
 
@@ -127,6 +141,13 @@ def process_environment_element(repo_id, element):
     unit.translated_description = translated_description
     unit.translated_name = translated_name
     unit.options = options
+    return unit
+
+
+def process_environment_element_id_only(repo_id, element):
+    unit = models.PackageEnvironment()
+    unit.package_environment_id = element.find('id').text
+    unit.repo_id = repo_id
     return unit
 
 

--- a/plugins/pulp_rpm/plugins/importers/yum/repomd/updateinfo.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/repomd/updateinfo.py
@@ -87,6 +87,13 @@ def process_package_element(element):
     return models.Errata(**package_info)
 
 
+def process_package_element_errata_id_only(element):
+    package_info = {
+        'errata_id': element.find('id').text,
+    }
+    return models.Errata(**package_info)
+
+
 def _parse_reference(element):
     return {
         # evidence shows that the "id" attribute is sometimes missing, such as


### PR DESCRIPTION
The codes fixes the following issues:
- Avoid reading unwanted repo metadata fields (such as Primary.xml, Updateinfo.xml) while determining units to download
- Avoid reading unwanted repo metadata fields (such as Primary.xml, Updateinfo.xml) when removing missing units (Mirror on Sync)
- Improve the query to purge duplicate units. Previously, it read the whole units_rpm collection (the largest collection). Once the collection reached millions of records it become very slow.
- Skipping repository publishing if Errata, Yum repo metadata and Comps are not changed. Previously, it would be triggered on every full sync.


closes: #8306
https://pulp.plan.io/issues/8306