### PR TITLE
Fix publication of a distribution tree for productmd 1.33+

### DIFF
--- a/CHANGES/8807.bugfix
+++ b/CHANGES/8807.bugfix
@@ -1,0 +1,1 @@
+Fixed publication of a distribution tree if productmd 1.33+ is installed.

--- a/pulp_rpm/app/kickstart/treeinfo.py
+++ b/pulp_rpm/app/kickstart/treeinfo.py
@@ -89,13 +89,13 @@ class PulpTreeInfo(TreeInfo):
 
         self.original_parser = parser
 
-    def serialize(self, parser):
+    def serialize(self, parser, main_variant=None):
         """
         Handle errors on serialize TreeInfo.
 
         """
         try:
-            super().serialize(parser)
+            super().serialize(parser, main_variant=main_variant)
         except Exception:
             sections = set(self.original_parser._sections.keys()) - set(parser._sections.keys())
             self.validate()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ createrepo_c~=0.17.0
 django_readonly_field
 jsonschema>=3.0
 libcomps~=0.1.15
-productmd>=1.25
+productmd~=1.33.0
 pulpcore>=3.13.0.dev
 PyGObject~=3.22
 solv~=0.7.17


### PR DESCRIPTION
closes #8807
https://pulp.plan.io/issues/8807