### PR TITLE
Filter out disallowed checksums for files in extra_files.json

### DIFF
--- a/CHANGES/9111.bugfix
+++ b/CHANGES/9111.bugfix
@@ -1,0 +1,1 @@
+Fixed an issue where mirrored syncs could fail if extra_files.json declared a checksum of a type that was disallowed in the Pulp settings.


### PR DESCRIPTION
[nocoverage'

closes: #9111
https://pulp.plan.io/issues/9111