### PR TITLE
Check if open_size_element has text attribute

### DIFF
--- a/plugins/pulp_rpm/plugins/importers/yum/repomd/metadata.py
+++ b/plugins/pulp_rpm/plugins/importers/yum/repomd/metadata.py
@@ -437,7 +437,7 @@ def process_repomd_data_element(data_element):
         file_info['open_checksum']['hex_digest'] = open_checksum_element.text
 
     open_size_element = data_element.find(OPEN_SIZE_TAG)
-    if open_size_element is not None:
+    if open_size_element is not None and open_size_element.text:
         file_info['open_size'] = int(open_size_element.text)
 
     for child in data_element.getchildren():


### PR DESCRIPTION
This fixes a bug in sync where sync fails due to open-size tag being empty but existing in repomd file. It works fine if there is a value for size or if there is no value for open_size, but if it does exist but has no value.
I was trying to sync Rocky BaseOS repo which has the following value set for open-size tag:
`<open-size/>`

Repomd file link for reference: [https://download.rockylinux.org/pub/rocky/8/BaseOS/x86_64/os/repodata/repomd.xml](url)
Due to that, we get the following error when running sync.
>  file_info['open_size'] = int(open_size_element.text)\nTypeError: int() argument must be a string or a number, not 'NoneType'\n", 

That is why we should also check if open_size_element has a text attribute.