### PR TITLE
Update CentOS URLs

### DIFF
--- a/pulp_rpm/tests/functional/api/test_sync.py
+++ b/pulp_rpm/tests/functional/api/test_sync.py
@@ -28,7 +28,7 @@ from pulp_smash.utils import get_pulp_setting
 from pulp_rpm.tests.functional.constants import (
     AMAZON_MIRROR,
     DRPM_UNSIGNED_FIXTURE_URL,
-    CENTOS7_OPSTOOLS,
+    CENTOS7_OPSTOOLS_URL,
     PULP_TYPE_ADVISORY,
     PULP_TYPE_MODULEMD,
     PULP_TYPE_PACKAGE,
@@ -1096,7 +1096,7 @@ class BasicSyncTestCase(PulpTestCase):
         repo = self.repo_api.create(gen_repo())
         self.addCleanup(self.repo_api.delete, repo.pulp_href)
 
-        body = gen_rpm_remote(url=CENTOS7_OPSTOOLS, policy="on_demand")
+        body = gen_rpm_remote(url=CENTOS7_OPSTOOLS_URL, policy="on_demand")
         remote = self.remote_api.create(body)
         self.addCleanup(self.remote_api.delete, remote.pulp_href)
 

--- a/pulp_rpm/tests/functional/constants.py
+++ b/pulp_rpm/tests/functional/constants.py
@@ -609,13 +609,16 @@ RPM_DIFF_NAME_SAME_CONTENT_URL = urljoin(PULP_FIXTURES_BASE_URL, "diff-name-same
 RPM_ONLY_METADATA_REPO_URL = urljoin(PULP_FIXTURES_BASE_URL, "rpm-unsigned-meta-only")
 
 AMAZON_MIRROR = "http://amazonlinux.us-east-1.amazonaws.com/2/core/latest/x86_64/mirror.list"
-CENTOS6_URL = "http://mirror.centos.org/centos-6/6.10/os/x86_64/"
 CENTOS7_URL = "http://mirror.centos.org/centos-7/7/os/x86_64/"
-CENTOS8_KICKSTART_APPSTREAM_URL = "http://mirror.centos.org/centos-8/8/AppStream/x86_64/kickstart/"
-CENTOS8_KICKSTART_BASEOS_URL = "http://mirror.centos.org/centos-8/8/BaseOS/x86_64/kickstart/"
-CENTOS8_APPSTREAM_URL = "http://mirror.centos.org/centos-8/8/AppStream/x86_64/os/"
-CENTOS8_BASEOS_URL = "http://mirror.centos.org/centos-8/8/BaseOS/x86_64/os/"
-CENTOS7_OPSTOOLS = "http://ftp.cs.stanford.edu/centos/7/opstools/x86_64/"
+CENTOS8_STREAM_BASEOS_URL = "http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/"
+CENTOS8_STREAM_APPSTREAM_URL = "http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/"
+CENTOS8_STREAM_KICKSTART_BASEOS_URL = (
+    "http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/kickstart/"
+)
+CENTOS8_STREAM_KICKSTART_APPSTREAM_URL = (
+    "http://mirror.centos.org/centos/8-stream/AppStream/x86_64/kickstart/"
+)
+CENTOS7_OPSTOOLS_URL = "http://ftp.cs.stanford.edu/centos/7/opstools/x86_64/"
 EPEL7_URL = "https://dl.fedoraproject.org/pub/epel/7/x86_64/"
 EPEL8_MIRRORLIST_URL = "https://mirrors.fedoraproject.org/mirrorlist?repo=epel-8&arch=x86_64"
 EPEL8_PLAYGROUND_KICKSTART_URL = "http://mirrors.sonic.net/epel/playground/8/Everything/x86_64/os/"

--- a/pulp_rpm/tests/performance/test_publish.py
+++ b/pulp_rpm/tests/performance/test_publish.py
@@ -23,10 +23,10 @@ from pulp_rpm.tests.functional.constants import (
     RPM_REMOTE_PATH,
     RPM_REPO_PATH,
     CENTOS7_URL,
-    CENTOS8_APPSTREAM_URL,
-    CENTOS8_BASEOS_URL,
-    CENTOS8_KICKSTART_APPSTREAM_URL,
-    CENTOS8_KICKSTART_BASEOS_URL,
+    CENTOS8_STREAM_APPSTREAM_URL,
+    CENTOS8_STREAM_BASEOS_URL,
+    CENTOS8_STREAM_KICKSTART_APPSTREAM_URL,
+    CENTOS8_STREAM_KICKSTART_BASEOS_URL,
     EPEL7_URL,
 )
 from pulp_rpm.tests.functional.utils import gen_rpm_remote
@@ -157,9 +157,9 @@ class PublishTestCase(unittest.TestCase):
         """Publish CentOS 7."""
         self.rpm_publish(url=CENTOS7_URL)
 
-    def test_centos8_baseos(self):
+    def test_centos_8stream_baseos(self):
         """Publish CentOS 8 BaseOS."""
-        publication_href = self.rpm_publish(url=CENTOS8_BASEOS_URL)
+        publication_href = self.rpm_publish(url=CENTOS8_STREAM_BASEOS_URL)
         # Test that the .treeinfo file is available and AppStream sub-repo is published correctly
         body = {"publication": publication_href, "name": "centos8", "base_path": "centos8"}
         response = self.client.using_handler(api.json_handler).post(RPM_DISTRIBUTION_PATH, body)
@@ -192,12 +192,12 @@ class PublishTestCase(unittest.TestCase):
 
     def test_centos8_appstream(self):
         """Publish CentOS 8 AppStream."""
-        self.rpm_publish(url=CENTOS8_APPSTREAM_URL)
+        self.rpm_publish(url=CENTOS8_STREAM_APPSTREAM_URL)
 
     def test_centos8_kickstart_baseos(self):
         """Kickstart Publish CentOS 8 BaseOS."""
-        self.rpm_publish(url=CENTOS8_KICKSTART_BASEOS_URL)
+        self.rpm_publish(url=CENTOS8_STREAM_KICKSTART_BASEOS_URL)
 
     def test_centos8_kickstart_appstream(self):
         """Kickstart Publish CentOS 8 AppStream."""
-        self.rpm_publish(url=CENTOS8_KICKSTART_APPSTREAM_URL)
+        self.rpm_publish(url=CENTOS8_STREAM_KICKSTART_APPSTREAM_URL)

--- a/pulp_rpm/tests/performance/test_pulp_to_pulp.py
+++ b/pulp_rpm/tests/performance/test_pulp_to_pulp.py
@@ -11,10 +11,10 @@ from pulp_smash.pulp3.utils import (
 
 from pulp_rpm.tests.functional.constants import (
     CENTOS7_URL,
-    CENTOS8_APPSTREAM_URL,
-    CENTOS8_BASEOS_URL,
-    CENTOS8_KICKSTART_APPSTREAM_URL,
-    CENTOS8_KICKSTART_BASEOS_URL,
+    CENTOS8_STREAM_APPSTREAM_URL,
+    CENTOS8_STREAM_BASEOS_URL,
+    CENTOS8_STREAM_KICKSTART_APPSTREAM_URL,
+    CENTOS8_STREAM_KICKSTART_BASEOS_URL,
 )
 from pulp_rpm.tests.functional.utils import (
     gen_rpm_client,
@@ -135,16 +135,16 @@ class SynctoSyncTestCase(unittest.TestCase):
 
     def test_centos8_baseos_on_demand(self):
         """Sync CentOS 8 BaseOS."""
-        self.do_test(url=CENTOS8_BASEOS_URL)
+        self.do_test(url=CENTOS8_STREAM_BASEOS_URL)
 
     def test_centos8_appstream_on_demand(self):
         """Sync CentOS 8 AppStream."""
-        self.do_test(url=CENTOS8_APPSTREAM_URL)
+        self.do_test(url=CENTOS8_STREAM_APPSTREAM_URL)
 
     def test_centos8_kickstart_baseos_on_demand(self):
         """Kickstart Sync CentOS 8 BaseOS."""
-        self.do_test(url=CENTOS8_KICKSTART_BASEOS_URL)
+        self.do_test(url=CENTOS8_STREAM_KICKSTART_BASEOS_URL)
 
     def test_centos8_kickstart_appstream_on_demand(self):
         """Kickstart Sync CentOS 8 AppStream."""
-        self.do_test(url=CENTOS8_KICKSTART_APPSTREAM_URL)
+        self.do_test(url=CENTOS8_STREAM_KICKSTART_APPSTREAM_URL)

--- a/pulp_rpm/tests/performance/test_sync.py
+++ b/pulp_rpm/tests/performance/test_sync.py
@@ -22,10 +22,10 @@ from pulp_rpm.tests.functional.constants import (
     RPM_REMOTE_PATH,
     RPM_REPO_PATH,
     CENTOS7_URL,
-    CENTOS8_APPSTREAM_URL,
-    CENTOS8_BASEOS_URL,
-    CENTOS8_KICKSTART_APPSTREAM_URL,
-    CENTOS8_KICKSTART_BASEOS_URL,
+    CENTOS8_STREAM_APPSTREAM_URL,
+    CENTOS8_STREAM_BASEOS_URL,
+    CENTOS8_STREAM_KICKSTART_APPSTREAM_URL,
+    CENTOS8_STREAM_KICKSTART_BASEOS_URL,
     EPEL8_MIRRORLIST_URL,
     EPEL8_PLAYGROUND_KICKSTART_URL,
 )
@@ -155,19 +155,19 @@ class SyncTestCase(unittest.TestCase):
 
     def test_centos8_baseos_on_demand(self):
         """Sync CentOS 8 BaseOS."""
-        self.rpm_sync(url=CENTOS8_BASEOS_URL)
+        self.rpm_sync(url=CENTOS8_STREAM_BASEOS_URL)
 
     def test_centos8_appstream_on_demand(self):
         """Sync CentOS 8 AppStream."""
-        self.rpm_sync(url=CENTOS8_APPSTREAM_URL)
+        self.rpm_sync(url=CENTOS8_STREAM_APPSTREAM_URL)
 
     def test_centos8_kickstart_baseos_on_demand(self):
         """Kickstart Sync CentOS 8 BaseOS."""
-        self.rpm_sync(url=CENTOS8_KICKSTART_BASEOS_URL)
+        self.rpm_sync(url=CENTOS8_STREAM_KICKSTART_BASEOS_URL)
 
     def test_centos8_kickstart_appstream_on_demand(self):
         """Kickstart Sync CentOS 8 AppStream."""
-        self.rpm_sync(url=CENTOS8_KICKSTART_APPSTREAM_URL)
+        self.rpm_sync(url=CENTOS8_STREAM_KICKSTART_APPSTREAM_URL)
 
     def test_epel8_mirrorlist_with_comment(self):
         """Kickstart Sync EPEL 8 (which includes a comment line)."""


### PR DESCRIPTION
CentOS 8 has been archived, repo links are dead. We could use the vault repos but they are already underprovisioned according to some CentOS project members.

Switching to use 8stream instead.

[noissue]