### PR TITLE
Fix handling of location_base / xml:base

### DIFF
--- a/CHANGES/9303.bugfix
+++ b/CHANGES/9303.bugfix
@@ -1,0 +1,1 @@
+For certain repos which use a rare feature of RPM metadata, "mirroring" would lead to a surprising / suboptimal result for most Pulp users. We now reject syncing these repos with mirroring enabled.

--- a/coverage.md
+++ b/coverage.md
@@ -60,7 +60,7 @@ This file contains list of features and their test coverage.
 | As a user, when a module is removed, its packages are removed as well ( not referenced by other modules) | NO |  |
 | As a user, I can't remove content when it is used in a repository | PART | covered list in test_crud_content |
 | **Consumer cases** |  |  |
-| As a user, I can use dnf to install all the content served by Pulp | PART | only covers rpm installation |
+| As a user, I can use dnf to install all the content served by Pulp | PART | only covers rpm installation with DNF |
 | **Retention** |  |  |
 | As a user, I can have a repository option that retains the latest N packages of the same name | PART | No coverage of packages with differing arch in same repo (src, i686, x86_64), no coverage of non-sync repo modifications, no coverage of modular RPMs being exempted. |
 | As a user, I can export RPM-repository content to be consumed by a downstream Pulp3 instance. | PART | basic pulp-export succeeds |

--- a/pulp_rpm/app/models/package.py
+++ b/pulp_rpm/app/models/package.py
@@ -288,8 +288,7 @@ class Package(Content):
             PULP_PACKAGE_ATTRS.ENHANCES: getattr(package, CR_PACKAGE_ATTRS.ENHANCES, []),
             PULP_PACKAGE_ATTRS.EPOCH: getattr(package, CR_PACKAGE_ATTRS.EPOCH) or "",
             PULP_PACKAGE_ATTRS.FILES: getattr(package, CR_PACKAGE_ATTRS.FILES, []),
-            PULP_PACKAGE_ATTRS.LOCATION_BASE: getattr(package, CR_PACKAGE_ATTRS.LOCATION_BASE)
-            or "",
+            PULP_PACKAGE_ATTRS.LOCATION_BASE: "",  # TODO, delete this entirely
             PULP_PACKAGE_ATTRS.LOCATION_HREF: getattr(package, CR_PACKAGE_ATTRS.LOCATION_HREF),
             PULP_PACKAGE_ATTRS.NAME: getattr(package, CR_PACKAGE_ATTRS.NAME),
             PULP_PACKAGE_ATTRS.OBSOLETES: getattr(package, CR_PACKAGE_ATTRS.OBSOLETES, []),
@@ -369,7 +368,7 @@ class Package(Content):
         package.enhances = list_to_createrepo_c(getattr(self, PULP_PACKAGE_ATTRS.ENHANCES))
         package.epoch = getattr(self, PULP_PACKAGE_ATTRS.EPOCH)
         package.files = list_to_createrepo_c(getattr(self, PULP_PACKAGE_ATTRS.FILES))
-        package.location_base = getattr(self, PULP_PACKAGE_ATTRS.LOCATION_BASE)
+        package.location_base = ""  # TODO: delete this entirely
         package.location_href = getattr(self, PULP_PACKAGE_ATTRS.LOCATION_HREF)
         package.name = getattr(self, PULP_PACKAGE_ATTRS.NAME)
         package.obsoletes = list_to_createrepo_c(getattr(self, PULP_PACKAGE_ATTRS.OBSOLETES))

--- a/pulp_rpm/tests/functional/api/test_character_encoding.py
+++ b/pulp_rpm/tests/functional/api/test_character_encoding.py
@@ -3,7 +3,7 @@ from urllib.parse import urljoin
 
 from pulp_smash import api, config, utils
 from pulp_smash.exceptions import TaskReportError
-from pulp_smash.pulp3.bindings import delete_orphans, PulpTestCase
+from pulp_smash.pulp3.bindings import PulpTestCase, delete_orphans
 from pulp_smash.pulp3.constants import ARTIFACTS_PATH
 from pulp_smash.pulp3.utils import (
     gen_repo,

--- a/pulp_rpm/tests/functional/api/test_consume_content.py
+++ b/pulp_rpm/tests/functional/api/test_consume_content.py
@@ -23,6 +23,7 @@ from pulp_rpm.tests.functional.constants import (
     RPM_DISTRIBUTION_PATH,
     RPM_REMOTE_PATH,
     RPM_REPO_PATH,
+    REPO_WITH_XML_BASE_URL,
 )
 from pulp_rpm.tests.functional.utils import set_up_module as setUpModule  # noqa:F401
 from pulp_rpm.tests.functional.utils import publish
@@ -83,7 +84,10 @@ class PackageManagerConsumeTestCase(PulpTestCase):
         new_artifact_count = self.artifacts_api.list().count
         self.assertEqual(new_artifact_count, self.before_consumption_artifact_count)
 
-    def do_test(self, policy):
+    def test_with_xml_base_in_metadata(self):
+        pass
+
+    def do_test(self, policy, mirror):
         """Verify whether package manager can consume content from Pulp."""
         if not self._has_dnf():
             self.skipTest("This test requires dnf")
@@ -98,7 +102,7 @@ class PackageManagerConsumeTestCase(PulpTestCase):
 
         before_sync_artifact_count = self.artifacts_api.list().count
         self.assertEqual(before_sync_artifact_count, 0)
-        sync(self.cfg, remote, repo)
+        sync(self.cfg, remote, repo, mirror=mirror)
 
         publication = publish(self.cfg, repo)
         self.addCleanup(client.delete, publication["pulp_href"])

--- a/pulp_rpm/tests/functional/constants.py
+++ b/pulp_rpm/tests/functional/constants.py
@@ -615,6 +615,8 @@ RPM_CDN_APPSTREAM_URL = "https://cdn.redhat.com/content/dist/rhel8/8.2/x86_64/ap
 RPM_CDN_BASEOS_URL = "https://cdn.redhat.com/content/dist/rhel8/8.2/x86_64/baseos/os/"
 EPEL8_MIRRORLIST_URL = "https://mirrors.fedoraproject.org/mirrorlist?repo=epel-8&arch=x86_64"
 EPEL8_PLAYGROUND_KICKSTART_URL = "http://mirrors.sonic.net/epel/playground/8/Everything/x86_64/os/"
+REPO_WITH_XML_BASE_URL = "https://harbottle.gitlab.io/harbottle-main/8/x86_64/"
+
 
 PULP_TYPE_ADVISORY = "rpm.advisory"
 PULP_TYPE_DISTRIBUTION_TREE = "rpm.distribution_tree"


### PR DESCRIPTION
This metadata feature is incompatible with metadata mirroring. Reject
repo syncs in this case and handle it more appropriately in other cases.

closes: #9303
https://pulp.plan.io/issues/9303