### PR TITLE
Pin Sphinx to <7.0 due to incompatibility in our docs-template.

### DIFF
--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -1,5 +1,5 @@
 plantuml
-sphinx
+sphinx<7.0
 sphinx-rtd-theme<1.2.0
 sphinxcontrib-openapi
 towncrier


### PR DESCRIPTION
[noissue]