### PR TITLE
Fix uln remotes http proxy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ productmd~=1.33.0
 pulpcore>=3.15.0
 PyGObject~=3.22
 solv~=0.7.17
-aiohttp_xmlrpc==1.3.2
+aiohttp_xmlrpc>1.3.2


### PR DESCRIPTION
Apparently, there was stuff wrong with the http-proxy support as well.
One of the main problems was that proxy-authentication has not been supported.

The changes required for aiohttp-xmlrpc > 1.3.2 are due to https://github.com/mosquito/aiohttp-xmlrpc/pull/48

RFC for whether I should open separate PRs and whether we need tickets for these changes.

Relates to https://github.com/pulp/pulp_rpm/pull/2200