### PR TITLE
Adapted to some (more) SUSE repo edge-cases.

### DIFF
--- a/CHANGES/8275.bugfix
+++ b/CHANGES/8275.bugfix
@@ -1,0 +1,1 @@
+Taught pulp_rpm how to deal with timestamp and filename oddities of SUSE repos.

--- a/CHANGES/9096.bugfix
+++ b/CHANGES/9096.bugfix
@@ -1,0 +1,1 @@
+Fixed a SUSE sync-error involving repomd-extra files with '-' in their filename.

--- a/coverage.md
+++ b/coverage.md
@@ -24,6 +24,8 @@ This file contains list of features and their test coverage.
 | As a user, I can sync from a mirror list with comments | YES |  |
 | As a user, I can sync from CDN using certificates | YES |  |
 | As a user, I can re-sync custom repository metadata when it was the only change in a repository | YES |  |
+| As a user, I can sync an existing advisory whose dates are timestamps (as opposed to datetimes) | NO  | Example: https://updates.suse.com/SUSE/Updates/SLE-SERVER/12-SP5/x86_64/update/ |
+| As a user, I can sync repos with repomd.xml files whose filenames contain dashes (e.g., app-icons.tar.gz) | NO  | Example: https://updates.suse.com/SUSE/Updates/SLE-SERVER/12-SP5/x86_64/update/ |
 | **Duplicates** |  |  |
 | As a user, I have only one advisory with the same id in a repo version | YES |  |
 | As a user, I have only one module with the same NSVCA in a repo version | NO |  |

--- a/pulp_rpm/app/tasks/publishing.py
+++ b/pulp_rpm/app/tasks/publishing.py
@@ -90,7 +90,9 @@ class PublicationData:
             current_file = content_artifact.artifact.file.file
             path = content_artifact.relative_path.split("/")[-1]
             if repo_metadata_file.checksum in path:
-                path = path.split("-")[-1]
+                # filenames can be checksum-xxxx.yyy - but can also be checksum-mmm-nnn-ooo.yyy
+                # split off the checksum, keep the rest
+                path = "-".join(path.split("-")[1:])
             if folder:
                 path = os.path.join(folder, path)
             with open(path, "wb") as new_file:
@@ -555,6 +557,7 @@ def generate_repo_metadata(
     repomdrecords.extend(extra_repomdrecords)
 
     sqlite_files = ("primary_db", "filelists_db", "other_db")
+
     for name, path, db_to_update in repomdrecords:
         record = cr.RepomdRecord(name, path)
         checksum_type = cr_checksum_type_from_string(


### PR DESCRIPTION
* Some metadata-files can have '-' in the filename
* Some advisory datetimes are just timestamps.

fixes #8275
[nocoverage]