### PR TITLE
Made modulemd-parsing come first, so package-parsing can be correct.

### DIFF
--- a/CHANGES/8952.bugfix
+++ b/CHANGES/8952.bugfix
@@ -1,0 +1,1 @@
+Taught sync to process modulemd before packages so is_modular can be known.

--- a/pulp_rpm/app/tasks/synchronizing.py
+++ b/pulp_rpm/app/tasks/synchronizing.py
@@ -712,17 +712,21 @@ class RpmFirstStage(Stage):
 
         await self.parse_distribution_tree()
 
+        # modularity-parsing MUST COME BEFORE package-parsing!
+        # The only way to know if a package is 'modular' in a repo, is to
+        # know that it is referenced in modulemd.
+        modulemd_list = []
+        modulemd_result = metadata_results.get("modules", None)
+        if modulemd_result:
+            modulemd_list = await self.parse_modules_metadata(modulemd_result)
+
+        # **Now** we can successfully parse package-metadata
         await self.parse_packages(
             metadata_results["primary"],
             metadata_results["filelists"],
             metadata_results["other"],
             file_extension=file_extension,
         )
-
-        modulemd_list = []
-        modulemd_result = metadata_results.get("modules", None)
-        if modulemd_result:
-            modulemd_list = await self.parse_modules_metadata(modulemd_result)
 
         groups_list = []
         comps_result = metadata_results.get("group", None)


### PR DESCRIPTION
closes #8952
[nocoverage]