### PR TITLE
Use proxy auth credentials of a Remote.

### DIFF
--- a/CHANGES/9064.bugfix
+++ b/CHANGES/9064.bugfix
@@ -1,0 +1,1 @@
+User proxy auth credentials of a Remote when syncing content.

--- a/pulp_rpm/app/downloaders.py
+++ b/pulp_rpm/app/downloaders.py
@@ -88,7 +88,9 @@ class RpmDownloader(HttpDownloader):
         else:
             url = self.url
 
-        async with self.session.get(url, proxy=self.proxy, auth=self.auth) as response:
+        async with self.session.get(
+            url, proxy=self.proxy, proxy_auth=self.proxy_auth, auth=self.auth
+        ) as response:
             self.raise_for_status(response)
             to_return = await self._handle_response(response)
             await response.release()


### PR DESCRIPTION
fixes: #9064
https://pulp.plan.io/issues/9064