### PR TITLE
[3.17] fix temp upload

### DIFF
--- a/CHANGES/2403.bugfix
+++ b/CHANGES/2403.bugfix
@@ -1,0 +1,1 @@
+Fix package temporary upload path.

--- a/pulp_rpm/app/shared_utils.py
+++ b/pulp_rpm/app/shared_utils.py
@@ -1,4 +1,5 @@
 import createrepo_c
+import os
 import tempfile
 import shutil
 
@@ -25,7 +26,7 @@ def _prepare_package(artifact, filename):
         filename: name of file uploaded by user
     """
     artifact_file = storage.open(artifact.file.name)
-    with tempfile.NamedTemporaryFile("wb", dir=".", suffix=filename) as temp_file:
+    with tempfile.NamedTemporaryFile("wb", dir=".", suffix=os.path.basename(filename)) as temp_file:
         shutil.copyfileobj(artifact_file, temp_file)
         temp_file.flush()
         cr_pkginfo = createrepo_c.package_from_rpm(


### PR DESCRIPTION
Fix temporary package upload path to not contain slashes.

closes: #2403
https://github.com/pulp/pulp_rpm/issues/2403