### PR TITLE
Apply a sort prior to the changelog limit

### DIFF
--- a/CHANGES/2363.bugfix
+++ b/CHANGES/2363.bugfix
@@ -1,0 +1,1 @@
+Fixed an edge case with the changelog limit.

--- a/pulp_rpm/app/metadata_parsing.py
+++ b/pulp_rpm/app/metadata_parsing.py
@@ -126,6 +126,9 @@ def process_other_package_element(element):
             text = subelement.text
             changelogs.append((author, date, text))
 
+    # make sure the changelogs are sorted by date
+    changelogs.sort(key=lambda t: t[1])
+
     if settings.KEEP_CHANGELOG_LIMIT is not None:
         # always keep at least one changelog, even if the limit is set to 0
         changelog_limit = settings.KEEP_CHANGELOG_LIMIT or 1


### PR DESCRIPTION
Small adjustments to changelog limiting

Sort the changelog entries by date first. I was hoping this wasn't
necessary since both legacy createrepo and createrepo_c use a specific
order, but I discovered that Oracle Linux used to use reverse
chronological order. I have no idea what tool they used but lets play
it safe for now

closes #2363
https://github.com/pulp/pulp_rpm/issues/2363
