### PR TITLE
Drop support for selecting md5, sha1, and sha224 during publication creation

### DIFF
--- a/CHANGES/2750.removal
+++ b/CHANGES/2750.removal
@@ -1,0 +1,1 @@
+Drop support for selecting md5, sha1, and sha224 during publication creation

--- a/pulp_rpm/app/constants.py
+++ b/pulp_rpm/app/constants.py
@@ -1,4 +1,5 @@
 from types import SimpleNamespace
+from django.conf import settings
 
 CHECKSUM_TYPES = SimpleNamespace(
     UNKNOWN="unknown",
@@ -22,6 +23,10 @@ CHECKSUM_CHOICES = (
     (CHECKSUM_TYPES.SHA384, CHECKSUM_TYPES.SHA384),
     (CHECKSUM_TYPES.SHA512, CHECKSUM_TYPES.SHA512),
 )
+
+ALLOWED_CHECKSUM_CHOICES = [
+    choice for choice in CHECKSUM_CHOICES if choice[0] in settings.ALLOWED_CONTENT_CHECKSUMS
+]
 
 ALLOWED_CHECKSUM_ERROR_MSG = """Checksum must be one of the allowed checksum types.
 You can adjust these with the 'ALLOWED_CONTENT_CHECKSUMS' setting."""

--- a/pulp_rpm/app/serializers/repository.py
+++ b/pulp_rpm/app/serializers/repository.py
@@ -22,6 +22,7 @@ from pulpcore.plugin.serializers import (
 
 from pulp_rpm.app.constants import (
     ALLOWED_CHECKSUM_ERROR_MSG,
+    ALLOWED_CHECKSUM_CHOICES,
     CHECKSUM_CHOICES,
     SKIP_TYPES,
     SYNC_POLICY_CHOICES,
@@ -210,12 +211,12 @@ class RpmPublicationSerializer(PublicationSerializer):
 
     metadata_checksum_type = serializers.ChoiceField(
         help_text=_("The checksum type for metadata."),
-        choices=CHECKSUM_CHOICES,
+        choices=ALLOWED_CHECKSUM_CHOICES,
         required=False,
     )
     package_checksum_type = serializers.ChoiceField(
         help_text=_("The checksum type for packages."),
-        choices=CHECKSUM_CHOICES,
+        choices=ALLOWED_CHECKSUM_CHOICES,
         required=False,
     )
     gpgcheck = serializers.IntegerField(

--- a/pulp_rpm/tests/functional/api/test_publish.py
+++ b/pulp_rpm/tests/functional/api/test_publish.py
@@ -1047,4 +1047,4 @@ class PublishUnsupportedChecksumTestCase(PulpTestCase):
         publish_data = RpmRpmPublication(repository=repo.pulp_href, package_checksum_type="md5")
         with self.assertRaises(ApiException) as ctx:
             self.publications.create(publish_data)
-        self.assertIn("Checksum must be one of the allowed checksum types.", ctx.exception.body)
+        self.assertIn("is not a valid choice", ctx.exception.body)


### PR DESCRIPTION

closes #2750
[nocoverage]