### PR TITLE
Configure libcomps to always generate `packagelist` element within a package group.

### DIFF
--- a/CHANGES/8713.bugfix
+++ b/CHANGES/8713.bugfix
@@ -1,0 +1,1 @@
+Fixed Pulp 3 to Pulp 2 sync for the package groups with empty packagelist, e.g. RHEL8 Appstream repository.

--- a/pulp_rpm/app/tasks/publishing.py
+++ b/pulp_rpm/app/tasks/publishing.py
@@ -525,7 +525,12 @@ def generate_repo_metadata(
 
     comps.toxml_f(
         comps_xml_path,
-        xml_options={"default_explicit": True, "empty_groups": True, "uservisible_explicit": True},
+        xml_options={
+            "default_explicit": True,
+            "empty_groups": True,
+            "empty_packages": True,
+            "uservisible_explicit": True,
+        },
     )
 
     pri_xml.close()


### PR DESCRIPTION
Pulp 2 relies on the packagelist element being present, even if it's empty.
It also seems to be a mandatory element according to this unofficial spec
https://pagure.io/rpm-metadata/blob/master/f/fedora/comps-schema/comps.dtd#_6

Before this fix, the packagelist element would only be generated if there is
at least one package in a group.

closes #8713
https://pulp.plan.io/issues/8713