### PR TITLE
Use checksum type of a package for publication if it's not configured.

### DIFF
--- a/CHANGES/9448.bugfix
+++ b/CHANGES/9448.bugfix
@@ -1,0 +1,2 @@
+Use checksum type of a package for publication if it's not configured.
+

--- a/pulp_rpm/app/tasks/publishing.py
+++ b/pulp_rpm/app/tasks/publishing.py
@@ -342,7 +342,15 @@ def publish(
     )
     with tempfile.TemporaryDirectory("."):
         with RpmPublication.create(repository_version) as publication:
-            publication.metadata_checksum_type = get_checksum_type("primary", checksum_types)
+            kwargs = {}
+            first_package = repository_version.content.filter(
+                pulp_type=Package.get_pulp_type()
+            ).first()
+            if first_package:
+                kwargs["default"] = first_package.cast().checksum_type
+            publication.metadata_checksum_type = get_checksum_type(
+                "primary", checksum_types, **kwargs
+            )
             publication.package_checksum_type = (
                 checksum_types.get("package") or publication.metadata_checksum_type
             )


### PR DESCRIPTION
closes #9448

[nocoverage]
[notest]