### PR TITLE
3.18 backports

### DIFF
--- a/CHANGES/3119.bugfix
+++ b/CHANGES/3119.bugfix
@@ -1,0 +1,1 @@
+Fix a bug with copying modules with depsolving enabled - dependencies were not copied.

--- a/pulp_rpm/app/depsolving.py
+++ b/pulp_rpm/app/depsolving.py
@@ -409,7 +409,7 @@ def module_dependencies_conversion(pool, module_solvable, dependency_list):
           dep_or_rel(solv.Dep, solve.REL_WITH, stream_dep(name, stream))
           dep_or_rel(solv.Dep, solve.REL_WITHOUT, stream_dep(name, stream))
         """
-        dep.Rel(op, rel) if dep is not None else rel
+        return dep.Rel(op, rel) if dep is not None else rel
 
     # Check each dependency dict in dependency_list and generate the solv requirements.
     reqs = None

--- a/pulp_rpm/tests/functional/conftest.py
+++ b/pulp_rpm/tests/functional/conftest.py
@@ -25,7 +25,12 @@ from pulpcore.client.pulp_rpm import (
     RpmRepositorySyncURL,
 )
 
-from pulp_rpm.tests.functional.constants import RPM_UNSIGNED_FIXTURE_URL, RPM_KICKSTART_FIXTURE_URL
+from pulp_rpm.tests.functional.constants import (
+    RPM_KICKSTART_FIXTURE_URL,
+    RPM_UNSIGNED_FIXTURE_URL,
+    RPM_MODULAR_FIXTURE_URL,
+)
+
 from pulp_rpm.tests.functional.utils import init_signed_repo_configuration
 
 
@@ -232,6 +237,12 @@ def rpm_unsigned_repo_immediate(init_and_sync):
 @pytest.fixture(scope="class")
 def rpm_unsigned_repo_on_demand(init_and_sync):
     repo, _ = init_and_sync(policy="on_demand")
+    return repo
+
+
+@pytest.fixture(scope="class")
+def rpm_modular_repo_on_demand(init_and_sync):
+    repo, _ = init_and_sync(url=RPM_MODULAR_FIXTURE_URL, policy="on_demand")
     return repo
 
 


### PR DESCRIPTION
closes #3119
https://github.com/pulp/pulp_rpm/issues/3119

(cherry picked from commit 7b6ecfc72d32053923b7cbc9be72c79fcb28cd9b)