### PR TITLE
Exclude a changelog entry

### DIFF
--- a/CHANGES/9096.bugfix
+++ b/CHANGES/9096.bugfix
@@ -1,1 +1,0 @@
-Fixed a SUSE sync-error involving repomd-extra files with '-' in their filename.


### PR DESCRIPTION
It was backported by accident, because 2 issues were associated with a single PR.
[noissue]