### PR TITLE
Fix unbound local error when Pulp receives a non-404 ClientResponseError

### DIFF
--- a/CHANGES/8787.bugfix
+++ b/CHANGES/8787.bugfix
@@ -1,0 +1,1 @@
+Fix UnboundLocalException if Pulp receives a non-404 HTTP error code when attempting to download metadata.


### PR DESCRIPTION
If Pulp receives a ClientResponseError when attempting to download a
file, but the status code isn't 404, then we go down the wrong code
path.

closes: #8787
https://pulp.plan.io/issues/8787