### PR TITLE
Fix client getting HTTP 404 Not Found when downloading rpm

### DIFF
--- a/CHANGES/3039.bugfix
+++ b/CHANGES/3039.bugfix
@@ -1,0 +1,1 @@
+Fix relative path and location href mismatch of the uploaded rpm caused by filename and rpm header mismatch. Clients are getting HTTP 404 Not Found error when downloading the rpm.

--- a/pulp_rpm/app/serializers/package.py
+++ b/pulp_rpm/app/serializers/package.py
@@ -252,7 +252,7 @@ class PackageSerializer(SingleArtifactContentUploadSerializer, ContentChecksumSe
             log.info(traceback.format_exc())
             raise NotAcceptable(detail="RPM file cannot be parsed for metadata")
 
-        new_pkg["location_href"] = (
+        filename = (
             format_nevra_short(
                 new_pkg["name"],
                 new_pkg["epoch"],
@@ -263,7 +263,10 @@ class PackageSerializer(SingleArtifactContentUploadSerializer, ContentChecksumSe
             + ".rpm"
         )
         if not data.get("relative_path"):
-            data["relative_path"] = new_pkg["location_href"]
+            data["relative_path"] = filename
+            new_pkg["location_href"] = filename
+        else:
+            new_pkg["location_href"] = data["relative_path"]
 
         data.update(new_pkg)
         return data


### PR DESCRIPTION
The location_href and relative_path will be mismatched causing 404 Not Found error on clients if user uploaded a rpm and provided a "relative_path" with non-standard rpm naming convention.

closes #3039