### PR TITLE
Reduce the memory usage when calculating checksum

### DIFF
--- a/plugins/pulp_rpm/plugins/distributors/yum/metadata/metadata.py
+++ b/plugins/pulp_rpm/plugins/distributors/yum/metadata/metadata.py
@@ -5,6 +5,7 @@ import traceback
 from gettext import gettext as _
 
 from pulp.plugins.util import misc
+from pulp.server.util import calculate_checksums
 
 from pulp_rpm.yum_plugin import util
 
@@ -97,8 +98,7 @@ class MetadataFileContext(object):
         file_name = os.path.basename(self.metadata_file_path)
         if self.checksum_type is not None and file_name != REPOMD_FILE_NAME:
             with open(self.metadata_file_path, 'rb') as file_handle:
-                content = file_handle.read()
-                checksum = self.checksum_constructor(content).hexdigest()
+                checksum = self.calculate_checksum(file_handle)
 
             self.checksum = checksum
             file_name_with_checksum = checksum + '-' + file_name
@@ -176,6 +176,13 @@ class MetadataFileContext(object):
             _LOG.debug('Closing metadata file: %s' % self.metadata_file_path)
             self.metadata_file_handle.flush()
             self.metadata_file_handle.close()
+
+    def calculate_checksum(self, file_handle):
+        """
+        Calculate checksum of the metadata file.
+        """
+        return calculate_checksums(file_handle, [self.checksum_type])[self.checksum_type]
+
 
     @staticmethod
     def _is_closed(file_object):

--- a/plugins/pulp_rpm/plugins/distributors/yum/metadata/repomd.py
+++ b/plugins/pulp_rpm/plugins/distributors/yum/metadata/repomd.py
@@ -8,6 +8,7 @@ from pulp_rpm.plugins.distributors.yum.metadata.metadata import (
     MetadataFileContext, REPO_DATA_DIR_NAME, REPOMD_FILE_NAME)
 
 from pulp_rpm.yum_plugin import util
+from pulp.server.util import CHECKSUM_CHUNK_SIZE
 
 
 _LOG = util.getLogger(__name__)
@@ -107,8 +108,7 @@ class RepomdXMLFileContext(MetadataFileContext):
         # calculating it again.
         if precalculated_checksum is None:
             with open(file_path, 'rb') as file_handle:
-                content = file_handle.read()
-                checksum_element.text = self.checksum_constructor(content).hexdigest()
+                checksum_element.text = self.calculate_checksum(file_handle)
         else:
             checksum_element.text = precalculated_checksum
 
@@ -132,8 +132,7 @@ class RepomdXMLFileContext(MetadataFileContext):
                     open_size = 0
                     checksum_const = self.checksum_constructor()
                     while True:
-                        # Read 1MB each time to save memory
-                        content = file_handle.read(1048576)
+                        content = file_handle.read(CHECKSUM_CHUNK_SIZE)
                         if not content:
                             break
                         open_size += len(content)


### PR DESCRIPTION
Read the metadata file in chunk when calculating its checksum to
save memory.

closes: #9553
https://pulp.plan.io/issues/9553