### PR TITLE
Fix data migration for pulp_rpm 3.17.0

### DIFF
--- a/CHANGES/2356.bugfix
+++ b/CHANGES/2356.bugfix
@@ -1,0 +1,1 @@
+Fixed a migration to be able to upgrade to pulp_rpm 3.17.


### PR DESCRIPTION
Users can't upgrade to pulp_rpm 3.17 without this fix, if they have
distribution tree content.
There is no harm or data problems in 3.17.0, just inability to upgrade to,
so one can safely rollback to 3.16.2.

closes #2356