### PR TITLE
Improved error message for ACS

### DIFF
--- a/CHANGES/2667.bugfix
+++ b/CHANGES/2667.bugfix
@@ -1,0 +1,1 @@
+Improved error message for Alternate Content Source refresh when it has insufficient permissions.

--- a/pulp_rpm/app/tasks/synchronizing.py
+++ b/pulp_rpm/app/tasks/synchronizing.py
@@ -294,7 +294,10 @@ def fetch_remote_url(remote, custom_url=None):
         # which doesn't support mirror lists.
         if custom_url:
             raise ValueError(
-                _("Remote URL {} for Alternate Content Source is invalid").format(custom_url)
+                _(
+                    "ACS remote for url '{}' raised an error '{}: {}'. "
+                    "Please check your ACS remote configuration."
+                ).format(custom_url, exc.status, exc.message)
             )
         log.info(
             _("Attempting to resolve a true url from potential mirrolist url '{}'").format(url)


### PR DESCRIPTION
Improved error message for Alternate Content Source refresh when it has
insufficient permissions.

closes: #2667
https://github.com/pulp/pulp_rpm/issues/2667