### PR TITLE
ACS refresh for bindings

### DIFF
--- a/CHANGES/2504.bugfix
+++ b/CHANGES/2504.bugfix
@@ -1,0 +1,1 @@
+Fixes ACS to not require ``name`` in bindings.

--- a/pulp_rpm/app/serializers/__init__.py
+++ b/pulp_rpm/app/serializers/__init__.py
@@ -1,4 +1,6 @@
-from .acs import RpmAlternateContentSourceSerializer  # noqa
+from .acs import (  # noqa
+    RpmAlternateContentSourceSerializer,
+)
 from .advisory import (  # noqa
     MinimalUpdateRecordSerializer,
     UpdateCollectionSerializer,

--- a/pulp_rpm/app/viewsets/acs.py
+++ b/pulp_rpm/app/viewsets/acs.py
@@ -122,6 +122,7 @@ class RpmAlternateContentSourceViewSet(AlternateContentSourceViewSet, RolesMixin
     @extend_schema(
         description="Trigger an asynchronous task to create Alternate Content Source content.",
         responses={202: TaskGroupOperationResponseSerializer},
+        request=None,
     )
     @action(methods=["post"], detail=True)
     def refresh(self, request, pk):

--- a/pulp_rpm/tests/functional/api/test_acs.py
+++ b/pulp_rpm/tests/functional/api/test_acs.py
@@ -80,7 +80,7 @@ class AlternateContentSourceSyncTestCase(PulpTestCase):
         self.assertIn("404, message='Not Found'", ctx.exception.task.error["description"])
 
         # ACS refresh
-        acs_refresh = self.acs_api.refresh(acs.pulp_href, acs)
+        acs_refresh = self.acs_api.refresh(acs.pulp_href)
         monitor_task_group(acs_refresh.task_group)
 
         # Sync repository with metadata only


### PR DESCRIPTION
Introduce new serializer for ACS refresh to avoid
bidnings requires ACS name for refresh.

closes: #2504
https://github.com/pulp/pulp_rpm/issues/2504