### PR TITLE
Do not publish unsupported metadata

### DIFF
--- a/CHANGES/2795.bugfix
+++ b/CHANGES/2795.bugfix
@@ -1,0 +1,1 @@
+Ensured unsupported metadata files are also handled during publish.

--- a/pulp_rpm/app/models/custom_metadata.py
+++ b/pulp_rpm/app/models/custom_metadata.py
@@ -23,6 +23,7 @@ class RepoMetadataFile(Content):
     """
 
     TYPE = "repo_metadata_file"
+    UNSUPPORTED_METADATA = ["prestodelta", "deltainfo"]
 
     data_type = models.TextField()
     checksum_type = models.TextField(choices=CHECKSUM_CHOICES)
@@ -34,3 +35,10 @@ class RepoMetadataFile(Content):
     class Meta:
         default_related_name = "%(app_label)s_%(model_name)s"
         unique_together = ("data_type", "checksum", "relative_path")
+
+    @property
+    def unsupported_metadata_type(self):
+        """
+        Metadata files that are known to contain deltarpm's are unsupported!
+        """
+        return self.data_type in self.UNSUPPORTED_METADATA

--- a/pulp_rpm/app/tasks/publishing.py
+++ b/pulp_rpm/app/tasks/publishing.py
@@ -88,6 +88,10 @@ class PublicationData:
         )
 
         for repo_metadata_file in repo_metadata_files:
+            if repo_metadata_file.unsupported_metadata_type:
+                # Normally these types are not synced in the first place, we skip them here, since
+                # they might still exist in old repo versions from before we started excluding them.
+                continue
             content_artifact = repo_metadata_file.contentartifact_set.get()
             current_file = content_artifact.artifact.file.file
             path = content_artifact.relative_path.split("/")[-1]

--- a/pulp_rpm/app/tasks/synchronizing.py
+++ b/pulp_rpm/app/tasks/synchronizing.py
@@ -110,7 +110,6 @@ metadata_files_for_mirroring = collections.defaultdict(dict)
 pkgid_to_location_href = collections.defaultdict(functools.partial(collections.defaultdict, set))
 
 
-UNSUPPORTED_METADATA = ["prestodelta", "deltainfo"]
 MIRROR_INCOMPATIBLE_REPO_ERR_MSG = (
     "This repository uses features which are incompatible with 'mirror' sync. "
     "Please sync without mirroring enabled."
@@ -763,7 +762,7 @@ class RpmFirstStage(Stage):
                         if (
                             uses_base_url
                             or illegal_relative_path
-                            or record.type in UNSUPPORTED_METADATA
+                            or record.type in RepoMetadataFile.UNSUPPORTED_METADATA
                         ):
                             raise ValueError(MIRROR_INCOMPATIBLE_REPO_ERR_MSG)
 
@@ -936,7 +935,7 @@ class RpmFirstStage(Stage):
                 for suffix in ["_zck", "_gz", "_xz"]:
                     if suffix in record.type:
                         should_skip = True
-                if record.type in UNSUPPORTED_METADATA:
+                if record.type in RepoMetadataFile.UNSUPPORTED_METADATA:
                     should_skip = True
 
                 if should_skip:


### PR DESCRIPTION
closes #2795

We already ignore these metadata types during sync, but if they were synced before this functionality was available, we should ignore them during publish as well!