### PR TITLE
Dealt with another situation incompatible with mirror syncing

### DIFF
--- a/CHANGES/9328.bugfix
+++ b/CHANGES/9328.bugfix
@@ -1,0 +1,1 @@
+For certain repos which use a rare feature of RPM metadata, "mirroring" would lead to a broken repo. We now reject syncing these repos with mirroring enabled.

--- a/pulp_rpm/app/tasks/synchronizing.py
+++ b/pulp_rpm/app/tasks/synchronizing.py
@@ -105,9 +105,9 @@ metadata_files_for_mirroring = collections.defaultdict(dict)
 pkgid_to_location_href = collections.defaultdict(dict)
 
 
-XML_BASE_AND_MIRROR_INCOMPATIBLE_ERR_MSG = (
-    "Repositories which provide an 'xml:base' parameter (location_base) in their "
-    "metadata are incompatible with 'mirror mode'."
+MIRROR_INCOMPATIBLE_REPO_ERR_MSG = (
+    "This repository uses features which are incompatible with 'mirror' sync. "
+    "Please sync without mirroring enabled."
 )
 
 
@@ -639,8 +639,8 @@ class RpmFirstStage(Stage):
                     checksum_types[record.type] = record_checksum_type
                     record.checksum_type = record_checksum_type
 
-                    if self.mirror and record.location_base:
-                        raise ValueError(XML_BASE_AND_MIRROR_INCOMPATIBLE_ERR_MSG)
+                    if self.mirror and record.location_base or ".." in record.location_href:
+                        raise ValueError(MIRROR_INCOMPATIBLE_REPO_ERR_MSG)
 
                     if not self.mirror and record.type not in types_to_download:
                         continue
@@ -1028,8 +1028,8 @@ class RpmFirstStage(Stage):
                 Args:
                     pkg (createrepo_c.Package): A completed createrepo_c package.
                 """
-                if self.mirror and pkg.location_base:
-                    raise ValueError(XML_BASE_AND_MIRROR_INCOMPATIBLE_ERR_MSG)
+                if self.mirror and pkg.location_base or ".." in pkg.location_href:
+                    raise ValueError(MIRROR_INCOMPATIBLE_REPO_ERR_MSG)
 
                 package = Package(**Package.createrepo_to_dict(pkg))
                 base_url = pkg.location_base or self.remote_url

--- a/pulp_rpm/tests/functional/api/test_sync.py
+++ b/pulp_rpm/tests/functional/api/test_sync.py
@@ -33,6 +33,7 @@ from pulp_rpm.tests.functional.constants import (
     PULP_TYPE_PACKAGE,
     PULP_TYPE_REPOMETADATA,
     REPO_WITH_XML_BASE_URL,
+    REPO_WITH_EXTERNAL_LOCATION_HREF_URL,
     RPM_ADVISORY_CONTENT_NAME,
     RPM_ADVISORY_COUNT,
     RPM_ADVISORY_DIFFERENT_PKGLIST_URL,
@@ -1247,11 +1248,25 @@ class InvalidSyncConfigTestCase(PulpTestCase):
         )
 
     def test_mirror_with_xml_base_fails(self):
-        """Test that if a repository that uses xml:base is synced in mirror-mode, it fails."""
+        """Test that syncing a repository that uses xml:base in mirror mode fails."""
         error = self.do_test(REPO_WITH_XML_BASE_URL, mirror=True)
 
         self.assertIn(
-            "xml:base",
+            "features which are incompatible with 'mirror' sync",
+            error,
+        )
+
+    def test_mirror_with_external_location_href_fails(self):
+        """
+        Test that syncing a repository that uses contains an external location_href fails.
+
+        External location_href refers to a location_href that points outside of the repo,
+        e.g. ../../Packages/blah.rpm
+        """
+        error = self.do_test(REPO_WITH_EXTERNAL_LOCATION_HREF_URL, mirror=True)
+
+        self.assertIn(
+            "features which are incompatible with 'mirror' sync",
             error,
         )
 

--- a/pulp_rpm/tests/functional/constants.py
+++ b/pulp_rpm/tests/functional/constants.py
@@ -616,7 +616,9 @@ RPM_CDN_BASEOS_URL = "https://cdn.redhat.com/content/dist/rhel8/8.2/x86_64/baseo
 EPEL8_MIRRORLIST_URL = "https://mirrors.fedoraproject.org/mirrorlist?repo=epel-8&arch=x86_64"
 EPEL8_PLAYGROUND_KICKSTART_URL = "http://mirrors.sonic.net/epel/playground/8/Everything/x86_64/os/"
 REPO_WITH_XML_BASE_URL = "https://harbottle.gitlab.io/harbottle-main/8/x86_64/"
-
+REPO_WITH_EXTERNAL_LOCATION_HREF_URL = (
+    "https://packages.rundeck.com/pagerduty/rundeck/rpm_any/rpm_any/x86_64/"
+)
 
 PULP_TYPE_ADVISORY = "rpm.advisory"
 PULP_TYPE_DISTRIBUTION_TREE = "rpm.distribution_tree"


### PR DESCRIPTION
Some repos use location_href values that point outside of the
repository. We cannot support this in mirror mode because we cannot
write paths outside of the repository namespace.

closes: #9328
https://pulp.plan.io/issues/9328