### PR TITLE
[3.18] Allow "group" aka comps metadata to be compressed

### DIFF
--- a/CHANGES/2753.bugfix
+++ b/CHANGES/2753.bugfix
@@ -1,0 +1,1 @@
+Allow syncing repos with a compressed comps.xml "group" metadata declared in repomd.xml.

--- a/pulp_rpm/app/shared_utils.py
+++ b/pulp_rpm/app/shared_utils.py
@@ -1,7 +1,6 @@
-import createrepo_c
+import createrepo_c as cr
 import tempfile
 import shutil
-
 from hashlib import sha256
 
 from django.conf import settings
@@ -49,7 +48,7 @@ def read_crpackage_from_artifact(artifact):
     with tempfile.NamedTemporaryFile("wb", dir=".", suffix=filename) as temp_file:
         shutil.copyfileobj(artifact_file, temp_file)
         temp_file.flush()
-        cr_pkginfo = createrepo_c.package_from_rpm(
+        cr_pkginfo = cr.package_from_rpm(
             temp_file.name, changelog_limit=settings.KEEP_CHANGELOG_LIMIT
         )
 


### PR DESCRIPTION
DNF supports compressed comps metadata - compression type is determined by filename and happens transparently the same for comps as it does for any other file.

closes #2753