### PR TITLE
Fix mirrored repositories for repos with distribution trees

### DIFF
--- a/CHANGES/9098.bugfix
+++ b/CHANGES/9098.bugfix
@@ -1,0 +1,1 @@
+Fix repository "mirroring" for repositories with Kickstart metadata / "Distribution Trees".


### PR DESCRIPTION
Fix mirrored repositories for repos with distribution trees

Two problems:
* Mirrored repositories were creating one publication per
  sub-repository, which is in contrast to the way that pulp normally
  works. Standard publish puts the sub-repos into the same publication
  in a direct sub-directory because this is the only way to have
  everything distributed properly. Otherwise the other publications are
  in-accessible.
* Even once we fix that, we still have the issue that the original
  .treeinfo contains the original relative paths. So even for the
  mirrored case, we still have to rewrite the .treeinfo data to look at
  the new repos. Luckily it's not signed or checksummed so we aren't
  prevented from doing this.

closes: #9098
https://pulp.plan.io/issues/9098
