### PR TITLE
Downloader debug log for URL

### DIFF
--- a/CHANGES/3088.feature
+++ b/CHANGES/3088.feature
@@ -1,0 +1,1 @@
+Add a debug log to see where is file downloaded from.

--- a/pulp_rpm/app/downloaders.py
+++ b/pulp_rpm/app/downloaders.py
@@ -87,6 +87,8 @@ class RpmDownloader(HttpDownloader):
             self.url = urlpath_sanitize(new_url) + auth_param
         else:
             self.url = new_url
+        # Let's log a URL for debugging where the file come from
+        log.debug(f"The URL of the file to download is {self.url}")
 
     def raise_for_status(self, response):
         """


### PR DESCRIPTION
To have downloader's URL in debug log.

closes: #3088
https://github.com/pulp/pulpcore/issues/3088