### PR TITLE
Fix a minor parsing bug that causes pulp-to-pulp sync to fail

### DIFF
--- a/CHANGES/2961.bugfix
+++ b/CHANGES/2961.bugfix
@@ -1,0 +1,1 @@
+Fix a minor module metadata parsing regression that broke Pulp-to-Pulp sync in some scenarios.

--- a/pulp_rpm/app/modulemd.py
+++ b/pulp_rpm/app/modulemd.py
@@ -71,11 +71,10 @@ def split_modulemd_file(file):
             for line in modulemd_file:
                 if line.startswith("---"):
                     if module:  # avoid first empty yield in the beginning of document
-                        yield module
+                        yield module.strip("\n")
                         module = ""
                 module += line
-
-            yield module
+            yield module.strip("\n")
 
 
 def check_mandatory_module_fields(module, required_fields):

--- a/pulp_rpm/app/tasks/publishing.py
+++ b/pulp_rpm/app/tasks/publishing.py
@@ -577,18 +577,21 @@ def generate_repo_metadata(
         modulemds = Modulemd.objects.filter(pk__in=content).order_by(*Modulemd.natural_key_fields())
         for modulemd in modulemds.iterator():
             mod_yml.write(modulemd.snippet.encode())
+            mod_yml.write(b"\n")
             has_modules = True
         modulemd_defaults = ModulemdDefaults.objects.filter(pk__in=content).order_by(
             *ModulemdDefaults.natural_key_fields()
         )
         for default in modulemd_defaults.iterator():
             mod_yml.write(default.snippet.encode())
+            mod_yml.write(b"\n")
             has_modules = True
         modulemd_obsoletes = ModulemdObsolete.objects.filter(pk__in=content).order_by(
             *ModulemdObsolete.natural_key_fields()
         )
         for obsolete in modulemd_obsoletes.iterator():
             mod_yml.write(obsolete.snippet.encode())
+            mod_yml.write(b"\n")
             has_modules = True
 
     # Process comps


### PR DESCRIPTION
Probably an actual yaml parser wouldn't care.

closes #2961
https://github.com/pulp/pulp_rpm/issues/2961