### PR TITLE
Username and password fields on ULN Remotes should be hidden

### DIFF
--- a/CHANGES/2428.bugfix
+++ b/CHANGES/2428.bugfix
@@ -1,0 +1,1 @@
+Fix ULN remote `username` and `password` fields which ought to have been write-only and hidden.

--- a/pulp_rpm/app/serializers/repository.py
+++ b/pulp_rpm/app/serializers/repository.py
@@ -170,11 +170,13 @@ class UlnRemoteSerializer(RpmBaseRemoteSerializer):
     username = serializers.CharField(
         help_text=_("Your ULN account username."),
         required=True,
+        write_only=True,
     )
-
     password = serializers.CharField(
         help_text=_("Your ULN account password."),
         required=True,
+        write_only=True,
+        style={"input_type": "password"},
     )
 
     url = serializers.CharField(


### PR DESCRIPTION
closes #2428