### PR TITLE
[3.14] Allow syncing duplicate NEVRAs, pick the newest one

### DIFF
--- a/CHANGES/2691.bugfix
+++ b/CHANGES/2691.bugfix
@@ -1,0 +1,1 @@
+Allow syncing repositories with duplicate NEVRA in mirror_complete mode, but make sure syncing those packages are skipped.


### PR DESCRIPTION
For various reasons rejecting repos with duplicate NEVRA entirely in
mirror_complete modes is probably not acceptable (there's just too
many, it's user-unfriendly) and yet permitting it as the
mirror_content_only mode creates issues because the location_href values
overlap (when manually publishing the repo, only one package can be
associated with a path e.g. Packages/f/foo-1.2.3-4.noarch.rpm, and it
might not be the same one the Yum / DNF / Zypper client selects,
resulting in checksum mismatches at the client)

We solve both these problems by:

* Only syncing one package per NEVRA, even if the metadata contains >1
* Matching the heuristics of Yum / DNF when picking which to skip so
  that clients don't request the ones we don't sync (in mirror_complete
  mode where the metadata contains all of them)
* Publishing artifacts in multiple locations in mirror_complete mode to
  match the original repository.

Although, as the 2nd problem is influenced by what we have historically
allowed, more work will be needed to "clean up" in a separate PR.

closes #2691

(cherry picked from commit 5e8a76cd0cdf3d98ebbe695895876d180839bd71)