### PR TITLE
Ensure sub-object ordering when computing an UpdateRecord's digest.

### DIFF
--- a/CHANGES/8716.bugfix
+++ b/CHANGES/8716.bugfix
@@ -1,0 +1,1 @@
+Fixed a workflow where two identical advisories could 'look different' to Pulp.

--- a/pulp_rpm/app/models/advisory.py
+++ b/pulp_rpm/app/models/advisory.py
@@ -185,12 +185,12 @@ class UpdateRecord(Content):
         rec.pushcount = self.pushcount
 
         if not collections:
-            collections = self.collections.all()
+            collections = self.collections.all().order_by("name", "pulp_id")
 
         for collection in collections:
             rec.append_collection(collection.to_createrepo_c())
 
-        for reference in self.references.all():
+        for reference in self.references.all().order_by("href"):
             rec.append_reference(reference.to_createrepo_c())
 
         return rec
@@ -205,7 +205,7 @@ class UpdateRecord(Content):
         """
         pkglist = []
         for collection in self.collections.all():
-            for pkg in collection.packages.all():
+            for pkg in collection.packages.all().order_by("sum"):
                 nevra = (pkg.name, pkg.epoch, pkg.version, pkg.release, pkg.arch)
                 pkglist.append(nevra)
         return pkglist
@@ -219,7 +219,7 @@ class UpdateRecord(Content):
 
         """
         modlist = []
-        for collection in self.collections.all():
+        for collection in self.collections.all().order_by("name", "pulp_id"):
             mod = collection.module
             if mod:
                 nsvca = (mod["name"], mod["stream"], mod["version"], mod["context"], mod["arch"])
@@ -321,7 +321,7 @@ class UpdateCollection(BaseModel):
             module.arch = self.module["arch"]
             col.module = module
 
-        for package in self.packages.all():
+        for package in self.packages.all().order_by("sum"):
             col.append(package.to_createrepo_c())
 
         return col


### PR DESCRIPTION
If collections/references/packagelists aren't explicitly ordered,
you can end up with two identical advisories having different
digests (and therefore being different Artifacts).

Note: there is no test with this PR, because forcing the
undesireable behavior requires a heavy concurrent load on
postgres, and even then may not happen, depending on externals
like disk-speed and postgres-caching. See the referenced issue
for a manual reproducer.

fixes #8708
Required PR: https://github.com/pulp/pulp_rpm/pull/1981
[nocoverage]