### PR TITLE
[Pulp 2] Add changelog limit to control the size of RPM metadata

### DIFF
--- a/plugins/pulp_rpm/plugins/importers/yum/parse/rpm.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/parse/rpm.py
@@ -18,7 +18,7 @@ from pulp_rpm.plugins import error_codes
 _LOGGER = logging.getLogger(__name__)
 
 
-def get_package_xml(pkg_path, sumtype=util.TYPE_SHA256):
+def get_package_xml(pkg_path, sumtype=util.TYPE_SHA256, changelog_limit=None):
     """
     Method to generate repo xmls - primary, filelists and other
     for a given rpm.
@@ -28,6 +28,9 @@ def get_package_xml(pkg_path, sumtype=util.TYPE_SHA256):
 
     :param sumtype: The type of checksum to use for creating the package xml
     :type  sumtype: basestring
+
+    :param changelog_limit: number of changelogs to include in package xml
+    :type changelog_limit: int
 
     :return:    rpm metadata dictionary or empty if rpm path doesnt exist
     :rtype:     dict
@@ -51,7 +54,7 @@ def get_package_xml(pkg_path, sumtype=util.TYPE_SHA256):
     metadata = {
         'primary': primary_xml_snippet.encode('utf-8'),
         'filelists': po.xml_dump_filelists_metadata(),
-        'other': po.xml_dump_other_metadata(),
+        'other': po.xml_dump_other_metadata(clog_limit=changelog_limit),
     }
     return metadata
 

--- a/plugins/pulp_rpm/plugins/importers/yum/upload.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/upload.py
@@ -401,7 +401,9 @@ def _handle_package(repo, type_id, unit_key, metadata, file_path, conduit, confi
         if type_id == models.DRPM._content_type_id.default:
             unit = models.DRPM(**_extract_drpm_data(file_path))
         else:
-            repodata = rpm_parse.get_package_xml(file_path, sumtype=util.TYPE_SHA256)
+            repodata = rpm_parse.get_package_xml(file_path,
+                                                 sumtype=util.TYPE_SHA256,
+                                                 changelog_limit=config.get('changelog_limit', 10))
             package_xml = (utils.fake_xml_element(repodata['primary'], constants.COMMON_NAMESPACE)
                                 .find(primary.PACKAGE_TAG))
             unit = primary.process_package_element(package_xml)


### PR DESCRIPTION
Currently, no changelog limits are applied either when the
packages are uploaded or the metadata is published. This
resulted in extreme growth of other.xml metadata over time.
It's causing a multitude of problems like consuming excessive
memory and causing OOM while running "yum repoquery --changelog",
sync failure with timeout to download other.xml etc.
Hence, added a changelog limit, that will be picked from the
config or default to 10, to limit the number of changelogs to
be included in the xml.
