### PR TITLE
Ensure that /tmp is not used but the current worker working directory.

### DIFF
--- a/CHANGES/9551.bugfix
+++ b/CHANGES/9551.bugfix
@@ -1,0 +1,1 @@
+Ensured that RPM plugin uses only a worker working directory and not /tmp which could have caused the out-of-disc-space issue since it's not expected that Pulp uses /tmp.

--- a/pulp_rpm/app/serializers/package.py
+++ b/pulp_rpm/app/serializers/package.py
@@ -1,3 +1,6 @@
+import logging
+import traceback
+
 from gettext import gettext as _
 
 from rest_framework import serializers
@@ -10,6 +13,9 @@ from pulpcore.plugin.serializers import (
 
 from pulp_rpm.app.models import Package
 from pulp_rpm.app.shared_utils import _prepare_package
+
+
+log = logging.getLogger(__name__)
 
 
 class PackageSerializer(SingleArtifactContentUploadSerializer, ContentChecksumSerializer):
@@ -237,7 +243,8 @@ class PackageSerializer(SingleArtifactContentUploadSerializer, ContentChecksumSe
         try:
             new_pkg = _prepare_package(data["artifact"], data["relative_path"])
         except OSError:
-            raise NotAcceptable(detail="RPM file cannot be parsed for metadata.")
+            log.info(traceback.format_exc())
+            raise NotAcceptable(detail="RPM file cannot be parsed for metadata")
 
         attrs = {key: new_pkg[key] for key in Package.natural_key_fields()}
         package = Package.objects.filter(**attrs)

--- a/pulp_rpm/app/shared_utils.py
+++ b/pulp_rpm/app/shared_utils.py
@@ -23,7 +23,7 @@ def _prepare_package(artifact, filename):
         filename: name of file uploaded by user
     """
     artifact_file = storage.open(artifact.file.name)
-    with tempfile.NamedTemporaryFile("wb", suffix=filename) as temp_file:
+    with tempfile.NamedTemporaryFile("wb", dir=".", suffix=filename) as temp_file:
         shutil.copyfileobj(artifact_file, temp_file)
         temp_file.flush()
         cr_pkginfo = createrepo_c.package_from_rpm(temp_file.name)

--- a/pulp_rpm/app/tasks/publishing.py
+++ b/pulp_rpm/app/tasks/publishing.py
@@ -204,7 +204,7 @@ class PublicationData:
             relative_path__in=[".treeinfo", "treeinfo"]
         )
         artifact_file = storage.open(original_treeinfo_content_artifact.artifact.file.name)
-        with tempfile.NamedTemporaryFile("wb") as temp_file:
+        with tempfile.NamedTemporaryFile("wb", dir=".") as temp_file:
             shutil.copyfileobj(artifact_file, temp_file)
             temp_file.flush()
             treeinfo = PulpTreeInfo()
@@ -219,9 +219,8 @@ class PublicationData:
             main_variant = treeinfo.original_parser._sections.get("general", {}).get(
                 "variant", None
             )
-            treeinfo_file = tempfile.NamedTemporaryFile()
+            treeinfo_file = tempfile.NamedTemporaryFile(dir=".")
             treeinfo.dump(treeinfo_file.name, main_variant=main_variant)
-
             PublishedMetadata.create_from_file(
                 relative_path=original_treeinfo_content_artifact.relative_path,
                 publication=self.publication,

--- a/pulp_rpm/app/tasks/synchronizing.py
+++ b/pulp_rpm/app/tasks/synchronizing.py
@@ -423,7 +423,7 @@ def synchronize(remote_pk, repository_pk, sync_policy, skip_types, optimize, url
             main_variant = treeinfo.original_parser._sections.get("general", {}).get(
                 "variant", None
             )
-            treeinfo_file = tempfile.NamedTemporaryFile(delete=False)
+            treeinfo_file = tempfile.NamedTemporaryFile(dir=".", delete=False)
             treeinfo.dump(treeinfo_file.name, main_variant=main_variant)
             store_metadata_for_mirroring(repository, treeinfo_file.name, namespace)
             break


### PR DESCRIPTION
Also log the real traceback to make it possible to troubleshoot the failure.

closes #9551
https://pulp.plan.io/issues/9551