### PR TITLE
Evaluate collection package queryset in the advisory merge explicitly.

### DIFF
--- a/pulp_rpm/app/advisory.py
+++ b/pulp_rpm/app/advisory.py
@@ -256,7 +256,7 @@ def _copy_update_collections_for(advisory, collections):
     new_collections = []
     with transaction.atomic():
         for collection in collections:
-            uc_packages = collection.packages.all()
+            uc_packages = list(collection.packages.all())
             collection.pk = None
             collection.update_record = advisory
             collection.save()


### PR DESCRIPTION
Needed for Django 3.2, it works both ways in Django 2.2.

[noissue]