### PR TITLE
Fixed 'sha'-using repos by teaching one more place to normalize check…

### DIFF
--- a/CHANGES/9580.bugfix
+++ b/CHANGES/9580.bugfix
@@ -1,0 +1,1 @@
+Fixed sync of repositories using 'sha' as an alias for the sha1 checksum-type.

--- a/pulp_rpm/app/tasks/synchronizing.py
+++ b/pulp_rpm/app/tasks/synchronizing.py
@@ -914,7 +914,8 @@ class RpmFirstStage(Stage):
                 if should_skip:
                     continue
 
-                file_data = {record.checksum_type: record.checksum, "size": record.size}
+                sanitized_checksum_type = getattr(CHECKSUM_TYPES, record.checksum_type.upper())
+                file_data = {sanitized_checksum_type: record.checksum, "size": record.size}
                 da = DeclarativeArtifact(
                     artifact=Artifact(**file_data),
                     url=urlpath_sanitize(self.remote_url, record.location_href),
@@ -924,7 +925,7 @@ class RpmFirstStage(Stage):
                 )
                 repo_metadata_file = RepoMetadataFile(
                     data_type=record.type,
-                    checksum_type=record.checksum_type,
+                    checksum_type=sanitized_checksum_type,
                     checksum=record.checksum,
                     relative_path=record.location_href,
                 )


### PR DESCRIPTION
…sum-type.

Test coverage is:
```
$ export FIPS_WORKFLOW=true
$ export CDN_CLIENT_CERT=`cat /PATH/TO/YOUR/cdn.crt`
$ export CDN_CLIENT_KEY=`cat /PATH/TO/YOUR/cdn.key`
$ export CDN_CA_CERT=`cat /PATH/TO/YOUR/redhat-uep.pem`
$ pulpcore-manager test pulp_rpm.tests.functional.api.test_fips_workflow.FipsRemotesTestCase.test_077_cdn_redhat_com_content_dist_rhel_server_6_6_6_x86_64_os
```

fixes #9580
[nocoverage]