### PR TITLE
Teach pulp_rpm to only use urljoin() where it really needs urljoin().

### DIFF
--- a/CHANGES/7995.bugfix
+++ b/CHANGES/7995.bugfix
@@ -1,0 +1,3 @@
+Taught pulp_rpm how to handle remotes whose URLs do not end in '/'.
+
+Specifically, some mirrors (e.g. Amazon2) return remotes like this.

--- a/pulp_rpm/app/downloaders.py
+++ b/pulp_rpm/app/downloaders.py
@@ -1,7 +1,7 @@
 from logging import getLogger
-from urllib.parse import urljoin
 
 from pulpcore.plugin.download import FileDownloader, HttpDownloader
+from pulp_rpm.app.shared_utils import urlpath_sanitize
 
 
 log = getLogger(__name__)
@@ -81,7 +81,7 @@ class RpmDownloader(HttpDownloader):
         """
         if self.sles_auth_token:
             auth_param = f"?{self.sles_auth_token}"
-            url = urljoin(self.url, auth_param)
+            url = urlpath_sanitize(self.url, auth_param)
         else:
             url = self.url
 

--- a/pulp_rpm/app/kickstart/treeinfo.py
+++ b/pulp_rpm/app/kickstart/treeinfo.py
@@ -1,7 +1,6 @@
 import json
 from gettext import gettext as _
 from configparser import MissingSectionHeaderError
-from urllib.parse import urljoin
 
 from django.utils.timezone import now
 
@@ -9,6 +8,7 @@ from productmd.common import SortedConfigParser
 from productmd.treeinfo import TreeInfo
 
 from pulp_rpm.app.constants import DIST_TREE_MAIN_REPO_PATH, PACKAGES_DIRECTORY
+from pulp_rpm.app.shared_utils import urlpath_sanitize
 
 
 def get_treeinfo_data(remote, remote_url):
@@ -20,7 +20,8 @@ def get_treeinfo_data(remote, remote_url):
     namespaces = [".treeinfo", "treeinfo"]
     for namespace in namespaces:
         downloader = remote.get_downloader(
-            url=urljoin(remote_url, namespace), silence_errors_for_response_status_codes={403, 404}
+            url=urlpath_sanitize(remote_url, namespace),
+            silence_errors_for_response_status_codes={403, 404},
         )
 
         try:

--- a/pulp_rpm/app/models/repository.py
+++ b/pulp_rpm/app/models/repository.py
@@ -39,6 +39,7 @@ from pulp_rpm.app.models import (
 
 from pulp_rpm.app.downloaders import RpmDownloader, RpmFileDownloader
 from pulp_rpm.app.exceptions import DistributionTreeConflict
+from pulp_rpm.app.shared_utils import urlpath_sanitize
 
 log = getLogger(__name__)
 
@@ -352,7 +353,7 @@ class RpmDistribution(PublicationDistribution):
             repository = RpmRepository.objects.get(pk=repository_pk)
             signing_service = repository.metadata_signing_service
             if signing_service:
-                gpgkey_path = urllib.parse.urljoin(
+                gpgkey_path = urlpath_sanitize(
                     settings.CONTENT_ORIGIN, settings.CONTENT_PATH_PREFIX
                 )
                 gpgkey_path = urllib.parse.urljoin(gpgkey_path, self.base_path, True)

--- a/pulp_rpm/tests/unit/test_shared_utils.py
+++ b/pulp_rpm/tests/unit/test_shared_utils.py
@@ -1,0 +1,66 @@
+from unittest import TestCase
+from pulp_rpm.app.shared_utils import is_previous_version, urlpath_sanitize
+
+
+class TestSharedUtils(TestCase):
+    """Test shared_utils functions."""
+
+    def test_is_previous_version(self):
+        """Test version-comparator."""
+        # Versions must be int or 1.2.3
+        # non-integer versions return False, always
+        # True if version <= target
+
+        # None
+        self.assertTrue(is_previous_version(None, "1"))
+        self.assertTrue(is_previous_version("1", None))
+        self.assertTrue(is_previous_version(None, None))
+
+        # Integer versions
+        # v = t : v < t : v > t
+        self.assertTrue(is_previous_version("1", "1"))
+        self.assertTrue(is_previous_version("1", "2"))
+        self.assertFalse(is_previous_version("2", "1"))
+
+        # m.n
+        # v = t : v m. < t m. : v m.n < t m.n : v m. > t.m : v m.n > t.m.n
+        self.assertTrue(is_previous_version("1.2", "1.2"))
+        self.assertTrue(is_previous_version("1.2", "2.2"))
+        self.assertTrue(is_previous_version("1.2", "1.3"))
+        self.assertFalse(is_previous_version("2.2", "1.2"))
+        self.assertFalse(is_previous_version("2.2", "2.1"))
+
+        # non-numeric : v not-digits : t not-digits : v-dot-nondigits : t dot-non-digits
+        self.assertFalse(is_previous_version("foo", "1.2"))
+        self.assertFalse(is_previous_version("1.2", "bar"))
+        self.assertFalse(is_previous_version("foo.2", "2.1"))
+        self.assertFalse(is_previous_version("1.2", "bar.1"))
+        self.assertTrue(is_previous_version("1.foo", "2.bar"))
+        self.assertFalse(is_previous_version("1.foo", "1.bar"))
+
+    def test_urlpath_sanitize(self):
+        """Test urljoin-replacement."""
+        # arbitrary number of args become one single-slash-separated string
+        a_expected = "a"
+        ab_expected = "a/b"
+        abc_expected = "a/b/c"
+
+        # a /a a/ /a/
+        self.assertEqual(a_expected, urlpath_sanitize("a"))
+        self.assertEqual(a_expected, urlpath_sanitize("/a"))
+        self.assertEqual(a_expected, urlpath_sanitize("a/"))
+        self.assertEqual(a_expected, urlpath_sanitize("/a/"))
+
+        # a b : a/ b : /a b : a b/ : a /b : a /b/ : a/ /b
+        self.assertEqual(ab_expected, urlpath_sanitize("a", "b"))
+        self.assertEqual(ab_expected, urlpath_sanitize("a/", "b"))
+        self.assertEqual(ab_expected, urlpath_sanitize("/a", "b"))
+        self.assertEqual(ab_expected, urlpath_sanitize("a", "b/"))
+        self.assertEqual(ab_expected, urlpath_sanitize("a", "/b"))
+        self.assertEqual(ab_expected, urlpath_sanitize("a", "/b/"))
+        self.assertEqual(ab_expected, urlpath_sanitize("a/", "/b"))
+
+        # a b c : a /b/ /c : /a/ /b/ /c/
+        self.assertEqual(abc_expected, urlpath_sanitize("a", "b", "c"))
+        self.assertEqual(abc_expected, urlpath_sanitize("a", "/b/", "/c"))
+        self.assertEqual(abc_expected, urlpath_sanitize("/a/", "/b/", "/c/"))


### PR DESCRIPTION
* Added shared_utils.urlpath_sanitize() to fill the niche that urljoin()
was being (incorrectly) used for.
* Added unit-tests for shared_util.
* Fixed a problem with shared_utils.is_previous_version() that unit-tests exposed.