### PR TITLE
Fixes for centos8-appstream-modulemd problems.

### DIFF
--- a/pulp_rpm/app/modulemd.py
+++ b/pulp_rpm/app/modulemd.py
@@ -65,15 +65,17 @@ def split_modulmd_file(file):
     m_open = (
         gzip.open if file.url.endswith(".gz") else lzma.open if file.url.endswith(".xz") else open
     )
-    with m_open(file.path, "r") as modulemd_file:
+    # We have to be explicit here, since gzip/lzma open(...,"r") defaults to **binary** mode.
+    with m_open(file.path, "rt") as modulemd_file:
         module = ""
+
         for line in modulemd_file:
-            line = line.decode("utf-8")
             if line.startswith("---"):
                 if module:  # avoid first empty yield in the beginning of document
                     yield module
                     module = ""
             module += line
+
         yield module
 
 

--- a/pulp_rpm/app/schema/modulemd.json
+++ b/pulp_rpm/app/schema/modulemd.json
@@ -16,7 +16,7 @@
         "module": {"type": "array"},
         "content": {"type": "array"}
       },
-      "required": ["module", "content"]
+      "required": ["module"]
     }
   },
   "required": ["name", "stream", "version", "context", "arch", "summary", "description", "license"],

--- a/pulp_rpm/app/tasks/synchronizing.py
+++ b/pulp_rpm/app/tasks/synchronizing.py
@@ -986,9 +986,11 @@ class RpmFirstStage(Stage):
             dc = DeclarativeContent(content=modulemd_content)
             dc.extra_data = defaultdict(list)
             modulemd_dcs.append(dc)
+
             # dc.content.artifacts are Modulemd artifacts
-            for artifact in dc.content.artifacts["rpms"]:
-                self.nevra_to_module.setdefault(artifact, set()).add(dc)
+            if dc.content.artifacts:
+                for artifact in dc.content.artifacts["rpms"]:
+                    self.nevra_to_module.setdefault(artifact, set()).add(dc)
 
         # Parsing module-defaults happens all at one time, and from here on no useful
         # work happens. So just report that it finished this stage.
@@ -1152,7 +1154,8 @@ class RpmFirstStage(Stage):
 
         # Module artifacts are divided by a type, here we need packages
         for modulemd in modulemd_list:
-            modular_artifact_nevras |= set(modulemd[PULP_MODULE_ATTR.ARTIFACTS].get("rpms"))
+            if modulemd[PULP_MODULE_ATTR.ARTIFACTS]:
+                modular_artifact_nevras |= set(modulemd[PULP_MODULE_ATTR.ARTIFACTS].get("rpms"))
 
         package_skip_nevras = set()
         # The repository can contain packages of arbitrary arches, and they are not comparable.


### PR DESCRIPTION
There exists a modulemd whose license has no 'content', and which has no artifacts. Adapt the code that assumes modulemds all Make Sense.

Coverage is in the 'performance' tests - that's what uncovered the problems in the first place.

[noissue]
[nocoverage]