### PR TITLE
Reduce memory consumption when syncing extremely large repositories

### DIFF
--- a/CHANGES/8467.bugfix
+++ b/CHANGES/8467.bugfix
@@ -1,0 +1,1 @@
+Reduce memory consumption when syncing extremely large repositories.


### PR DESCRIPTION
re: #8467
https://pulp.plan.io/issues/8467