### PR TITLE
Modular data re-sync repair

### DIFF
--- a/CHANGES/2735.bugfix
+++ b/CHANGES/2735.bugfix
@@ -1,0 +1,1 @@
+Fix recreation of modular snippet when missing.

--- a/pulp_rpm/app/modulemd.py
+++ b/pulp_rpm/app/modulemd.py
@@ -70,7 +70,7 @@ def parse_modulemd(module_names, module_index):
             modulemd = dict()
             modulemd[PULP_MODULE_ATTR.NAME] = stream.props.module_name
             modulemd[PULP_MODULE_ATTR.STREAM] = stream.props.stream_name
-            modulemd[PULP_MODULE_ATTR.VERSION] = stream.props.version
+            modulemd[PULP_MODULE_ATTR.VERSION] = str(stream.props.version)
             modulemd[PULP_MODULE_ATTR.STATIC_CONTEXT] = stream.props.static_context
             modulemd[PULP_MODULE_ATTR.CONTEXT] = stream.props.context
             modulemd[PULP_MODULE_ATTR.ARCH] = stream.props.arch

--- a/pulp_rpm/app/tasks/synchronizing.py
+++ b/pulp_rpm/app/tasks/synchronizing.py
@@ -1576,6 +1576,18 @@ class RpmQueryExistingContents(Stage):
                 ):
                     for d_content in d_content_by_nat_key[result.natural_key()]:
                         # ============ The below lines are added vs. pulpcore ============
+                        if model_type == Modulemd:
+                            # Fix saved snippet if malformed in DB, covers #2735
+                            if result.snippet != d_content.content.snippet:
+                                result.snippet = d_content.content.snippet
+                                await sync_to_async(result.save)()
+
+                        if model_type == ModulemdDefaults:
+                            # Fix saved snippet if malformed in DB, covers #2735
+                            if result.snippet != d_content.content.snippet:
+                                result.snippet = d_content.content.snippet
+                                await sync_to_async(result.save)()
+
                         if model_type == Package:
                             # changelogs coming out of the database are list[list],
                             # coming from the stage are list[tuple]


### PR DESCRIPTION
extend RpmQueryExisting stage to fix missing modular snippets.

closes: #2735
https://github.com/pulp/pulp_rpm/issues/2735