### PR TITLE
Use new, more memory-efficient createrepo_c API

### DIFF
--- a/CHANGES/9309.misc
+++ b/CHANGES/9309.misc
@@ -1,0 +1,1 @@
+Take advantage of a newer and more memory-efficient createrepo_c API for parsing metadata.

--- a/pulp_rpm/app/settings.py
+++ b/pulp_rpm/app/settings.py
@@ -9,3 +9,4 @@ INSTALLED_APPS = ["django_readonly_field", "dynaconf_merge"]
 ALLOW_AUTOMATIC_UNSAFE_ADVISORY_CONFLICT_RESOLUTION = False
 DEFAULT_ULN_SERVER_BASE_URL = "https://linux-update.oracle.com/"
 RPM_ITERATIVE_PARSING = True
+RPM_USE_OLD_ITERATIVE_PARSER = True


### PR DESCRIPTION
Currently waiting on an upstream release of createrepo_c