### PR TITLE
Allow "group" aka comps metadata to be compressed

### DIFF
--- a/CHANGES/2753.bugfix
+++ b/CHANGES/2753.bugfix
@@ -1,0 +1,1 @@
+Allow syncing repos with a compressed comps.xml "group" metadata declared in repomd.xml.

--- a/pulp_rpm/app/shared_utils.py
+++ b/pulp_rpm/app/shared_utils.py
@@ -1,7 +1,6 @@
-import createrepo_c
+import createrepo_c as cr
 import tempfile
 import shutil
-
 from hashlib import sha256
 
 from django.conf import settings
@@ -49,7 +48,7 @@ def read_crpackage_from_artifact(artifact):
     with tempfile.NamedTemporaryFile("wb", dir=".", suffix=filename) as temp_file:
         shutil.copyfileobj(artifact_file, temp_file)
         temp_file.flush()
-        cr_pkginfo = createrepo_c.package_from_rpm(
+        cr_pkginfo = cr.package_from_rpm(
             temp_file.name, changelog_limit=settings.KEEP_CHANGELOG_LIMIT
         )
 

--- a/pulp_rpm/app/tasks/synchronizing.py
+++ b/pulp_rpm/app/tasks/synchronizing.py
@@ -87,7 +87,11 @@ from pulp_rpm.app.modulemd import parse_modular
 from pulp_rpm.app.comps import strdict_to_dict, dict_digest
 from pulp_rpm.app.kickstart.treeinfo import PulpTreeInfo, TreeinfoData
 from pulp_rpm.app.metadata_parsing import MetadataParser
-from pulp_rpm.app.shared_utils import is_previous_version, get_sha256, urlpath_sanitize
+from pulp_rpm.app.shared_utils import (
+    is_previous_version,
+    get_sha256,
+    urlpath_sanitize,
+)
 from pulp_rpm.app.rpm_version import RpmVersion
 
 log = logging.getLogger(__name__)
@@ -1051,7 +1055,11 @@ class RpmFirstStage(Stage):
         dc_groups = []
 
         comps = libcomps.Comps()
-        comps.fromxml_f(comps_result.path)
+        with tempfile.TemporaryDirectory(dir=".") as tf:
+            decompressed_path = os.path.join(tf, "comps.xml")
+            cr.decompress_file(comps_result.path, decompressed_path, cr.AUTO_DETECT_COMPRESSION)
+            with open(decompressed_path) as f:
+                comps.fromxml_str(f.read())
 
         async with ProgressReport(message="Parsed Comps", code="sync.parsing.comps") as comps_pb:
             comps_total = len(comps.groups) + len(comps.categories) + len(comps.environments)


### PR DESCRIPTION
DNF supports compressed comps metadata - compression type is determined by filename and happens transparently the same for comps as it does for any other file.

closes #2753