### PR TITLE
Allow string integers in modulemd version

### DIFF
--- a/CHANGES/2998.bugfix
+++ b/CHANGES/2998.bugfix
@@ -1,0 +1,1 @@
+Loosen modulemd validation to allow version numbers that have string type but represent integers

--- a/pulp_rpm/app/modulemd.py
+++ b/pulp_rpm/app/modulemd.py
@@ -164,6 +164,11 @@ def parse_modular(file):
         # are not enough then we only need to take required data from dict which is
         # parsed by pyyaml library
         if parsed_data["document"] == "modulemd":
+            # the validator currently accepts formatting slightly different to the
+            # spec due to the misconfiguration of some Rocky Linux 9 repositories
+            # https://bugs.rockylinux.org/view.php?id=2575
+            # further discussion on this issue can be found here:
+            # https://github.com/pulp/pulp_rpm/issues/2998
             validator = Draft7Validator(MODULEMD_SCHEMA)
             err = []
             for error in sorted(validator.iter_errors(parsed_data["data"]), key=str):

--- a/pulp_rpm/app/schema/modulemd.json
+++ b/pulp_rpm/app/schema/modulemd.json
@@ -5,7 +5,10 @@
   "type": "object",
   "properties": {
     "name": {"type": "string"},
-    "version": {"type": "integer"},
+    "version": {
+      "type": ["integer", "string"],
+      "pattern": "^[0-9]+$"
+    },
     "context": {"type": ["number", "string"]},
     "arch": {"type": "string"},
     "summary": {"type": "string"},


### PR DESCRIPTION
Trivial fix, allows modulemd version data to be of type string if that string represents a valid integer, matching very basic regex.