### PR TITLE
Fix FileNotFoundError during sync or pulp-2to3 migration

### DIFF
--- a/CHANGES/9636.bugfix
+++ b/CHANGES/9636.bugfix
@@ -1,0 +1,1 @@
+Fixed `FileNotFoundError` during sync and Pulp 2 to Pulp 3 migration when a custom repo metadata has its checksum as a filename.

--- a/pulp_rpm/app/tasks/publishing.py
+++ b/pulp_rpm/app/tasks/publishing.py
@@ -91,8 +91,12 @@ class PublicationData:
             path = content_artifact.relative_path.split("/")[-1]
             if repo_metadata_file.checksum in path:
                 # filenames can be checksum-xxxx.yyy - but can also be checksum-mmm-nnn-ooo.yyy
+                # Some old repos might have filename of checksum only so we need to take care
+                # of that too
                 # split off the checksum, keep the rest
-                path = "-".join(path.split("-")[1:])
+                filename = path.split("-")[1:]
+                if filename:
+                    path = "-".join(filename)
             if folder:
                 path = os.path.join(folder, path)
             with open(path, "wb") as new_file:


### PR DESCRIPTION
It happens when a checksum is used as a filename for a custom repo metadata file.

All kudos for the fix go to @hao-yu.

closes #9636
https://pulp.plan.io/issues/9636