### PR TITLE
Generated .repo should include a name field

### DIFF
--- a/CHANGES/9438.bugfix
+++ b/CHANGES/9438.bugfix
@@ -1,0 +1,1 @@
+Generated .repo file now includes the "name" field.

--- a/pulp_rpm/app/models/repository.py
+++ b/pulp_rpm/app/models/repository.py
@@ -427,10 +427,15 @@ class RpmDistribution(Distribution):
             repository, publication = self.get_repository_and_publication()
             if not publication:
                 return
-            base_url = f"{settings.CONTENT_ORIGIN}{settings.CONTENT_PATH_PREFIX}{self.base_path}/"
+            base_url = "{}/".format(
+                urlpath_sanitize(
+                    settings.CONTENT_ORIGIN, settings.CONTENT_PATH_PREFIX, self.base_path
+                )
+            )
             val = textwrap.dedent(
                 f"""\
                 [{self.name}]
+                name={self.name}
                 enabled=1
                 baseurl={base_url}
                 gpgcheck={publication.gpgcheck}
@@ -441,9 +446,7 @@ class RpmDistribution(Distribution):
             signing_service = repository.metadata_signing_service
             if signing_service:
                 gpgkey_path = urlpath_sanitize(
-                    settings.CONTENT_ORIGIN,
-                    settings.CONTENT_PATH_PREFIX,
-                    self.base_path,
+                    base_url,
                     "/repodata/repomd.xml.key",
                 )
                 val += f"gpgkey={gpgkey_path}\n"


### PR DESCRIPTION
closes: #9438
https://pulp.plan.io/issues/9438