### PR TITLE
Fixed concurrent-overlapping-subrepo syncs.

### DIFF
--- a/CHANGES/2278.bugfix
+++ b/CHANGES/2278.bugfix
@@ -1,0 +1,1 @@
+Addressed concurrent-sync subrepo collisions.


### PR DESCRIPTION
Syncing the 'same' kickstart repo into multiple repositories at the same time would cause fatal errors. Taught pulp_rpm to notice the collisions and assume "whoever got there first" is The Winner.

Issue #2278 has reliable reproducer script for the failure-case.

fixes #2278.
[nocoverage]