### PR TITLE
properly call tree.get() for timestamp handling

### DIFF
--- a/CHANGES/8623.bugfix
+++ b/CHANGES/8623.bugfix
@@ -1,0 +1,1 @@
+Fixed sync/migration of the kickstart repositories with floating point build_timestamp.

--- a/pulp_rpm/app/kickstart/treeinfo.py
+++ b/pulp_rpm/app/kickstart/treeinfo.py
@@ -134,7 +134,7 @@ class PulpTreeInfo(TreeInfo):
         tree = self.original_parser._sections.get("tree", {})
 
         if "." in str(tree.get("build_timestamp")):
-            build_timestamp = float(tree.get["build_timestamp"])
+            build_timestamp = float(tree.get("build_timestamp"))
 
         if build_timestamp and parser._sections.get("general", {}).get("timestamp"):
             parser._sections["general"]["timestamp"] = build_timestamp


### PR DESCRIPTION
fixes #8623