### PR TITLE
Fix a serializer viewset interaction issue

### DIFF
--- a/CHANGES/2430.bugfix
+++ b/CHANGES/2430.bugfix
@@ -1,0 +1,1 @@
+Fix the behavior of `gpgcheck` and `repo_gpgcheck` options when specified on the repository.

--- a/pulp_rpm/app/serializers/repository.py
+++ b/pulp_rpm/app/serializers/repository.py
@@ -217,7 +217,6 @@ class RpmPublicationSerializer(PublicationSerializer):
     gpgcheck = serializers.IntegerField(
         max_value=1,
         min_value=0,
-        default=0,
         required=False,
         help_text=_(
             "An option specifying whether a client should perform "
@@ -227,7 +226,6 @@ class RpmPublicationSerializer(PublicationSerializer):
     repo_gpgcheck = serializers.IntegerField(
         max_value=1,
         min_value=0,
-        default=0,
         required=False,
         help_text=_(
             "An option specifying whether a client should perform "


### PR DESCRIPTION
Since a default value is provided on the publication serializer, it can't properly fall back to the repository settings: https://github.com/pulp/pulp_rpm/blob/main/pulp_rpm/app/viewsets.py#L272-L275

We need it to return `None` when not provided so that ^ line can work properly.

closes #2430