### PR TITLE
Remove CentOS 8 Stream kickstart tests

### DIFF
--- a/pulp_rpm/tests/functional/constants.py
+++ b/pulp_rpm/tests/functional/constants.py
@@ -612,12 +612,6 @@ AMAZON_MIRROR = "http://amazonlinux.us-east-1.amazonaws.com/2/core/latest/x86_64
 CENTOS7_URL = "http://mirror.centos.org/centos-7/7/os/x86_64/"
 CENTOS8_STREAM_BASEOS_URL = "http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/"
 CENTOS8_STREAM_APPSTREAM_URL = "http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/"
-CENTOS8_STREAM_KICKSTART_BASEOS_URL = (
-    "http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/kickstart/"
-)
-CENTOS8_STREAM_KICKSTART_APPSTREAM_URL = (
-    "http://mirror.centos.org/centos/8-stream/AppStream/x86_64/kickstart/"
-)
 CENTOS7_OPSTOOLS_URL = "http://ftp.cs.stanford.edu/centos/7/opstools/x86_64/"
 EPEL7_URL = "https://dl.fedoraproject.org/pub/epel/7/x86_64/"
 EPEL8_MIRRORLIST_URL = "https://mirrors.fedoraproject.org/mirrorlist?repo=epel-8&arch=x86_64"

--- a/pulp_rpm/tests/performance/test_sync.py
+++ b/pulp_rpm/tests/performance/test_sync.py
@@ -24,8 +24,6 @@ from pulp_rpm.tests.functional.constants import (
     CENTOS7_URL,
     CENTOS8_STREAM_APPSTREAM_URL,
     CENTOS8_STREAM_BASEOS_URL,
-    CENTOS8_STREAM_KICKSTART_APPSTREAM_URL,
-    CENTOS8_STREAM_KICKSTART_BASEOS_URL,
     EPEL8_MIRRORLIST_URL,
     EPEL8_PLAYGROUND_KICKSTART_URL,
 )
@@ -160,14 +158,6 @@ class SyncTestCase(unittest.TestCase):
     def test_centos8_appstream_on_demand(self):
         """Sync CentOS 8 AppStream."""
         self.rpm_sync(url=CENTOS8_STREAM_APPSTREAM_URL)
-
-    def test_centos8_kickstart_baseos_on_demand(self):
-        """Kickstart Sync CentOS 8 BaseOS."""
-        self.rpm_sync(url=CENTOS8_STREAM_KICKSTART_BASEOS_URL)
-
-    def test_centos8_kickstart_appstream_on_demand(self):
-        """Kickstart Sync CentOS 8 AppStream."""
-        self.rpm_sync(url=CENTOS8_STREAM_KICKSTART_APPSTREAM_URL)
 
     def test_epel8_mirrorlist_with_comment(self):
         """Kickstart Sync EPEL 8 (which includes a comment line)."""


### PR DESCRIPTION
The CentOS 8 Stream kickstart repos appear to have been removed, but the
"normal" repos have all of the kickstart metadata, so we're exercising
all the correct codepaths.

[noissue]