### PR TITLE
[3.11.z fix] DistributionTree workaround

### DIFF
--- a/CHANGES/2326.bugfix
+++ b/CHANGES/2326.bugfix
@@ -1,0 +1,1 @@
+Fixed distribution tree sync for repositories with partial .treeinfo (e.g. most of CentOS 8 repositories).

--- a/pulp_rpm/app/kickstart/treeinfo.py
+++ b/pulp_rpm/app/kickstart/treeinfo.py
@@ -128,13 +128,13 @@ class PulpTreeInfo(TreeInfo):
             if "general" not in parser._sections:
                 parser._sections["general"] = general
 
-            if "." in str(general.get("timestamp")):
+            if general.get("timestamp"):
                 build_timestamp = float(general["timestamp"])
 
         tree = self.original_parser._sections.get("tree", {})
 
-        if "." in str(tree.get("build_timestamp")):
-            build_timestamp = float(tree.get["build_timestamp"])
+        if tree.get("build_timestamp"):
+            build_timestamp = float(tree.get("build_timestamp"))
 
         if build_timestamp and parser._sections.get("general", {}).get("timestamp"):
             parser._sections["general"]["timestamp"] = build_timestamp


### PR DESCRIPTION
Affects sync and pulp-2to3-migration(if the modified stage is used).
[noissue]

Mostly a cherry-pick from c6b97ca5598af73f7ad037a1a7b5d9a604b4d697.
Resolved conflicts + added handling of duplicates in one batch,
needed for pulp-2to3-migration.