### PR TITLE
Fix unreliable filelist parsing

### DIFF
--- a/CHANGES/8972.misc
+++ b/CHANGES/8972.misc
@@ -1,0 +1,1 @@
+Added tests that metadata is written and read correctly.

--- a/CHANGES/9107.bugfix
+++ b/CHANGES/9107.bugfix
@@ -1,0 +1,1 @@
+The fix for a previous issue resulting in incorrect metadata (#8995) was still regressing in some circumstances. Implemented a complete fix and added tests to ensure it never recurs.

--- a/coverage.md
+++ b/coverage.md
@@ -26,6 +26,7 @@ This file contains list of features and their test coverage.
 | As a user, I can re-sync custom repository metadata when it was the only change in a repository | YES |  |
 | As a user, I can sync an existing advisory whose dates are timestamps (as opposed to datetimes) | NO  | Example: https://updates.suse.com/SUSE/Updates/SLE-SERVER/12-SP5/x86_64/update/ |
 | As a user, I can sync repos with repomd.xml files whose filenames contain dashes (e.g., app-icons.tar.gz) | NO  | Example: https://updates.suse.com/SUSE/Updates/SLE-SERVER/12-SP5/x86_64/update/ |
+| As a user, the metadata being produced by Pulp (and being saved to Pulp) is correct | PART | Primary, Filelists and Other metadata is mostly covered. Updateinfo, Groups, and Distribution Tree metadata is not covered. "Weird" cases not covered. |
 | **Duplicates** |  |  |
 | As a user, I have only one advisory with the same id in a repo version | YES |  |
 | As a user, I have only one module with the same NSVCA in a repo version | NO |  |

--- a/functest_requirements.txt
+++ b/functest_requirements.txt
@@ -2,3 +2,5 @@ git+https://github.com/pulp/pulp-smash.git#egg=pulp-smash
 productmd>=1.25
 pytest
 git+https://github.com/pulp/pulpcore.git#egg=pulpcore  # re: https://pulp.plan.io/issues/7883
+dictdiffer
+xmltodict

--- a/pulp_rpm/app/metadata_parsing.py
+++ b/pulp_rpm/app/metadata_parsing.py
@@ -100,11 +100,12 @@ def process_filelists_package_element(element):
     pkgid = element.attrib["pkgid"]
 
     files = []
-    for element in element.findall("{*}file"):
-        basename, filename = os.path.split(element.text)
-        ftype = element.attrib.get("type")
-
-        files.append((ftype, basename, filename))
+    for subelement in element:
+        if subelement.tag == "file" or re.sub(NS_STRIP_RE, "", subelement.tag) == "file":
+            basename, filename = os.path.split(subelement.text)
+            basename = f"{basename}/"
+            ftype = subelement.attrib.get("type")
+            files.append((ftype, basename, filename))
 
     return pkgid, files
 
@@ -114,11 +115,11 @@ def process_other_package_element(element):
     pkgid = element.attrib["pkgid"]
 
     changelogs = []
-    for element in element.findall("{*}changelog"):
-        author = element.attrib["author"]
-        date = int(element.attrib["date"])
-        text = element.text
-
-        changelogs.append((author, date, text))
+    for subelement in element:
+        if subelement.tag == "changelog" or re.sub(NS_STRIP_RE, "", subelement.tag) == "changelog":
+            author = subelement.attrib["author"]
+            date = int(subelement.attrib["date"])
+            text = subelement.text
+            changelogs.append((author, date, text))
 
     return pkgid, changelogs

--- a/pulp_rpm/app/settings.py
+++ b/pulp_rpm/app/settings.py
@@ -8,3 +8,4 @@ Check `Plugin Writer's Guide`_ for more details.
 INSTALLED_APPS = ["django_readonly_field", "dynaconf_merge"]
 ALLOW_AUTOMATIC_UNSAFE_ADVISORY_CONFLICT_RESOLUTION = False
 DEFAULT_ULN_SERVER_BASE_URL = "https://linux-update.oracle.com/"
+RPM_ITERATIVE_PARSING = True

--- a/pulp_rpm/tests/functional/api/test_sync.py
+++ b/pulp_rpm/tests/functional/api/test_sync.py
@@ -18,6 +18,7 @@ from pulp_smash.pulp3.utils import (
     get_removed_content,
     delete_orphans,
     modify_repo,
+    wget_download_on_host,
 )
 from pulp_smash.utils import get_pulp_setting
 
@@ -137,23 +138,7 @@ class BasicSyncTestCase(PulpTestCase):
 
     def test_sync_local(self):
         """Test syncing from the local filesystem."""
-        import shutil
-
-        if not shutil.which("wget"):
-            unittest.skip("Cannot run file:// sync tests without 'wget' available.")
-
-        cli.Client(self.cfg).run(
-            (
-                "wget",
-                "--recursive",
-                "--no-parent",
-                "--no-host-directories",
-                "--directory-prefix",
-                "/tmp",
-                RPM_UNSIGNED_FIXTURE_URL,
-            )
-        )
-
+        wget_download_on_host(RPM_UNSIGNED_FIXTURE_URL, "/tmp")
         remote = self.remote_api.create(gen_rpm_remote(url="file:///tmp/rpm-unsigned/"))
 
         repo, remote = self.do_test(remote=remote, mirror=True)

--- a/pulp_rpm/tests/functional/api/test_sync.py
+++ b/pulp_rpm/tests/functional/api/test_sync.py
@@ -467,7 +467,7 @@ class BasicSyncTestCase(PulpTestCase):
                 )
             metadata["files"] = sorted(files)
 
-        diff = dictdiffer.diff(package, RPM_COMPLEX_PACKAGE_DATA)
+        diff = dictdiffer.diff(package, RPM_COMPLEX_PACKAGE_DATA, ignore={"time_file"})
         self.assertListEqual(list(diff), [], list(diff))
 
     def test_sync_diff_checksum_packages(self):

--- a/pulp_rpm/tests/functional/constants.py
+++ b/pulp_rpm/tests/functional/constants.py
@@ -1,4 +1,5 @@
 """Constants for Pulp RPM plugin tests."""
+
 from urllib.parse import urljoin
 
 from pulp_smash import config
@@ -80,6 +81,8 @@ RPM_SHA512_FIXTURE_URL = urljoin(PULP_FIXTURES_BASE_URL, "rpm-with-sha-512/")
 
 RPM_SIGNED_FIXTURE_URL = urljoin(PULP_FIXTURES_BASE_URL, "rpm-signed/")
 """The URL to a repository with signed RPM packages."""
+
+RPM_COMPLEX_FIXTURE_URL = urljoin(PULP_FIXTURES_BASE_URL, "rpm-complex-pkg/")
 
 RPM_SINGLE_REQUEST_UPLOAD = urljoin(BASE_PATH, "content/rpm/packages/")
 
@@ -197,6 +200,103 @@ RPM_PACKAGE_DATA = {
     # everything nicely
 }
 """The metadata for one RPM package."""
+
+
+RPM_COMPLEX_PACKAGE_DATA = {
+    "arch": "x86_64",
+    "artifact": None,
+    "changelogs": [
+        [
+            "Lucille Bluth <lucille@bluthcompany.com> - 1.1.1-1",
+            1617192000,
+            "- It's a banana, Michael. How much could it cost, $10?",
+        ],
+        [
+            "Job Bluth <job@alliance-of-magicians.com> - 2.2.2-2",
+            1619352000,
+            "- I've made a huge mistake",
+        ],
+        [
+            "George Bluth <george@federalprison.gov> - 3.3.3-3",
+            1623672000,
+            "- There’s always money in the banana stand",
+        ],
+    ],
+    "checksum_type": "sha256",
+    "conflicts": [["foxnetwork", "GT", "0", "5555", None, False]],
+    "description": "Complex package",
+    "enhances": [["(bananas or magic)", None, None, None, None, False]],
+    "epoch": "1",
+    "files": [
+        [None, "/etc/complex/", "pkg.cfg"],
+        [None, "/usr/bin/", "complex_a"],
+        ["dir", "/usr/share/doc/", "complex-package"],
+        [None, "/usr/share/doc/complex-package/", "README"],
+        ["dir", "/var/lib/", "complex"],
+        ["ghost", "/var/log/", "complex.log"],
+    ],
+    "is_modular": False,
+    "location_base": "",
+    "location_href": "complex-package-2.3.4-5.el8.x86_64.rpm",
+    "md5": None,
+    "name": "complex-package",
+    "obsoletes": [
+        ["bluemangroup", "LT", "0", "32.1", "0", False],
+        ["cornballer", "LT", "0", "444", None, False],
+    ],
+    "pkg_id": "bbb7b0e9350a0f75b923bdd0ef4f9af39765c668a3e70bfd3486ea9f0f618aaf",
+    "provides": [
+        ["/usr/bin/ls", None, None, None, None, False],
+        ["complex-package", "EQ", "1", "2.3.4", "5.el8", False],
+        ["complex-package(x86-64)", "EQ", "1", "2.3.4", "5.el8", False],
+        ["laughter", "EQ", "0", "33", None, False],
+        ["narration(ronhoward)", None, None, None, None, False],
+    ],
+    "recommends": [
+        ["((hiding and attic) if light-treason)", None, None, None, None, False],
+        ["GeneParmesan(PI)", None, None, None, None, False],
+        ["yacht", "GT", "9", "11.0", "0", False],
+    ],
+    "release": "5.el8",
+    "requires": [
+        ["/usr/bin/bash", None, None, None, None, False],
+        ["/usr/sbin/useradd", None, None, None, None, True],
+        ["arson", "GE", "0", "1.0.0", "1", False],
+        ["fur", "LE", "0", "2", None, False],
+        ["staircar", "LE", "0", "99.1", "3", False],
+    ],
+    "rpm_buildhost": "localhost",
+    "rpm_group": "Development/Tools",
+    "rpm_header_end": 8413,
+    "rpm_header_start": 4504,
+    "rpm_license": "MPLv2",
+    "rpm_packager": "Michael Bluth",
+    "rpm_sourcerpm": "complex-package-2.3.4-5.el8.src.rpm",
+    "rpm_vendor": "Bluth Company",
+    "sha1": None,
+    "sha224": None,
+    "sha256": None,
+    "sha384": None,
+    "sha512": None,
+    "size_archive": 932,
+    "size_installed": 117,
+    "size_package": 8680,
+    "suggests": [
+        ["(bobloblaw >= 1.1 if maritimelaw else anyone < 0.5.1-2)", None, None, None, None, False],
+        ["(dove and return)", None, None, None, None, False],
+        ["(job or money > 9000)", None, None, None, None, False],
+    ],
+    "summary": "A package for exercising many different features of RPM metadata",
+    "supplements": [
+        ["((hiding and illusion) unless alliance-of-magicians)", None, None, None, None, False],
+        ["comedy", "EQ", "0", "11.1", "4", False],
+    ],
+    "time_build": 1627052743,
+    "time_file": 1627056000,
+    "url": "http://bobloblaw.com",
+    "version": "2.3.4",
+}
+
 
 RPM_PACKAGE_DATA2 = {
     "name": "duck",

--- a/pulp_rpm/tests/functional/content_handler/test_config_repo.py
+++ b/pulp_rpm/tests/functional/content_handler/test_config_repo.py
@@ -36,29 +36,28 @@ class ContentHandlerTests(PulpTestCase):
         cls.distributions_api = DistributionsRpmApi(cls.client)
         delete_orphans(cls.cfg)
 
-    def setUp(self) -> None:
-        """Set up the test."""
-        self._setUp()
-
-    def _setUp(self, cleanup=True):
-        """Helper to the setUp method."""
+    def setUp(self):
+        """Setup method."""
         self.repo = self.repo_api.create(gen_repo())
 
         publish_data = RpmRpmPublication(repository=self.repo.pulp_href)
         publish_response = self.publications_api.create(publish_data)
         created_resources = monitor_task(publish_response.task).created_resources
-        publication_href = created_resources[0]
+        self.publication = self.publications_api.read(created_resources[0])
 
-        dist_data = gen_distribution(publication=publication_href)
+        dist_data = gen_distribution(publication=self.publication.pulp_href)
         dist_response = self.distributions_api.create(dist_data)
         created_resources = monitor_task(dist_response.task).created_resources
         self.dist = self.distributions_api.read(created_resources[0])
-        if cleanup:
-            self.addCleanup(self.repo_api.delete, self.repo.pulp_href)
-            self.addCleanup(self.publications_api.delete, publication_href)
-            self.addCleanup(self.distributions_api.delete, self.dist.pulp_href)
 
-    def testConfigRepoInListingUnsigned(self):
+    def tearDown(self):
+        """Tearddown method."""
+        if self.publication:
+            self.publications_api.delete(self.publication.pulp_href)
+        self.repo_api.delete(self.repo.pulp_href)
+        self.distributions_api.delete(self.dist.pulp_href)
+
+    def test_config_repo_in_listing_unsigned(self):
         """Whether the served resources are in the directory listing."""
         resp = requests.get(self.dist.base_url)
 
@@ -66,15 +65,12 @@ class ContentHandlerTests(PulpTestCase):
         self.assertIn(b"config.repo", resp.content)
         self.assertNotIn(b"repomd.xml.key", resp.content)
 
-    def testConfigRepoUnsigned(self):
+    def test_config_repo_unsigned(self):
         """Whether config.repo can be downloaded and has the right content."""
         self.config_repo_check()
 
-    def testConfigRepoAutoDistribute(self):
+    def test_config_repo_auto_distribute(self):
         """Whether config.repo is properly served using auto-distribute."""
-        self._setUp(cleanup=False)
-        self.addCleanup(self.repo_api.delete, self.repo.pulp_href)
-        self.addCleanup(self.distributions_api.delete, self.dist.pulp_href)
         publication_href = self.dist.publication
         body = {"repository": self.repo.pulp_href}
         monitor_task(self.distributions_api.partial_update(self.dist.pulp_href, body).task)
@@ -85,6 +81,7 @@ class ContentHandlerTests(PulpTestCase):
         self.config_repo_check()
         # Delete publication and check that 404 is now returned
         self.publications_api.delete(publication_href)
+        self.publication = None
         resp = requests.get(f"{self.dist.base_url}config.repo")
         self.assertEqual(resp.status_code, 404)
 

--- a/pulp_rpm/tests/functional/utils.py
+++ b/pulp_rpm/tests/functional/utils.py
@@ -1,4 +1,5 @@
 """Utilities for tests for the rpm plugin."""
+import gzip
 import os
 import requests
 import subprocess
@@ -251,3 +252,22 @@ def get_package_repo_path(package_filename):
 
     """
     return os.path.join(PACKAGES_DIRECTORY, package_filename.lower()[0], package_filename)
+
+
+def read_xml_gz(content):
+    """
+    Read xml and xml.gz.
+
+    Tests work normally but fails for S3 due '.gz'
+    Why is it only compressed for S3?
+    """
+    with NamedTemporaryFile() as temp_file:
+        temp_file.write(content)
+        temp_file.seek(0)
+
+        try:
+            content_xml = gzip.open(temp_file.name).read()
+        except OSError:
+            # FIXME: fix this as in CI primary/update_info.xml has '.gz' but it is not gzipped
+            content_xml = temp_file.read()
+        return content_xml


### PR DESCRIPTION
.findall() is not reliable in the face of namespaces. Don't use it
anymore.

closes: #9107
https://pulp.plan.io/issues/9107