### PR TITLE
Mark static_context as not required

### DIFF
--- a/CHANGES/8814.bugfix
+++ b/CHANGES/8814.bugfix
@@ -1,0 +1,1 @@
+Allow static_context to be absent.

--- a/pulp_rpm/app/serializers/modulemd.py
+++ b/pulp_rpm/app/serializers/modulemd.py
@@ -31,6 +31,7 @@ class ModulemdSerializer(SingleArtifactContentUploadSerializer, ContentChecksumS
     )
     static_context = serializers.BooleanField(
         help_text=_("Modulemd static-context flag."),
+        required=False,
     )
     context = serializers.CharField(
         help_text=_("Modulemd context."),


### PR DESCRIPTION
Since Django 2.1 BooleanField is required=True by default.

closes #8814
https://pulp.plan.io/issues/8814