### PR TITLE
Ensure that Pulp never publishes repos with duplicate NEVRA

### DIFF
--- a/CHANGES/2407.bugfix
+++ b/CHANGES/2407.bugfix
@@ -1,0 +1,1 @@
+Made sure that Pulp doesn't publish repos with duplicate NEVRA in some edge case scenarios.


### PR DESCRIPTION
Some repos are incorrect up in such a way that they bypass our protections
against this scenario and Pulp ends up generating inappropriate
metadata, which then gets caught if (another) Pulp tries to sync those
repos.

closes #2407