### PR TITLE
Fixed tests that relied on now-unresponsive duke.edu site.

### DIFF
--- a/pulp_rpm/tests/functional/constants.py
+++ b/pulp_rpm/tests/functional/constants.py
@@ -358,11 +358,11 @@ RPM_CUSTOM_REPO_METADATA_CHANGED_FIXTURE_URL = urljoin(
 RPM_MD5_REPO_FIXTURE_URL = urljoin(PULP_FIXTURES_BASE_URL, "rpm-with-md5/")
 
 CENTOS6_URL = "http://mirror.centos.org/centos-6/6.10/os/x86_64/"
-CENTOS7_URL = "http://mirror.linux.duke.edu/pub/centos/7/os/x86_64/"
-CENTOS8_KICKSTART_APP_URL = "http://mirror.linux.duke.edu/pub/centos/8/AppStream/x86_64/kickstart/"
-CENTOS8_KICKSTART_BASEOS_URL = "http://mirror.linux.duke.edu/pub/centos/8/BaseOS/x86_64/kickstart/"
-CENTOS8_APPSTREAM_URL = "http://mirror.linux.duke.edu/pub/centos/8/AppStream/x86_64/os/"
-CENTOS8_BASEOS_URL = "http://mirror.linux.duke.edu/pub/centos/8/BaseOS/x86_64/os/"
+CENTOS7_URL = "http://mirror.centos.org/centos-7/7/os/x86_64/"
+CENTOS8_KICKSTART_APP_URL = "http://mirror.centos.org/centos-8/8/AppStream/x86_64/kickstart/"
+CENTOS8_KICKSTART_BASEOS_URL = "http://mirror.centos.org/centos-8/8/BaseOS/x86_64/kickstart/"
+CENTOS8_APPSTREAM_URL = "http://mirror.centos.org/centos-8/8/AppStream/x86_64/os/"
+CENTOS8_BASEOS_URL = "http://mirror.centos.org/centos-8/8/BaseOS/x86_64/os/"
 EPEL7_URL = "https://dl.fedoraproject.org/pub/epel/7/x86_64/"
 RPM_CDN_APPSTREAM_URL = "https://cdn.redhat.com/content/dist/rhel8/8.2/x86_64/appstream/os/"
 RPM_CDN_BASEOS_URL = "https://cdn.redhat.com/content/dist/rhel8/8.2/x86_64/baseos/os/"

--- a/pulp_rpm/tests/performance/test_sync.py
+++ b/pulp_rpm/tests/performance/test_sync.py
@@ -61,7 +61,9 @@ class SyncTestCase(unittest.TestCase):
         """
         return datetime.strptime(s, parse_format)
 
-    def rpm_sync(self, url=RPM_KICKSTART_FIXTURE_URL, policy="on_demand", check_dist_tree=True):
+    def rpm_sync(
+        self, url=RPM_KICKSTART_FIXTURE_URL, policy="on_demand", check_dist_tree=True, resync=True
+    ):
         """Sync repositories with the rpm plugin.
 
         This test targets the following issue:
@@ -121,26 +123,27 @@ class SyncTestCase(unittest.TestCase):
                 get_added_content_summary(repo).items(),
             )
 
-        # Sync the repository again.
-        latest_version_href = repo["latest_version_href"]
-        response = self.client.using_handler(api.json_handler).post(
-            urljoin(repo["pulp_href"], "sync/"), data
-        )
-        sync_task = self.client.get(response["task"])
-        created_at = self.parse_date_from_string(sync_task["pulp_created"])
-        started_at = self.parse_date_from_string(sync_task["started_at"])
-        finished_at = self.parse_date_from_string(sync_task["finished_at"])
-        task_duration = finished_at - started_at
-        waiting_time = started_at - created_at
-        print(
-            "\n->  Re-sync => Waiting time (s): {wait} | Service time (s): {service}".format(
-                wait=waiting_time.total_seconds(), service=task_duration.total_seconds()
+        if resync:
+            # Sync the repository again.
+            latest_version_href = repo["latest_version_href"]
+            response = self.client.using_handler(api.json_handler).post(
+                urljoin(repo["pulp_href"], "sync/"), data
             )
-        )
-        repo = self.client.get(repo["pulp_href"])
+            sync_task = self.client.get(response["task"])
+            created_at = self.parse_date_from_string(sync_task["pulp_created"])
+            started_at = self.parse_date_from_string(sync_task["started_at"])
+            finished_at = self.parse_date_from_string(sync_task["finished_at"])
+            task_duration = finished_at - started_at
+            waiting_time = started_at - created_at
+            print(
+                "\n->  Re-sync => Waiting time (s): {wait} | Service time (s): {service}".format(
+                    wait=waiting_time.total_seconds(), service=task_duration.total_seconds()
+                )
+            )
+            repo = self.client.get(repo["pulp_href"])
 
-        # Check that nothing has changed since the last sync.
-        self.assertEqual(latest_version_href, repo["latest_version_href"])
+            # Check that nothing has changed since the last sync.
+            self.assertEqual(latest_version_href, repo["latest_version_href"])
 
     def test_centos7_on_demand(self):
         """Sync CentOS 7."""
@@ -170,7 +173,10 @@ class SyncTestCase(unittest.TestCase):
     def test_epel8_mirrorlist_with_comment(self):
         """Kickstart Sync EPEL 8 (which includes a comment line)."""
         # EPEL8 doesn't contain distribution tree
-        self.rpm_sync(url=EPEL8_MIRRORLIST_URL, check_dist_tree=False)
+        # Different mirrors may have different content, which
+        # will cause the resync in rpm_sync to result in a new repo-version.
+        # Don't fail a test due to outside data concerns...
+        self.rpm_sync(url=EPEL8_MIRRORLIST_URL, check_dist_tree=False, resync=False)
 
     def test_epel8_playground_kickstart_on_demand(self):
         """Kickstart Sync Epel 8 playground."""


### PR DESCRIPTION
Also taught EPEL-mirror-test to not care about resync, different
returns from the mirrorlist could cause the test to fail if the
resync chose a new mirror that had different repodata.

[noissue]