### PR TITLE
Optional relative_path when upload

### DIFF
--- a/CHANGES/2440.feature
+++ b/CHANGES/2440.feature
@@ -1,0 +1,1 @@
+Make ``relative_path`` optional when uploading a package.

--- a/docs/_scripts/package.sh
+++ b/docs/_scripts/package.sh
@@ -3,7 +3,7 @@
 # Create RPM package from an artifact
 echo "Create RPM content from artifact."
 TASK_URL=$(http POST "$BASE_ADDR"/pulp/api/v3/content/rpm/packages/ \
-    artifact="$ARTIFACT_HREF" relative_path="$PKG" | jq -r '.task')
+    artifact="$ARTIFACT_HREF" | jq -r '.task')
 
 # Poll the task (here we use a function defined in docs/_scripts/base.sh)
 wait_until_task_finished "$BASE_ADDR""$TASK_URL"

--- a/docs/_scripts/package_cli.sh
+++ b/docs/_scripts/package_cli.sh
@@ -4,7 +4,6 @@
 echo "Create RPM content from artifact."
 PACKAGE_HREF=$(pulp rpm content create \
                --sha256 "${ARTIFACT_SHA256}" \
-               --relative-path "${PKG}" \
                | jq -r '.pulp_href')
 export PACKAGE_HREF
 

--- a/docs/workflows/upload.rst
+++ b/docs/workflows/upload.rst
@@ -117,6 +117,19 @@ Package GET response (after task complete):
 Add content to repository ``foo``
 *********************************
 
+.. note::
+
+   It is recommended to omit the ``relative_path`` and have Pulp generate a common pool location.
+   This will be ``/repo/Packages/s/squirrel-0.1-1.noarch.rpm`` as shown below.
+
+   When specifying a ``relative_path``, make sure to add the exact name of the package
+   including its name, version, release and arch as in ``squirrel-0.1-1.noarch.rpm``.
+   It is composed of the ``name-version-release.arch.rpm``.
+
+   .. code-block:: none
+
+      relative_path="squirrel-0.1-1.noarch.rpm"
+
 Using pulp-cli commands :
 
 .. literalinclude:: ../_scripts/add_remove_cli.sh

--- a/pulp_rpm/app/models/package.py
+++ b/pulp_rpm/app/models/package.py
@@ -332,6 +332,44 @@ class Package(Content):
             PULP_PACKAGE_ATTRS.VERSION: getattr(package, CR_PACKAGE_ATTRS.VERSION),
         }
 
+    @staticmethod
+    def to_nevra(pkg):
+        """
+        Generate NEVRA from a package metadata.
+
+        Args:
+            pkg(dict): package metadata
+
+        Returns: NEVRA as a string
+        """
+        return f"{pkg['name']}-{pkg['epoch']}:{pkg['version']}-{pkg['release']}.{pkg['arch']}.rpm"
+
+    @staticmethod
+    def to_nvra(pkg):
+        """
+        Generate NEVRA from a package metadata.
+
+        Args:
+            pkg(dict): package metadata
+
+        Returns: NVRA as a string
+        """
+        return f"{pkg['name']}-{pkg['version']}-{pkg['release']}.{pkg['arch']}.rpm"
+
+    @classmethod
+    def short_nevra(cls, pkg):
+        """
+        Returns NEVRA or NVRA based on epoch.
+
+        Args:
+            pkg(dict): package metadata
+
+        Returns: NEVRA or NVRA based on epoch.
+        """
+        if int(pkg["epoch"]) > 0:
+            return cls.to_nevra(pkg)
+        return cls.to_nvra(pkg)
+
     def to_createrepo_c(self):
         """
         Convert Package object to a createrepo_c package object.

--- a/pulp_rpm/app/models/package.py
+++ b/pulp_rpm/app/models/package.py
@@ -247,16 +247,14 @@ class Package(Content):
         """
         Package NEVRA string (Name-Epoch-Version-Release-Architecture).
         """
-        return "{n}-{e}:{v}-{r}.{a}".format(
-            n=self.name, e=self.epoch, v=self.version, r=self.release, a=self.arch
-        )
+        return self.to_nevra(self.createrepo_to_dict(self))
 
     @property
     def nvra(self):
         """
         Package NVRA string (Name-Version-Release-Architecture).
         """
-        return "{n}-{v}-{r}.{a}".format(n=self.name, v=self.version, r=self.release, a=self.arch)
+        return self.to_nvra(self.createrepo_to_dict(self))
 
     class Meta:
         default_related_name = "%(app_label)s_%(model_name)s"

--- a/pulp_rpm/app/serializers/package.py
+++ b/pulp_rpm/app/serializers/package.py
@@ -12,7 +12,7 @@ from pulpcore.plugin.serializers import (
 )
 
 from pulp_rpm.app.models import Package
-from pulp_rpm.app.shared_utils import _generate_package_nevra, _prepare_package
+from pulp_rpm.app.shared_utils import _prepare_package
 
 
 log = logging.getLogger(__name__)
@@ -274,8 +274,9 @@ class PackageSerializer(SingleArtifactContentUploadSerializer, ContentChecksumSe
                 _("There is already a package with: {values}.").format(values=error_data)
             )
 
+        new_pkg["location_href"] = Package.short_nevra(new_pkg)
         if not data.get("relative_path"):
-            data["relative_path"] = _generate_package_nevra(new_pkg)
+            data["relative_path"] = new_pkg["location_href"]
 
         data.update(new_pkg)
         return data

--- a/pulp_rpm/app/shared_utils.py
+++ b/pulp_rpm/app/shared_utils.py
@@ -32,24 +32,9 @@ def _prepare_package(artifact):
         )
 
     package = Package.createrepo_to_dict(cr_pkginfo)
-    package["location_href"] = filename
 
     artifact_file.close()
     return package
-
-
-def _generate_package_nevra(pkg):
-    """
-    Helper function to generate NEVRA.
-
-    Args:
-        pkg(dict): package metadata
-
-    Returns: NEVRA or NVRA as a string
-    """
-    if int(pkg["epoch"]) > 0:
-        return f"{pkg['name']}-{pkg['epoch']}:{pkg['version']}-{pkg['release']}.{pkg['arch']}.rpm"
-    return f"{pkg['name']}-{pkg['version']}-{pkg['release']}.{pkg['arch']}.rpm"
 
 
 def urlpath_sanitize(*args):

--- a/pulp_rpm/tests/functional/api/test_upload.py
+++ b/pulp_rpm/tests/functional/api/test_upload.py
@@ -82,5 +82,5 @@ class ContentUnitTestCase(PulpTestCase):
         """Upload a Package and return Task of upload."""
         with NamedTemporaryFile() as file_to_upload:
             file_to_upload.write(http_get(remote_path))
-            upload_attrs = {"file": file_to_upload.name, "relative_path": RPM_PACKAGE_FILENAME}
+            upload_attrs = {"file": file_to_upload.name}
             return self.content_api.create(**upload_attrs)


### PR DESCRIPTION
User doesn't have to specify ``relative_path``.
It is generated by NVRA info from package if not specified.

closes: #2440
https://github.com/pulp/pulp_rpm/issues/2440