### PR TITLE
Resolve conflicting dependency_solving defaults

### DIFF
--- a/docs/workflows/copy.rst
+++ b/docs/workflows/copy.rst
@@ -100,13 +100,13 @@ dependencies)
 
 Solving these complex dependency relationships can be quite expensive, but is often necessary for
 correctness. It is **enabled by default**, but can be disabled by setting the "dependency_solving"
-parameter to a value of False when making calls against the API. Note that if you do choose not to
-use dependency-solving, (or if you configure it incorrectly), it is possible to create incomplete
+parameter to a value of ``False`` when making calls against the API. Note that if you do choose not
+to use dependency-solving, (or if you configure it incorrectly), it is possible to create incomplete
 repositories.
 
 .. note::
 
-    While the default value for this "dependency_solving" parameter is currently "false", this
+    While the default value for the "dependency_solving" parameter is currently ``True``, this
     default is potentially subject to change in the future - until such a time as this API is
     stabilized.
 


### PR DESCRIPTION
Before this patch, the note about `dependency_solving` and the preceding paragraph gave two different default values ('**enabled by default**' vs 'currently "false"').  The API docs and the [source][0] say the default is currently `True`, so this patch updates the note text to reflect that.

[0]: https://github.com/pulp/pulp_rpm/blob/9a91832a39c924a77413fa31960996f9b2d38556/pulp_rpm/app/serializers/repository.py#L301-L303
[noissue]