### PR TITLE
Added support for reusing duplicate content

### DIFF
--- a/CHANGES/2764.feature
+++ b/CHANGES/2764.feature
@@ -1,0 +1,3 @@
+The package upload feature was changed to allow the upload of packages which are already
+uploaded - in this scenario, the API will display the existing package as if it had just
+been created.

--- a/pulp_rpm/app/serializers/package.py
+++ b/pulp_rpm/app/serializers/package.py
@@ -252,28 +252,6 @@ class PackageSerializer(SingleArtifactContentUploadSerializer, ContentChecksumSe
             log.info(traceback.format_exc())
             raise NotAcceptable(detail="RPM file cannot be parsed for metadata")
 
-        attrs = {key: new_pkg[key] for key in Package.natural_key_fields()}
-        package = Package.objects.filter(**attrs)
-
-        if package.exists():
-            keywords = (
-                "name",
-                "epoch",
-                "version",
-                "release",
-                "arch",
-                "checksum_type",
-                "pkgId",
-            )
-            error_data = ", ".join(
-                ["=".join(item) for item in new_pkg.items() if item[0] in keywords]
-            )
-
-            package.get().touch()
-            raise serializers.ValidationError(
-                _("There is already a package with: {values}.").format(values=error_data)
-            )
-
         new_pkg["location_href"] = (
             format_nevra_short(
                 new_pkg["name"],
@@ -289,6 +267,17 @@ class PackageSerializer(SingleArtifactContentUploadSerializer, ContentChecksumSe
 
         data.update(new_pkg)
         return data
+
+    def retrieve(self, data):
+        try:
+            pkg = Package.createrepo_to_dict(read_crpackage_from_artifact(data["artifact"]))
+        except OSError:
+            log.info(traceback.format_exc())
+            raise NotAcceptable(detail="RPM file cannot be parsed for metadata")
+
+        package = Package(**pkg)
+
+        return Package.objects.filter(package.q()).first()
 
     class Meta:
         fields = (

--- a/pulp_rpm/tests/functional/api/test_upload.py
+++ b/pulp_rpm/tests/functional/api/test_upload.py
@@ -67,8 +67,7 @@ class ContentUnitTestCase(PulpTestCase):
         except PulpTaskError:
             pass
         task_report = self.tasks_api.read(upload.task)
-        msg = "There is already a package with"
-        self.assertTrue(msg in task_report.error["description"])
+        assert task_report.created_resources[0] == package.pulp_href
 
     def test_upload_non_ascii(self):
         """Test whether one can upload an RPM with non-ascii metadata."""


### PR DESCRIPTION
Pulpcore contains a new feature since version 3.22.0, which changes Pulp's behavior when there's an attempt to re-upload existing content. Instead of raising an exception, the pulp_href of the existing unit is returned, while this unit is possibly also added to the specified repository.

closes #2764