### PR TITLE
Fix modular metadata

### DIFF
--- a/CHANGES/2786.bugfix
+++ b/CHANGES/2786.bugfix
@@ -1,0 +1,1 @@
+Fix metadata for users who already attempted to migrate to ``3.18.1`` unsuccessfully.


### PR DESCRIPTION
if already run migration with ``3.18.1`` modular metadata are corrupted.

cannot use data repair command as modular Models are broken and django cannot work with them in usual way.

closes: #2786
https://github.com/pulp/pulp_rpm/issues/2786