### PR TITLE
Fix sync issues w/ new iterative parser

### DIFF
--- a/CHANGES/8944.bugfix
+++ b/CHANGES/8944.bugfix
@@ -1,0 +1,1 @@
+Fix an AssertionError that could occur when processing malformed (but technically valid) metadata.

--- a/CHANGES/8955.bugfix
+++ b/CHANGES/8955.bugfix
@@ -1,0 +1,1 @@
+Fix filelists and changelogs not always being parsed correctly.

--- a/pulp_rpm/app/metadata_parsing.py
+++ b/pulp_rpm/app/metadata_parsing.py
@@ -80,11 +80,11 @@ def iterative_files_changelog_parser(file_extension, filelists_xml_path, other_x
 
                 break
 
-            filelists_root_element.clear()  # clear all previously parsed ancestors of the root
-            other_root_element.clear()
-
             (filelists_pkgid, files) = process_filelists_package_element(filelists_element)
             (other_pkgid, changelogs) = process_other_package_element(other_element)
+
+            filelists_root_element.clear()  # clear all previously parsed ancestors of the root
+            other_root_element.clear()
 
             assert (
                 filelists_pkgid == other_pkgid

--- a/pulp_rpm/app/metadata_parsing.py
+++ b/pulp_rpm/app/metadata_parsing.py
@@ -100,7 +100,7 @@ def process_filelists_package_element(element):
     pkgid = element.attrib["pkgid"]
 
     files = []
-    for element in element.findall("file"):
+    for element in element.findall("{*}file"):
         basename, filename = os.path.split(element.text)
         ftype = element.attrib.get("type")
 
@@ -114,7 +114,7 @@ def process_other_package_element(element):
     pkgid = element.attrib["pkgid"]
 
     changelogs = []
-    for element in element.findall("changelog"):
+    for element in element.findall("{*}changelog"):
         author = element.attrib["author"]
         date = int(element.attrib["date"])
         text = element.text

--- a/pulp_rpm/app/models/repository.py
+++ b/pulp_rpm/app/models/repository.py
@@ -52,6 +52,9 @@ class RpmRemote(Remote):
     TYPE = "rpm"
     sles_auth_token = models.CharField(max_length=512, null=True)
 
+    DEFAULT_DOWNLOAD_CONCURRENCY = 7
+    DEFAULT_MAX_RETRIES = 4
+
     @property
     def download_factory(self):
         """


### PR DESCRIPTION
Handle duplicate packages in upstream repos

Some repositories have some packages listed in the metadata twice. This
shouldn't happen (but it does). createrepo_c deduplicates by virtue of
parsing everything into a dict keyed by pkgid, but the iterative parser
does not. This eventually results in a mismatch once the iterative
parser comes across a package that the createrepo_c primary parser
already handled. So we keep a list of pkgid's we've already written out
in order to skip them once the iterative parser hits them a 2nd (or 3rd,
etc.) time.

closes: #8944
https://pulp.plan.io/issues/8944

Fix filelists and changelogs not being properly parsed

closes: #8955
https://pulp.plan.io/issues/8955