### PR TITLE
Added 'treeinfo' to available skip-types at sync time.

### DIFF
--- a/CHANGES/2848.misc
+++ b/CHANGES/2848.misc
@@ -1,0 +1,3 @@
+Added "treeinfo" to available skip_types at sync-time. This option
+allows the user to sync a repository without pulling down
+kickstart data and sub-repositories.

--- a/docs/workflows/create_sync_publish.rst
+++ b/docs/workflows/create_sync_publish.rst
@@ -206,6 +206,10 @@ The ``mirror`` option is deprecated, ``sync_policy`` should be used instead. If 
 Optionally, you can skip ``SRPM`` packages by using ``skip_types:="[\"srpm\"]"``
 option.
 
+Optionally, you can skip kickstart-trees referred to by a parent repository by using ``skip_types:="[\"treeinfo\"]"``
+
+You can combine these options by using by using ``skip_types:="[\"srpm\", \"treeinfo\"]"``.
+
 By default, ``optimize=True`` and sync will only proceed if changes are present.
 You can override this by setting ``optimize=False`` which will disable optimizations and
 run a full sync.

--- a/pulp_rpm/app/constants.py
+++ b/pulp_rpm/app/constants.py
@@ -81,7 +81,7 @@ PACKAGE_DB_REPODATA = ["primary_db", "filelists_db", "other_db"]
 UPDATE_REPODATA = ["updateinfo"]
 MODULAR_REPODATA = ["modules"]
 COMPS_REPODATA = ["group"]
-SKIP_TYPES = ["srpm"]
+SKIP_TYPES = ["srpm", "treeinfo"]
 
 CR_UPDATE_RECORD_ATTRS = SimpleNamespace(
     ID="id",

--- a/pulp_rpm/app/tasks/synchronizing.py
+++ b/pulp_rpm/app/tasks/synchronizing.py
@@ -411,10 +411,14 @@ def synchronize(remote_pk, repository_pk, sync_policy, skip_types, optimize, url
     log.info(_("Synchronizing: repository={r} remote={p}").format(r=repository.name, p=remote.name))
 
     deferred_download = remote.policy != Remote.IMMEDIATE  # Interpret download policy
+    skip_treeinfo = "treeinfo" in skip_types
 
     def get_treeinfo_data(remote, remote_url):
         """Get Treeinfo data from remote."""
         treeinfo_serialized = {}
+        if skip_treeinfo:
+            return treeinfo_serialized
+
         namespaces = [".treeinfo", "treeinfo"]
         for namespace in namespaces:
             downloader = remote.get_downloader(
@@ -457,8 +461,8 @@ def synchronize(remote_pk, repository_pk, sync_policy, skip_types, optimize, url
             repomd_path = result.path
             repomd = cr.Repomd(repomd_path)
             repomd_checksum = get_sha256(repomd_path)
-            treinfo_file_data = get_treeinfo_data(remote, url)
-            treeinfo_checksum = treinfo_file_data.get("hash", "")
+            treeinfo_file_data = get_treeinfo_data(remote, url)
+            treeinfo_checksum = treeinfo_file_data.get("hash", "")
 
         return {
             "url": remote.url,  # use the original remote url so that mirrorlists are optimizable


### PR DESCRIPTION
Lets user sync only the parent repository, and not any of the treeinfo data or subrepos.

closes #2848.

(cherry picked from commit c0afe5aaa91673fb14150fd8103e04)