### PR TITLE
[3.17] Test ``is_modular``

### DIFF
--- a/CHANGES/2620.misc
+++ b/CHANGES/2620.misc
@@ -1,0 +1,1 @@
+Test ``is_modular`` flag.

--- a/coverage.md
+++ b/coverage.md
@@ -28,6 +28,7 @@ This file contains list of features and their test coverage.
 | As a user, I can sync repos with repomd.xml files whose filenames contain dashes (e.g., app-icons.tar.gz) | NO  | Example: https://updates.suse.com/SUSE/Updates/SLE-SERVER/12-SP5/x86_64/update/ |
 | As a user, the content metadata being saved to Pulp is correct | PART | Packages and distribution trees are covered. Updateinfo and Groups metadata is not covered. "Weird" cases not covered. |
 | As a user, the metadata being produced by Pulp is correct | PART | Primary, Filelists, and Other metadata is covered, Distribution Tree (.treeinfo) metadata is covered, Updateinfo and Groups metadata is not covered. "Weird" cases not covered. |
+| As a user, I can see a package from modular repository is marked as modular | YES | Using ``is modular`` field on a package |
 | **Duplicates** |  |  |
 | As a user, I have only one advisory with the same id in a repo version | YES |  |
 | As a user, I have only one module with the same NSVCA in a repo version | NO |  |

--- a/pulp_rpm/tests/functional/api/test_modular.py
+++ b/pulp_rpm/tests/functional/api/test_modular.py
@@ -1,0 +1,49 @@
+from pulpcore.client.pulp_rpm import RpmRepositorySyncURL
+
+from pulp_smash.pulp3.utils import gen_repo, get_content
+from pulp_smash.pulp3.bindings import monitor_task
+
+from pulp_rpm.tests.functional.utils import gen_rpm_remote
+from pulp_rpm.tests.functional.constants import (
+    RPM_SIGNED_FIXTURE_URL,
+    RPM_PACKAGE_CONTENT_NAME,
+    RPM_FIXTURE_SUMMARY,
+    RPM_MODULAR_FIXTURE_URL,
+)
+
+
+def test_is_modular_flag(
+    rpm_repository_api,
+    rpm_package_api,
+    rpm_rpmremote_api,
+    gen_object_with_cleanup,
+    delete_orphans_pre,
+):
+    """
+    Test package is marked as modular when synced from modular repository.
+    """
+
+    remote_data = gen_rpm_remote(RPM_SIGNED_FIXTURE_URL)
+    remote = gen_object_with_cleanup(rpm_rpmremote_api, remote_data)
+    repo_data = gen_repo(remote=remote.pulp_href)
+    repo = gen_object_with_cleanup(rpm_repository_api, repo_data)
+    sync_url = RpmRepositorySyncURL(remote=remote.pulp_href)
+    sync_response = rpm_repository_api.sync(repo.pulp_href, sync_url)
+    monitor_task(sync_response.task)
+
+    # assert no package is marked modular
+    assert rpm_package_api.list().count == RPM_FIXTURE_SUMMARY[RPM_PACKAGE_CONTENT_NAME]
+    for pkg in get_content(repo.to_dict())[RPM_PACKAGE_CONTENT_NAME]:
+        assert pkg["is_modular"] is False
+
+    remote_modular_data = gen_rpm_remote(RPM_MODULAR_FIXTURE_URL)
+    remote_modular = gen_object_with_cleanup(rpm_rpmremote_api, remote_modular_data)
+    repo_modular_data = gen_repo(remote=remote_modular.pulp_href)
+    repo_modular = gen_object_with_cleanup(rpm_repository_api, repo_modular_data)
+    sync_url = RpmRepositorySyncURL(remote=remote_modular.pulp_href)
+    sync_response = rpm_repository_api.sync(repo_modular.pulp_href, sync_url)
+    monitor_task(sync_response.task)
+
+    # assert all package from modular repo is marked as modular
+    for pkg in get_content(repo_modular.to_dict())[RPM_PACKAGE_CONTENT_NAME]:
+        assert pkg["is_modular"] is True

--- a/pulp_rpm/tests/functional/conftest.py
+++ b/pulp_rpm/tests/functional/conftest.py
@@ -1,0 +1,92 @@
+import pytest
+
+from pulpcore.client.pulp_rpm import (
+    ApiClient as RpmApiClient,
+    ContentAdvisoriesApi,
+    ContentPackagecategoriesApi,
+    ContentPackagegroupsApi,
+    ContentPackagelangpacksApi,
+    ContentPackagesApi,
+    DistributionsRpmApi,
+    PublicationsRpmApi,
+    RemotesRpmApi,
+    RemotesUlnApi,
+    RepositoriesRpmApi,
+)
+
+from pulp_smash.pulp3.bindings import delete_orphans
+
+
+@pytest.fixture(scope="session")
+def rpm_client(bindings_cfg):
+    """Fixture for RPM client."""
+    return RpmApiClient(bindings_cfg)
+
+
+@pytest.fixture(scope="session")
+def rpm_repository_api(rpm_client):
+    """Fixture for RPM repositories API."""
+    return RepositoriesRpmApi(rpm_client)
+
+
+@pytest.fixture(scope="session")
+def rpm_rpmremote_api(rpm_client):
+    """Fixture for RPM remote API."""
+    return RemotesRpmApi(rpm_client)
+
+
+@pytest.fixture(scope="session")
+def rpm_ulnremote_api(rpm_client):
+    """Fixture for RPM remote API."""
+    return RemotesUlnApi(rpm_client)
+
+
+@pytest.fixture(scope="session")
+def rpm_publication_api(rpm_client):
+    """Fixture for RPM publication API."""
+    return PublicationsRpmApi(rpm_client)
+
+
+@pytest.fixture(scope="session")
+def rpm_distribution_api(rpm_client):
+    """Fixture for RPM distribution API."""
+    return DistributionsRpmApi(rpm_client)
+
+
+@pytest.fixture(scope="session")
+def rpm_package_api(rpm_client):
+    """Fixture for RPM distribution API."""
+    return ContentPackagesApi(rpm_client)
+
+
+@pytest.fixture(scope="session")
+def rpm_advisory_api(rpm_client):
+    """Fixture for RPM distribution API."""
+    return ContentAdvisoriesApi(rpm_client)
+
+
+@pytest.fixture(scope="session")
+def rpm_package_category_api(rpm_client):
+    """Fixture for RPM distribution API."""
+    return ContentPackagecategoriesApi(rpm_client)
+
+
+@pytest.fixture(scope="session")
+def rpm_package_groups_api(rpm_client):
+    """Fixture for RPM distribution API."""
+    return ContentPackagegroupsApi(rpm_client)
+
+
+@pytest.fixture(scope="session")
+def rpm_package_lang_packs_api(rpm_client):
+    """Fixture for RPM distribution API."""
+    return ContentPackagelangpacksApi(rpm_client)
+
+
+# This will appear in pulpcore in higher versions
+@pytest.fixture
+def delete_orphans_pre(request):
+    if request.node.get_closest_marker("parallel") is not None:
+        raise pytest.UsageError("This test is not suitable to be marked parallel.")
+    delete_orphans()
+    yield


### PR DESCRIPTION
Simple test to check that modular packages are marked as modular
package. Added missing pytest config to run the test.

closes: #2620
https://github.com/pulp/pulp_rpm/issues/2620