### PR TITLE
Can't use an EPEL mirror for kickstart-tests anymore.

### DIFF
--- a/CHANGES/2832.misc
+++ b/CHANGES/2832.misc
@@ -1,0 +1,1 @@
+Fixed a test that was broken by an EPEL-mirror-format change.

--- a/pulp_rpm/tests/functional/constants.py
+++ b/pulp_rpm/tests/functional/constants.py
@@ -615,7 +615,7 @@ CENTOS9_STREAM_BASEOS_URL = "http://mirror.stream.centos.org/9-stream/BaseOS/x86
 CENTOS9_STREAM_APPSTREAM_URL = "http://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/"
 EPEL7_URL = "https://dl.fedoraproject.org/pub/epel/7/x86_64/"
 EPEL8_MIRRORLIST_URL = "https://mirrors.fedoraproject.org/mirrorlist?repo=epel-8&arch=x86_64"
-EPEL8_PLAYGROUND_KICKSTART_URL = "http://mirrors.sonic.net/epel/playground/8/Everything/x86_64/os/"
+F36_KICKSTART_URL = "https://dl.fedoraproject.org/pub/fedora/linux/releases/36/Server/x86_64/os/"
 RHEL6_KICKSTART_CDN_URL = "https://cdn.redhat.com/content/dist/rhel/server/6/6.10/x86_64/kickstart/"
 RHEL8_BASEOS_CDN_URL = "https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/"
 RHEL8_APPSTREAM_CDN_URL = "https://cdn.redhat.com/content/dist/rhel8/8/x86_64/appstream/os/"

--- a/pulp_rpm/tests/performance/test_sync.py
+++ b/pulp_rpm/tests/performance/test_sync.py
@@ -25,7 +25,7 @@ from pulp_rpm.tests.functional.constants import (
     CENTOS8_STREAM_APPSTREAM_URL,
     CENTOS8_STREAM_BASEOS_URL,
     EPEL8_MIRRORLIST_URL,
-    EPEL8_PLAYGROUND_KICKSTART_URL,
+    F36_KICKSTART_URL,
 )
 from pulp_rpm.tests.functional.utils import gen_rpm_client, skip_if
 from pulpcore.client.pulp_rpm import (
@@ -167,9 +167,9 @@ class SyncTestCase(unittest.TestCase):
         # Don't fail a test due to outside data concerns...
         self.rpm_sync(url=EPEL8_MIRRORLIST_URL, check_dist_tree=False, resync=False)
 
-    def test_epel8_playground_kickstart_on_demand(self):
+    def test_f36_kickstart_on_demand(self):
         """Kickstart Sync Epel 8 playground."""
-        self.rpm_sync(url=EPEL8_PLAYGROUND_KICKSTART_URL)
+        self.rpm_sync(url=F36_KICKSTART_URL)
 
 
 class CDNTestCase(unittest.TestCase):


### PR DESCRIPTION
Changed reliance on sonic-playground-epel8 to fedora36-server.

fixes #2832