### PR TITLE
Fixed regression in Amazon-repo-downloading encoding issue.

### DIFF
--- a/CHANGES/9529.bugfix
+++ b/CHANGES/9529.bugfix
@@ -1,0 +1,2 @@
+Fixed a regression dealing with downloads of filenames containing special characters.
+Specifically, synching Amazon linux repositories with RPMs like uuid-c++.


### PR DESCRIPTION
Note RE testing - currently only Amazon's httpd causes this behavior,
and only on content-download. We'd have to have a fixture running
behind a specifically-configured webserver to reproduce the behavior.

fixes #9529
[nocoverage]