### PR TITLE
[3.18] Fix client getting HTTP 404 Not Found when downloading rpm

### DIFF
--- a/CHANGES/3039.bugfix
+++ b/CHANGES/3039.bugfix
@@ -1,0 +1,1 @@
+Fix relative path and location href mismatch of the uploaded rpm caused by filename and rpm header mismatch. Clients are getting HTTP 404 Not Found error when downloading the rpm.

--- a/pulp_rpm/app/serializers/package.py
+++ b/pulp_rpm/app/serializers/package.py
@@ -12,7 +12,7 @@ from pulpcore.plugin.serializers import (
 )
 
 from pulp_rpm.app.models import Package
-from pulp_rpm.app.shared_utils import read_crpackage_from_artifact, format_nevra_short
+from pulp_rpm.app.shared_utils import read_crpackage_from_artifact, format_nvra
 
 
 log = logging.getLogger(__name__)
@@ -274,10 +274,9 @@ class PackageSerializer(SingleArtifactContentUploadSerializer, ContentChecksumSe
                 _("There is already a package with: {values}.").format(values=error_data)
             )
 
-        new_pkg["location_href"] = (
-            format_nevra_short(
+        filename = (
+            format_nvra(
                 new_pkg["name"],
-                new_pkg["epoch"],
                 new_pkg["version"],
                 new_pkg["release"],
                 new_pkg["arch"],
@@ -285,7 +284,10 @@ class PackageSerializer(SingleArtifactContentUploadSerializer, ContentChecksumSe
             + ".rpm"
         )
         if not data.get("relative_path"):
-            data["relative_path"] = new_pkg["location_href"]
+            data["relative_path"] = filename
+            new_pkg["location_href"] = filename
+        else:
+            new_pkg["location_href"] = data["relative_path"]
 
         data.update(new_pkg)
         return data


### PR DESCRIPTION
The location_href and relative_path will be mismatched causing 404 Not Found error on clients if user uploaded a rpm and provided a "relative_path" with non-standard rpm naming convention.

closes #3039

(cherry picked from commit 949424d83aca0fbab3a13175fbfc8de8c40febf5)