### PR TITLE
Refactor to make metadata mirroring easier

### DIFF
--- a/CHANGES/8764.misc
+++ b/CHANGES/8764.misc
@@ -1,0 +1,1 @@
+Refactored the sync pipeline to make the logic easier to follow.

--- a/pulp_rpm/app/constants.py
+++ b/pulp_rpm/app/constants.py
@@ -69,7 +69,6 @@ PACKAGE_DB_REPODATA = ["primary_db", "filelists_db", "other_db"]
 UPDATE_REPODATA = ["updateinfo"]
 MODULAR_REPODATA = ["modules"]
 COMPS_REPODATA = ["group"]
-SKIP_REPODATA = ["group_gz", "prestodelta"]
 SKIP_TYPES = ["srpm"]
 
 CR_UPDATE_RECORD_ATTRS = SimpleNamespace(

--- a/pulp_rpm/app/tasks/synchronizing.py
+++ b/pulp_rpm/app/tasks/synchronizing.py
@@ -44,7 +44,6 @@ from pulp_rpm.app.constants import (
     PACKAGE_REPODATA,
     PULP_MODULE_ATTR,
     PULP_MODULEDEFAULTS_ATTR,
-    SKIP_REPODATA,
     UPDATE_REPODATA,
 )
 from pulp_rpm.app.models import (
@@ -323,7 +322,13 @@ class RpmFirstStage(Stage):
     """
 
     def __init__(
-        self, remote, repository, deferred_download, skip_types=None, new_url=None, treeinfo=None
+        self,
+        remote,
+        repository,
+        deferred_download,
+        skip_types=None,
+        new_url=None,
+        treeinfo=None,
     ):
         """
         The first stage of a pulp_rpm sync pipeline.
@@ -345,11 +350,14 @@ class RpmFirstStage(Stage):
         self.remote = remote
         self.repository = repository
         self.deferred_download = deferred_download
+
         self.treeinfo = treeinfo
         self.skip_types = [] if skip_types is None else skip_types
 
-        self.data = FirstStageData()
-        self.data.remote_url = new_url or self.remote.url
+        self.remote_url = new_url or self.remote.url
+
+        self.nevra_to_module = defaultdict(dict)
+        self.pkgname_to_groups = defaultdict(list)
 
     @staticmethod
     async def parse_updateinfo(updateinfo_xml_path):
@@ -428,34 +436,56 @@ class RpmFirstStage(Stage):
 
     async def run(self):
         """Build `DeclarativeContent` from the repodata."""
-        progress_data = dict(message="Downloading Metadata Files", code="sync.downloading.metadata")
-        with ProgressReport(**progress_data) as metadata_pb:
-            self.data.metadata_pb = metadata_pb
-
-            downloader = self.remote.get_downloader(
-                url=urlpath_sanitize(self.data.remote_url, "repodata/repomd.xml")
+        with tempfile.TemporaryDirectory("."):
+            progress_data = dict(
+                message="Downloading Metadata Files", code="sync.downloading.metadata"
             )
-            result = await downloader.run()
-            metadata_pb.increment()
+            with ProgressReport(**progress_data) as metadata_pb:
+                downloader = self.remote.get_downloader(
+                    url=urlpath_sanitize(self.remote_url, "repodata/repomd.xml")
+                )
+                result = await downloader.run()
+                metadata_pb.increment()
 
-            repomd_path = result.path
-            self.data.repomd = cr.Repomd(repomd_path)
+                repomd_path = result.path
+                repomd = cr.Repomd(repomd_path)
 
-            self.repository.last_sync_revision_number = self.data.repomd.revision
-            self.repository.last_sync_repomd_checksum = get_sha256(repomd_path)
+                self.repository.last_sync_revision_number = repomd.revision
+                self.repository.last_sync_repomd_checksum = get_sha256(repomd_path)
 
-            await self.parse_distribution_tree()
-            await self.parse_repository_metadata()
-            await self.parse_modules_metadata()
-            await self.parse_packages_components()
-            await self.parse_content()
+                checksum_types = {}
+                metadata_downloaders = {}
+                types_to_download = (
+                    set(PACKAGE_REPODATA)
+                    | set(UPDATE_REPODATA)
+                    | set(COMPS_REPODATA)
+                    | set(MODULAR_REPODATA)
+                )
 
-            # now send modules down the pipeline since all relations have been set up
-            for modulemd in self.data.modulemd_list:
-                await self.put(modulemd)
+                # TODO: do we actually need to download all metadata for mirror case,
+                # or use RepoMetadataFile?
+                for record in repomd.records:
+                    checksum_types[record.type] = getattr(
+                        CHECKSUM_TYPES, record.checksum_type.upper()
+                    )
+                    record.checksum_type = getattr(CHECKSUM_TYPES, record.checksum_type.upper())
 
-            for dc_group in self.data.dc_groups:
-                await self.put(dc_group)
+                    if record.type in types_to_download:
+                        sanitized = urlpath_sanitize(self.remote_url, record.location_href)
+                        downloader = self.remote.get_downloader(url=sanitized)
+                        metadata_downloaders[record.type] = asyncio.ensure_future(downloader.run())
+
+                self.repository.original_checksum_types = checksum_types
+
+                try:
+                    for future in asyncio.as_completed(list(metadata_downloaders.values())):
+                        await future
+                        metadata_pb.increment()
+                except ClientResponseError as exc:
+                    raise HTTPNotFound(reason=_("File not found: {}".format(exc.request_info.url)))
+
+                metadata_files = {key: val.result() for key, val in metadata_downloaders.items()}
+                await self.parse_repository_metadata(repomd, metadata_files)
 
     async def parse_distribution_tree(self):
         """Parse content from the file treeinfo if present."""
@@ -463,7 +493,7 @@ class RpmFirstStage(Stage):
             d_artifacts = [
                 DeclarativeArtifact(
                     artifact=Artifact(),
-                    url=urlpath_sanitize(self.data.remote_url, self.treeinfo["filename"]),
+                    url=urlpath_sanitize(self.remote_url, self.treeinfo["filename"]),
                     relative_path=".treeinfo",
                     remote=self.remote,
                     deferred_download=False,
@@ -473,7 +503,7 @@ class RpmFirstStage(Stage):
                 artifact = Artifact(**checksum)
                 da = DeclarativeArtifact(
                     artifact=artifact,
-                    url=urlpath_sanitize(self.data.remote_url, path),
+                    url=urlpath_sanitize(self.remote_url, path),
                     relative_path=path,
                     remote=self.remote,
                     deferred_download=self.deferred_download,
@@ -485,107 +515,271 @@ class RpmFirstStage(Stage):
             dc.extra_data = self.treeinfo
             await self.put(dc)
 
-    async def parse_repository_metadata(self):
-        """Parse repository metadata from repomd.xml."""
-        repository_metadata_parser = RepositoryMetadataParser(self.data, self.remote)
-        repository_metadata_parser.parse()
+    async def parse_repository_metadata(self, repomd, metadata_results):
+        """Parse repository metadata."""
+        needed_metadata = set(PACKAGE_REPODATA) - set(metadata_results.keys())
 
-        if repository_metadata_parser.repomd_dcs:
-            for dc in repository_metadata_parser.repomd_dcs:
-                await self.put(dc)
-        self.repository.original_checksum_types = repository_metadata_parser.checksum_types
-
-    async def parse_modules_metadata(self):
-        """Parse modules' metadata which define what packages are built for specific releases."""
-        if self.data.modules_url:
-            downloader = self.remote.get_downloader(url=self.data.modules_url)
-            modulemd_result = await downloader.run()
-
-            modules_metadata_parser = ModulesMetadataParser(self.data, modulemd_result)
-            modules_metadata_parser.parse()
-
-            if modules_metadata_parser.default_content_dcs:
-                for default_content_dc in modules_metadata_parser.default_content_dcs:
-                    await self.put(default_content_dc)
-
-    async def parse_packages_components(self):
-        """Parse packages' components that define how are the packages bundled."""
-        if self.data.comps_url:
-            downloader = self.remote.get_downloader(url=self.data.comps_url)
-            comps_result = await downloader.run()
-            packages_components_parser = PackagesComponentsParser(self.data, comps_result)
-            packages_components_parser.parse()
-
-            if packages_components_parser.package_language_pack_dc:
-                await self.put(packages_components_parser.package_language_pack_dc)
-
-            for dc_category in packages_components_parser.dc_categories:
-                await self.put(dc_category)
-
-            for dc_environment in packages_components_parser.dc_environments:
-                await self.put(dc_environment)
-
-            # delete lists now that we're done with them for memory savings
-            del packages_components_parser.dc_environments
-            del packages_components_parser.dc_categories
-
-    async def parse_content(self):
-        """Download and parse packages' content from the remote repository."""
-        if self.data.updateinfo_url:
-            updateinfo_downloader = self.remote.get_downloader(url=self.data.updateinfo_url)
-        else:
-            updateinfo_downloader = None
-
-        # to preserve order, downloaders are created after all repodata urls are identified
-        package_repodata_downloaders = []
-        for repodata_type in PACKAGE_REPODATA:
-            downloader = self.remote.get_downloader(
-                url=self.data.package_repodata_urls[repodata_type]
+        if needed_metadata:
+            raise FileNotFoundError(
+                _("XML file(s): {filenames} not found").format(filenames=", ".join(needed_metadata))
             )
-            package_repodata_downloaders.append(downloader.run())
 
-        try:
-            if updateinfo_downloader:
-                await self.parse_advisories(await updateinfo_downloader.run())
-            await self.parse_packages(await asyncio.gather(*package_repodata_downloaders))
-        except ClientResponseError as exc:
-            raise HTTPNotFound(reason=_("File not found: {}".format(exc.request_info.url)))
+        await self.parse_distribution_tree()
 
-    async def parse_packages(self, results):
+        await self.parse_packages(
+            metadata_results["primary"],
+            metadata_results["filelists"],
+            metadata_results["other"],
+        )
+
+        modulemd_list = []
+        modulemd_result = metadata_results.get("modules", None)
+        if modulemd_result:
+            modulemd_list = await self.parse_modules_metadata(modulemd_result)
+
+        groups_list = []
+        comps_result = metadata_results.get("group", None)
+        if comps_result:
+            groups_list = await self.parse_packages_components(comps_result)
+
+        updateinfo_result = metadata_results.get("updateinfo", None)
+        if updateinfo_result:
+            await self.parse_advisories(updateinfo_result)
+
+        # now send modules and groups down the pipeline since all relations have been set up
+        for modulemd_dc in modulemd_list:
+            await self.put(modulemd_dc)
+
+        for group_dc in groups_list:
+            await self.put(group_dc)
+
+        record_types = (
+            set(PACKAGE_REPODATA)
+            | set(PACKAGE_DB_REPODATA)
+            | set(UPDATE_REPODATA)
+            | set(COMPS_REPODATA)
+            | set(MODULAR_REPODATA)
+        )
+
+        for record in repomd.records:
+            should_skip = False
+            if record.type not in record_types:
+                # TODO: mirror case needs to get copies of these, also.
+                for suffix in ["_zck", "_gz", "_xz"]:
+                    if suffix in record.type:
+                        should_skip = True
+                if record.type in ["prestodelta"]:
+                    should_skip = True
+
+                if should_skip:
+                    continue
+
+                file_data = {record.checksum_type: record.checksum, "size": record.size}
+                da = DeclarativeArtifact(
+                    artifact=Artifact(**file_data),
+                    url=urlpath_sanitize(self.remote_url, record.location_href),
+                    relative_path=record.location_href,
+                    remote=self.remote,
+                    deferred_download=False,
+                )
+                repo_metadata_file = RepoMetadataFile(
+                    data_type=record.type,
+                    checksum_type=record.checksum_type,
+                    checksum=record.checksum,
+                    relative_path=record.location_href,
+                )
+                dc = DeclarativeContent(content=repo_metadata_file, d_artifacts=[da])
+                await self.put(dc)
+
+    async def parse_modules_metadata(self, modulemd_result):
+        """Parse modules' metadata which define what packages are built for specific releases."""
+        modulemd_index = mmdlib.ModuleIndex.new()
+        modulemd_index.update_from_file(modulemd_result.path, True)
+
+        modulemd_names = modulemd_index.get_module_names() or []
+        modulemd_all = parse_modulemd(modulemd_names, modulemd_index)
+        modulemd_list = []
+
+        # Parsing modules happens all at one time, and from here on no useful work happens.
+        # So just report that it finished this stage.
+        modulemd_pb_data = {"message": "Parsed Modulemd", "code": "sync.parsing.modulemds"}
+        with ProgressReport(**modulemd_pb_data) as modulemd_pb:
+            modulemd_total = len(modulemd_all)
+            modulemd_pb.total = modulemd_total
+            modulemd_pb.done = modulemd_total
+
+        for modulemd in modulemd_all:
+            artifact = modulemd.pop("artifact")
+            relative_path = "{}{}{}{}{}snippet".format(
+                modulemd[PULP_MODULE_ATTR.NAME],
+                modulemd[PULP_MODULE_ATTR.STREAM],
+                modulemd[PULP_MODULE_ATTR.VERSION],
+                modulemd[PULP_MODULE_ATTR.CONTEXT],
+                modulemd[PULP_MODULE_ATTR.ARCH],
+            )
+            da = DeclarativeArtifact(
+                artifact=artifact, relative_path=relative_path, url=modulemd_result.url
+            )
+            modulemd_content = Modulemd(**modulemd)
+            dc = DeclarativeContent(content=modulemd_content, d_artifacts=[da])
+            dc.extra_data = defaultdict(list)
+
+            # dc.content.artifacts are Modulemd artifacts
+            for artifact in dc.content.artifacts:
+                self.nevra_to_module.setdefault(artifact, set()).add(dc)
+            modulemd_list.append(dc)
+
+        # Parse modulemd default names
+        modulemd_default_names = parse_defaults(modulemd_index)
+
+        # Parsing module-defaults happens all at one time, and from here on no useful
+        # work happens. So just report that it finished this stage.
+        modulemd_defaults_pb_data = {
+            "message": "Parsed Modulemd-defaults",
+            "code": "sync.parsing.modulemd_defaults",
+        }
+        with ProgressReport(**modulemd_defaults_pb_data) as modulemd_defaults_pb:
+            modulemd_defaults_total = len(modulemd_default_names)
+            modulemd_defaults_pb.total = modulemd_defaults_total
+            modulemd_defaults_pb.done = modulemd_defaults_total
+
+        default_content_dcs = []
+        for default in modulemd_default_names:
+            artifact = default.pop("artifact")
+            relative_path = "{}{}snippet".format(
+                default[PULP_MODULEDEFAULTS_ATTR.MODULE], default[PULP_MODULEDEFAULTS_ATTR.STREAM]
+            )
+            da = DeclarativeArtifact(
+                artifact=artifact, relative_path=relative_path, url=modulemd_result.url
+            )
+            default_content = ModulemdDefaults(**default)
+            default_content_dcs.append(
+                DeclarativeContent(content=default_content, d_artifacts=[da])
+            )
+
+        if default_content_dcs:
+            for default_content_dc in default_content_dcs:
+                await self.put(default_content_dc)
+
+        return modulemd_list
+
+    async def parse_packages_components(self, comps_result):
+        """Parse packages' components that define how are the packages bundled."""
+        group_to_categories = defaultdict(list)
+
+        group_to_environments = defaultdict(list)
+        optionalgroup_to_environments = defaultdict(list)
+
+        package_language_pack_dc = None
+        dc_categories = []
+        dc_environments = []
+        dc_groups = []
+
+        comps = libcomps.Comps()
+        comps.fromxml_f(comps_result.path)
+
+        with ProgressReport(message="Parsed Comps", code="sync.parsing.comps") as comps_pb:
+            comps_total = len(comps.groups) + len(comps.categories) + len(comps.environments)
+            comps_pb.total = comps_total
+            comps_pb.done = comps_total
+
+        if comps.langpacks:
+            langpack_dict = PackageLangpacks.libcomps_to_dict(comps.langpacks)
+            packagelangpack = PackageLangpacks(
+                matches=strdict_to_dict(comps.langpacks), digest=dict_digest(langpack_dict)
+            )
+            package_language_pack_dc = DeclarativeContent(content=packagelangpack)
+            package_language_pack_dc.extra_data = defaultdict(list)
+
+        # init categories declarative content
+        if comps.categories:
+            for category in comps.categories:
+                category_dict = PackageCategory.libcomps_to_dict(category)
+                category_dict["digest"] = dict_digest(category_dict)
+                packagecategory = PackageCategory(**category_dict)
+                dc = DeclarativeContent(content=packagecategory)
+                dc.extra_data = defaultdict(list)
+
+                if packagecategory.group_ids:
+                    for group_id in packagecategory.group_ids:
+                        group_to_categories[group_id["name"]].append(dc)
+                dc_categories.append(dc)
+
+        # init environments declarative content
+        if comps.environments:
+            for environment in comps.environments:
+                environment_dict = PackageEnvironment.libcomps_to_dict(environment)
+                environment_dict["digest"] = dict_digest(environment_dict)
+                packageenvironment = PackageEnvironment(**environment_dict)
+                dc = DeclarativeContent(content=packageenvironment)
+                dc.extra_data = defaultdict(list)
+
+                if packageenvironment.option_ids:
+                    for option_id in packageenvironment.option_ids:
+                        optionalgroup_to_environments[option_id["name"]].append(dc)
+
+                if packageenvironment.group_ids:
+                    for group_id in packageenvironment.group_ids:
+                        group_to_environments[group_id["name"]].append(dc)
+
+                dc_environments.append(dc)
+
+        # init groups declarative content
+        if comps.groups:
+            for group in comps.groups:
+                group_dict = PackageGroup.libcomps_to_dict(group)
+                group_dict["digest"] = dict_digest(group_dict)
+                packagegroup = PackageGroup(**group_dict)
+                dc = DeclarativeContent(content=packagegroup)
+                dc.extra_data = defaultdict(list)
+
+                if packagegroup.packages:
+                    for package in packagegroup.packages:
+                        self.pkgname_to_groups[package["name"]].append(dc)
+
+                if dc.content.id in group_to_categories.keys():
+                    for dc_category in group_to_categories[dc.content.id]:
+                        dc.extra_data["category_relations"].append(dc_category)
+                        dc_category.extra_data["packagegroups"].append(dc)
+
+                if dc.content.id in group_to_environments.keys():
+                    for dc_environment in group_to_environments[dc.content.id]:
+                        dc.extra_data["environment_relations"].append(dc_environment)
+                        dc_environment.extra_data["packagegroups"].append(dc)
+
+                if dc.content.id in optionalgroup_to_environments.keys():
+                    for dc_environment in optionalgroup_to_environments[dc.content.id]:
+                        dc.extra_data["env_relations_optional"].append(dc_environment)
+                        dc_environment.extra_data["optionalgroups"].append(dc)
+
+                dc_groups.append(dc)
+
+        if package_language_pack_dc:
+            await self.put(package_language_pack_dc)
+
+        for dc_category in dc_categories:
+            await self.put(dc_category)
+
+        for dc_environment in dc_environments:
+            await self.put(dc_environment)
+
+        return dc_groups
+
+    async def parse_packages(self, primary_xml, filelists_xml, other_xml):
         """Parse packages from the remote repository."""
-        primary_xml_path = results[0].path
-        filelists_xml_path = results[1].path
-        other_xml_path = results[2].path
-
-        self.data.metadata_pb.done += 3
-        self.data.metadata_pb.save()
-
         packages = await RpmFirstStage.parse_repodata(
-            primary_xml_path, filelists_xml_path, other_xml_path
+            primary_xml.path, filelists_xml.path, other_xml.path
         )
 
         # skip SRPM if defined
         if "srpm" in self.skip_types:
             packages = {pkgId: pkg for pkgId, pkg in packages.items() if pkg.arch != "src"}
 
-        await self._parse_packages(packages)
-
-    async def parse_advisories(self, result):
-        """Parse advisories from the remote repository."""
-        updateinfo_xml_path = result.path
-
-        self.data.metadata_pb.increment()
-
-        updates = await RpmFirstStage.parse_updateinfo(updateinfo_xml_path)
-        await self._parse_advisories(updates)
-
-    async def _parse_packages(self, packages):
         progress_data = {
             "message": "Parsed Packages",
             "code": "sync.parsing.packages",
             "total": len(packages),
         }
-
         with ProgressReport(**progress_data) as packages_pb:
             while True:
                 try:
@@ -597,7 +791,7 @@ class RpmFirstStage(Stage):
                 artifact = Artifact(size=package.size_package)
                 checksum_type = getattr(CHECKSUM_TYPES, package.checksum_type.upper())
                 setattr(artifact, checksum_type, package.pkgId)
-                url = urlpath_sanitize(self.data.remote_url, package.location_href)
+                url = urlpath_sanitize(self.remote_url, package.location_href)
                 filename = os.path.basename(package.location_href)
                 da = DeclarativeArtifact(
                     artifact=artifact,
@@ -610,21 +804,25 @@ class RpmFirstStage(Stage):
                 dc.extra_data = defaultdict(list)
 
                 # find if a package relates to a modulemd
-                if dc.content.nevra in self.data.nevra_to_module.keys():
+                if dc.content.nevra in self.nevra_to_module.keys():
                     dc.content.is_modular = True
-                    for dc_modulemd in self.data.nevra_to_module[dc.content.nevra]:
+                    for dc_modulemd in self.nevra_to_module[dc.content.nevra]:
                         dc.extra_data["modulemd_relation"].append(dc_modulemd)
                         dc_modulemd.extra_data["package_relation"].append(dc)
 
-                if dc.content.name in self.data.pkgname_to_groups.keys():
-                    for dc_group in self.data.pkgname_to_groups[dc.content.name]:
+                if dc.content.name in self.pkgname_to_groups.keys():
+                    for dc_group in self.pkgname_to_groups[dc.content.name]:
                         dc.extra_data["group_relations"].append(dc_group)
                         dc_group.extra_data["related_packages"].append(dc)
 
                 packages_pb.increment()
                 await self.put(dc)
 
-    async def _parse_advisories(self, updates):
+    async def parse_advisories(self, result):
+        """Parse advisories from the remote repository."""
+        updateinfo_xml_path = result.path
+
+        updates = await RpmFirstStage.parse_updateinfo(updateinfo_xml_path)
         progress_data = {
             "message": "Parsed Advisories",
             "code": "sync.parsing.advisories",
@@ -654,281 +852,6 @@ class RpmFirstStage(Stage):
                 dc = DeclarativeContent(content=update_record)
                 dc.extra_data = future_relations
                 await self.put(dc)
-
-
-class FirstStageData:
-    """A data class that holds data required for synchronization.
-
-    The stored data are passed between multiple worker classes and are altered during
-    the synchronization process.
-    """
-
-    def __init__(self):
-        """Store shared data which are going to be used by parsers."""
-        self.metadata_pb = None
-
-        self.nevra_to_module = defaultdict(dict)
-        self.pkgname_to_groups = defaultdict(list)
-
-        self.package_repodata_urls = {}
-        self.repomd = None
-        self.remote_url = None
-        self.comps_url = None
-        self.modules_url = None
-        self.updateinfo_url = None
-        self.modulemd_list = []
-        self.dc_groups = []
-
-
-class RepositoryMetadataParser:
-    """A class used for parsing repository metadata (repomd)."""
-
-    def __init__(self, data, remote):
-        """Store the data class, the passed remote, and initialize class variables."""
-        self.data = data
-        self.remote = remote
-
-        self.checksum_types = {}
-        self.repomd_dcs = []
-
-    def parse(self):
-        """Parse repository metadata."""
-        required_metadata_found = set()
-        for record in self.data.repomd.records:
-            self.checksum_types[record.type] = getattr(CHECKSUM_TYPES, record.checksum_type.upper())
-            record.checksum_type = getattr(CHECKSUM_TYPES, record.checksum_type.upper())
-
-            if record.type in PACKAGE_REPODATA:
-                required_metadata_found.add(record.type)
-                self.data.package_repodata_urls[record.type] = urlpath_sanitize(
-                    self.data.remote_url, record.location_href
-                )
-            elif record.type in UPDATE_REPODATA:
-                self.data.updateinfo_url = urlpath_sanitize(
-                    self.data.remote_url, record.location_href
-                )
-            elif record.type in COMPS_REPODATA:
-                self.data.comps_url = urlpath_sanitize(self.data.remote_url, record.location_href)
-            elif record.type in MODULAR_REPODATA:
-                self.data.modules_url = urlpath_sanitize(self.data.remote_url, record.location_href)
-            elif record.type in SKIP_REPODATA:
-                pass
-            else:
-                self._set_repomd_file(record)
-
-        missing_types = set(PACKAGE_REPODATA) - required_metadata_found
-        if missing_types:
-            raise FileNotFoundError(
-                _("XML file(s): {filenames} not found").format(filenames=", ".join(missing_types))
-            )
-
-    def _set_repomd_file(self, record):
-        if "_zck" not in record.type and record.type not in PACKAGE_DB_REPODATA:
-            file_data = {record.checksum_type: record.checksum, "size": record.size}
-            da = DeclarativeArtifact(
-                artifact=Artifact(**file_data),
-                url=urlpath_sanitize(self.data.remote_url, record.location_href),
-                relative_path=record.location_href,
-                remote=self.remote,
-                deferred_download=False,
-            )
-            repo_metadata_file = RepoMetadataFile(
-                data_type=record.type,
-                checksum_type=record.checksum_type,
-                checksum=record.checksum,
-                relative_path=record.location_href,
-            )
-            dc = DeclarativeContent(content=repo_metadata_file, d_artifacts=[da])
-            self.repomd_dcs.append(dc)
-
-
-class ModulesMetadataParser:
-    """A class used for parsing modules' metadata (modulemd)."""
-
-    def __init__(self, data, modulemd_result):
-        """Store the data class and initialize a list of default contents' declarative contents."""
-        self.data = data
-        self.modulemd_result = modulemd_result
-
-        self.default_content_dcs = []
-
-    def parse(self):
-        """Parse module.yaml, if exists, to create relations between packages."""
-        if self.modulemd_result:
-            modulemd_index = mmdlib.ModuleIndex.new()
-            modulemd_index.update_from_file(self.modulemd_result.path, True)
-
-            self._parse_modulemd_list(modulemd_index)
-            self._parse_modulemd_default_names(modulemd_index)
-
-    def _parse_modulemd_list(self, modulemd_index):
-        modulemd_names = modulemd_index.get_module_names() or []
-        modulemd_all = parse_modulemd(modulemd_names, modulemd_index)
-
-        # Parsing modules happens all at one time, and from here on no useful work happens.
-        # So just report that it finished this stage.
-        modulemd_pb_data = {"message": "Parsed Modulemd", "code": "sync.parsing.modulemds"}
-        with ProgressReport(**modulemd_pb_data) as modulemd_pb:
-            modulemd_total = len(modulemd_all)
-            modulemd_pb.total = modulemd_total
-            modulemd_pb.done = modulemd_total
-
-        for modulemd in modulemd_all:
-            artifact = modulemd.pop("artifact")
-            relative_path = "{}{}{}{}{}snippet".format(
-                modulemd[PULP_MODULE_ATTR.NAME],
-                modulemd[PULP_MODULE_ATTR.STREAM],
-                modulemd[PULP_MODULE_ATTR.VERSION],
-                modulemd[PULP_MODULE_ATTR.CONTEXT],
-                modulemd[PULP_MODULE_ATTR.ARCH],
-            )
-            da = DeclarativeArtifact(
-                artifact=artifact, relative_path=relative_path, url=self.data.modules_url
-            )
-            modulemd_content = Modulemd(**modulemd)
-            dc = DeclarativeContent(content=modulemd_content, d_artifacts=[da])
-            dc.extra_data = defaultdict(list)
-
-            # dc.content.artifacts are Modulemd artifacts
-            for artifact in dc.content.artifacts:
-                self.data.nevra_to_module.setdefault(artifact, set()).add(dc)
-            self.data.modulemd_list.append(dc)
-
-        # delete list now that we're done with it for memory savings
-        del modulemd_all
-
-    def _parse_modulemd_default_names(self, modulemd_index):
-        modulemd_default_names = parse_defaults(modulemd_index)
-
-        # Parsing module-defaults happens all at one time, and from here on no useful
-        # work happens. So just report that it finished this stage.
-        modulemd_defaults_pb_data = {
-            "message": "Parsed Modulemd-defaults",
-            "code": "sync.parsing.modulemd_defaults",
-        }
-        with ProgressReport(**modulemd_defaults_pb_data) as modulemd_defaults_pb:
-            modulemd_defaults_total = len(modulemd_default_names)
-            modulemd_defaults_pb.total = modulemd_defaults_total
-            modulemd_defaults_pb.done = modulemd_defaults_total
-
-        for default in modulemd_default_names:
-            artifact = default.pop("artifact")
-            relative_path = "{}{}snippet".format(
-                default[PULP_MODULEDEFAULTS_ATTR.MODULE], default[PULP_MODULEDEFAULTS_ATTR.STREAM]
-            )
-            da = DeclarativeArtifact(
-                artifact=artifact, relative_path=relative_path, url=self.data.modules_url
-            )
-            default_content = ModulemdDefaults(**default)
-            self.default_content_dcs.append(
-                DeclarativeContent(content=default_content, d_artifacts=[da])
-            )
-
-        # delete list now that we're done with it for memory savings
-        del modulemd_default_names
-
-
-class PackagesComponentsParser:
-    """A class used for parsing packages' components (comps)."""
-
-    def __init__(self, data, comps_result):
-        """Store the data class and initialize structures required for parsing."""
-        self.data = data
-        self.comps_result = comps_result
-
-        self.group_to_categories = defaultdict(list)
-
-        self.group_to_environments = defaultdict(list)
-        self.optionalgroup_to_environments = defaultdict(list)
-
-        self.package_language_pack_dc = None
-        self.dc_categories = []
-        self.dc_environments = []
-
-    def parse(self):
-        """Parse packages' components."""
-        comps = libcomps.Comps()
-        comps.fromxml_f(self.comps_result.path)
-
-        with ProgressReport(message="Parsed Comps", code="sync.parsing.comps") as comps_pb:
-            comps_total = len(comps.groups) + len(comps.categories) + len(comps.environments)
-            comps_pb.total = comps_total
-            comps_pb.done = comps_total
-
-        if comps.langpacks:
-            langpack_dict = PackageLangpacks.libcomps_to_dict(comps.langpacks)
-            packagelangpack = PackageLangpacks(
-                matches=strdict_to_dict(comps.langpacks), digest=dict_digest(langpack_dict)
-            )
-            self.package_language_pack_dc = DeclarativeContent(content=packagelangpack)
-            self.package_language_pack_dc.extra_data = defaultdict(list)
-
-        self._init_dc_categories(comps)
-        self._init_dc_environments(comps)
-        self._init_dc_groups(comps)
-
-    def _init_dc_categories(self, comps):
-        if comps.categories:
-            for category in comps.categories:
-                category_dict = PackageCategory.libcomps_to_dict(category)
-                category_dict["digest"] = dict_digest(category_dict)
-                packagecategory = PackageCategory(**category_dict)
-                dc = DeclarativeContent(content=packagecategory)
-                dc.extra_data = defaultdict(list)
-
-                if packagecategory.group_ids:
-                    for group_id in packagecategory.group_ids:
-                        self.group_to_categories[group_id["name"]].append(dc)
-                self.dc_categories.append(dc)
-
-    def _init_dc_environments(self, comps):
-        if comps.environments:
-            for environment in comps.environments:
-                environment_dict = PackageEnvironment.libcomps_to_dict(environment)
-                environment_dict["digest"] = dict_digest(environment_dict)
-                packageenvironment = PackageEnvironment(**environment_dict)
-                dc = DeclarativeContent(content=packageenvironment)
-                dc.extra_data = defaultdict(list)
-
-                if packageenvironment.option_ids:
-                    for option_id in packageenvironment.option_ids:
-                        self.optionalgroup_to_environments[option_id["name"]].append(dc)
-
-                if packageenvironment.group_ids:
-                    for group_id in packageenvironment.group_ids:
-                        self.group_to_environments[group_id["name"]].append(dc)
-
-                self.dc_environments.append(dc)
-
-    def _init_dc_groups(self, comps):
-        if comps.groups:
-            for group in comps.groups:
-                group_dict = PackageGroup.libcomps_to_dict(group)
-                group_dict["digest"] = dict_digest(group_dict)
-                packagegroup = PackageGroup(**group_dict)
-                dc = DeclarativeContent(content=packagegroup)
-                dc.extra_data = defaultdict(list)
-
-                if packagegroup.packages:
-                    for package in packagegroup.packages:
-                        self.data.pkgname_to_groups[package["name"]].append(dc)
-
-                if dc.content.id in self.group_to_categories.keys():
-                    for dc_category in self.group_to_categories[dc.content.id]:
-                        dc.extra_data["category_relations"].append(dc_category)
-                        dc_category.extra_data["packagegroups"].append(dc)
-
-                if dc.content.id in self.group_to_environments.keys():
-                    for dc_environment in self.group_to_environments[dc.content.id]:
-                        dc.extra_data["environment_relations"].append(dc_environment)
-                        dc_environment.extra_data["packagegroups"].append(dc)
-
-                if dc.content.id in self.optionalgroup_to_environments.keys():
-                    for dc_environment in self.optionalgroup_to_environments[dc.content.id]:
-                        dc.extra_data["env_relations_optional"].append(dc_environment)
-                        dc_environment.extra_data["optionalgroups"].append(dc)
-
-                self.data.dc_groups.append(dc)
 
 
 class RpmInterrelateContent(Stage):


### PR DESCRIPTION
The existing code makes it really difficult to manage all of the places where new logic needs to be inserted.  e.g. every type of metadata is downloaded in a separate function, and tons of data is being passed around unecessarily.  Converting some classes back into functions, and merging some functions that don't really serve any benefit in being separate.

[noissue]