### PR TITLE
Subtree only sync is failing 

### DIFF
--- a/CHANGES/9565.bugfix
+++ b/CHANGES/9565.bugfix
@@ -1,0 +1,1 @@
+In case that only a subtree is synced, it can happen that the PRIMARY_REPO key does not exists in repo_sync_results and the sync failed with accessing a not existing key at the end.

--- a/pulp_rpm/app/tasks/synchronizing.py
+++ b/pulp_rpm/app/tasks/synchronizing.py
@@ -526,6 +526,7 @@ def synchronize(remote_pk, repository_pk, sync_policy, skip_types, optimize, url
             # publication needs to contain exactly the same metadata at the same paths.
             if not mirror_metadata and optimize and repo_config["should_skip"]:
                 skipped_syncs += 1
+                repo_sync_results[directory] = repo.latest_version()
                 continue
 
             stage = RpmFirstStage(


### PR DESCRIPTION
In case that only a subtree is synced, it can happen that the PRIMARY_REPO key does not exists in repo_sync_results and the sync failed with accessing a not existing key at the end.

closes: #9565

https://pulp.plan.io/issues/9565