### PR TITLE
Restore embedded-basic-auth-in-url functionality.

### DIFF
--- a/CHANGES/9472.bugfix
+++ b/CHANGES/9472.bugfix
@@ -1,0 +1,6 @@
+Restored the functionality of specifying basic-auth parameters in a remote's URL.
+
+NOTE: it's much better to specify username/pwd explcitly on the Remote, rather
+than relying on embedding them in the URL. This fix will probably be deprecated in
+the future.
+(backported from #9464)


### PR DESCRIPTION
backports #9464
[nocoverage]

fixes #9472

(cherry picked from commit 6cbae29b4a08e5452f3634c204a4266f344f8b6c)