### PR TITLE
Fixed concurrent-ks-tree-syncs by making disttree ID repo-specific.

### DIFF
--- a/CHANGES/2278.bugfix
+++ b/CHANGES/2278.bugfix
@@ -1,0 +1,3 @@
+Fixed concurrent-overlapping-sync of subrepos by making them repository-unique.
+
+This change is transparent to end-users.


### PR DESCRIPTION
DistributionTree digest and subrepo-names now both end with the pulp-id of the "owning" Repository, making them unique to that repo and therefore protected from concurrent-updates against anything that is changing that Repository.

Addon/Variant/Image are transitively made unique by virtue of having their DistributionTree be part of their unique-together.

Sub-repo **content** (e.g. Packages et al) are de-duplicated via their existing uniqueness constraints.

The end result is a minor increase in Content objects (i.e., DistTrees/Addons/Images/Variants that used to have only one instance are now one-per-containing-repo), and a small impact on subrepo-syncing (since previously-unique subrepos will now have a first-sync that would have been skipped). Content will continue to only be sync'd once.

fixes #2278.
fixes #2775.
closes #2304.
[nocoverage]