### PR TITLE
Download SRPMs on_demand when mirrored and ignored

### DIFF
--- a/CHANGES/9231.feature
+++ b/CHANGES/9231.feature
@@ -1,0 +1,1 @@
+The current behavior of the `skip_types` setting is that it is ignored during "mirror" syncs, as mirroring implies syncing everything. However this could significantly inflate disk space required if using the "immediate" policy. We now adjust the behavior so that in this scenario, the download policy for SRPMs is set to "on_demand" despite the overall download policy.

--- a/pulp_rpm/tests/functional/api/test_sync.py
+++ b/pulp_rpm/tests/functional/api/test_sync.py
@@ -1074,7 +1074,7 @@ class BasicSyncTestCase(PulpTestCase):
 
     def test_sync_skip_srpm_ignored_on_mirror(self):
         """SRPMs are not skipped if the repo is synced in mirror mode."""  # noqa
-        # TODO: This might change with https://pulp.plan.io/issues/9231
+        delete_orphans()
         body = gen_rpm_remote(SRPM_UNSIGNED_FIXTURE_URL)
         remote = self.remote_api.create(body)
         repo = self.repo_api.create(gen_repo())
@@ -1084,7 +1084,10 @@ class BasicSyncTestCase(PulpTestCase):
         self.addCleanup(self.remote_api.delete, remote.pulp_href)
 
         repo = self.repo_api.read(repo.pulp_href)
-        present_package_count = len(get_content(repo.to_dict())[PULP_TYPE_PACKAGE])
+        package_content = get_content(repo.to_dict())[PULP_TYPE_PACKAGE]
+        for package in package_content:
+            self.assertEqual(package["artifact"], None)
+        present_package_count = len(package_content)
         present_advisory_count = len(get_content(repo.to_dict())[PULP_TYPE_ADVISORY])
         self.assertEqual(present_package_count, SRPM_UNSIGNED_FIXTURE_PACKAGE_COUNT)
         self.assertEqual(present_advisory_count, SRPM_UNSIGNED_FIXTURE_ADVISORY_COUNT)


### PR DESCRIPTION
When skip_types contains "srpm" and mirror=True, we override the overall
download policy and download them on-demand, as they cannot be truly
ignored.

closes: #9231
https://pulp.plan.io/issues/9231