### PR TITLE
Fixed orphan cleanup task failing with `Repository matching query does

### DIFF
--- a/CHANGES/2733.bugfix
+++ b/CHANGES/2733.bugfix
@@ -1,0 +1,1 @@
+Fixed orphan cleanup error in case Addon(Variant) were pointing to same subrepo.

--- a/pulp_rpm/app/models/distribution.py
+++ b/pulp_rpm/app/models/distribution.py
@@ -335,7 +335,11 @@ def cleanup_subrepos(sender, instance, **kwargs):
     Remove subrepos when a DistributionTree is being removed.
 
     """
-    subrepo = instance.repository
+    subrepo = None
+    try:
+        subrepo = instance.repository
+    except Repository.DoesNotExist:
+        pass
     if subrepo:
         Variant.objects.filter(repository=subrepo).delete()
         Addon.objects.filter(repository=subrepo).delete()


### PR DESCRIPTION
not exist`

closes #2733