### PR TITLE
Adds changelog entry for the pinning of productmd version.

### DIFF
--- a/CHANGES/8902.bugfix
+++ b/CHANGES/8902.bugfix
@@ -1,0 +1,4 @@
+Pinned version of productmd to be <1.33.
+
+Users with productmd 1.33 were experiencing TypeError: serialize() got an unexpected keyword
+argument 'main_variant'


### PR DESCRIPTION
fixes: #8902
https://pulp.plan.io/issues/8902