### PR TITLE
Revert "Added support for reusing duplicate content"

### DIFF
--- a/CHANGES/2764.feature
+++ b/CHANGES/2764.feature
@@ -1,3 +1,0 @@
-The package upload feature was changed to allow the upload of packages which are already
-uploaded - in this scenario, the API will display the existing package as if it had just
-been created.

--- a/pulp_rpm/tests/functional/api/test_crud_content_unit.py
+++ b/pulp_rpm/tests/functional/api/test_crud_content_unit.py
@@ -6,15 +6,10 @@ from urllib.parse import urljoin
 from pulp_smash.pulp3.bindings import (
     delete_orphans,
     monitor_task,
+    PulpTaskError,
     PulpTestCase,
 )
-
-from pulp_smash.pulp3.utils import (
-    gen_repo,
-    get_content,
-    get_content_summary,
-    get_added_content_summary,
-)
+from pulp_smash.pulp3.utils import gen_repo, get_content
 
 from pulp_rpm.tests.functional.utils import (
     gen_artifact,
@@ -57,10 +52,8 @@ class ContentUnitTestCase(PulpTestCase):
         """Create class-wide variable."""
         delete_orphans()
         cls.content_unit = {}
+        cls.rpm_content_api = ContentPackagesApi(gen_rpm_client())
         cls.artifact = gen_artifact(RPM_SIGNED_URL)
-        cls.client = gen_rpm_client()
-        cls.rpm_content_api = ContentPackagesApi(cls.client)
-        cls.repo_api = RepositoriesRpmApi(cls.client)
 
     @classmethod
     def tearDownClass(cls):
@@ -133,31 +126,15 @@ class ContentUnitTestCase(PulpTestCase):
         self.assertIn(msg, exc.exception.args[0])
 
     @skip_if(bool, "content_unit", False)
-    def test_05_duplicate_no_repo_return_existing_href(self):
-        """Attempt to create duplicate package without specifying a repository."""
+    def test_05_duplicate_raise_error(self):
+        """Attempt to create duplicate package."""
         attrs = gen_rpm_content_attrs(self.artifact, RPM_PACKAGE_FILENAME)
         response = self.rpm_content_api.create(**attrs)
-        duplicate = self.rpm_content_api.read(monitor_task(response.task).created_resources[0])
-        assert duplicate.pulp_href == self.content_unit["pulp_href"]
-
-    @skip_if(bool, "content_unit", False)
-    def test_06_duplicate_add_to_repo(self):
-        """Attempt to create duplicate package while specifying a repository."""
-        repo = self.repo_api.create(gen_repo())
-        attrs = gen_rpm_content_attrs(self.artifact, RPM_PACKAGE_FILENAME)
-        attrs["repository"] = repo.pulp_href
-        response = self.rpm_content_api.create(**attrs)
-        monitored_response = monitor_task(response.task)
-
-        duplicate = self.rpm_content_api.read(monitored_response.created_resources[1])
-        assert duplicate.pulp_href == self.content_unit["pulp_href"]
-
-        repo = self.repo_api.read(repo.pulp_href)
-        assert repo.latest_version_href.endswith("/versions/1/")
-        assert get_content_summary(repo.to_dict()) == {"rpm.package": 1}
-        assert get_added_content_summary(repo.to_dict()) == {"rpm.package": 1}
-
-        self.repo_api.delete(repo.pulp_href)
+        with self.assertRaises(PulpTaskError) as cm:
+            monitor_task(response.task)
+        task_result = cm.exception.task.to_dict()
+        msg = "There is already a package with"
+        self.assertTrue(msg in task_result["error"]["description"])
 
 
 class ContentUnitRemoveTestCase(PulpTestCase):

--- a/pulp_rpm/tests/functional/api/test_upload.py
+++ b/pulp_rpm/tests/functional/api/test_upload.py
@@ -67,7 +67,8 @@ class ContentUnitTestCase(PulpTestCase):
         except PulpTaskError:
             pass
         task_report = self.tasks_api.read(upload.task)
-        assert task_report.created_resources[0] == package.pulp_href
+        msg = "There is already a package with"
+        self.assertTrue(msg in task_report.error["description"])
 
     def test_upload_non_ascii(self):
         """Test whether one can upload an RPM with non-ascii metadata."""


### PR DESCRIPTION
Reverting because there are a number of upload-related issues in pulp_rpm, and we don't want to make things worse in the released code until we've resolved what to do with/for them.

This reverts commit 54ec7c3f2e0a5a2263054a685ed68213a85b70f4.