### PR TITLE
[PR #2380/ecfdb826 backport][3.11] Make sure more file descriptors are closed properly

### DIFF
--- a/CHANGES/2379.bugfix
+++ b/CHANGES/2379.bugfix
@@ -1,0 +1,1 @@
+Fixed a `Directory not empty` error during publication creation. Usually observed on NFS and during pulp-2to3-migration but any publication creation can be affected.


### PR DESCRIPTION
A backport of https://github.com/pulp/pulp_rpm/pull/2380.

(cherry picked from commit ecfdb826f1a337c68d4ce5ed8e15a4dae721691a)