### PR TITLE
Fixed concurrent-ks-tree-syncs by making disttree ID repo-specific.

### DIFF
--- a/CHANGES/2278.bugfix
+++ b/CHANGES/2278.bugfix
@@ -1,0 +1,3 @@
+Fixed concurrent-overlapping-sync of subrepos by making them repository-unique.
+
+This change is transparent to end-users.

--- a/pulp_rpm/app/tasks/synchronizing.py
+++ b/pulp_rpm/app/tasks/synchronizing.py
@@ -9,6 +9,7 @@ import tempfile
 
 from collections import defaultdict
 from gettext import gettext as _  # noqa:F401
+from hashlib import sha256
 
 from asgiref.sync import sync_to_async
 from django.conf import settings
@@ -487,24 +488,16 @@ def synchronize(remote_pk, repository_pk, sync_policy, skip_types, optimize, url
 
     with tempfile.TemporaryDirectory(dir="."):
         remote_url = fetch_remote_url(remote, url)
-        sync_details = get_sync_details(remote, remote_url, sync_policy, repository)
 
-        repo_sync_config[PRIMARY_REPO] = {
-            "should_skip": should_optimize_sync(sync_details, repository.last_sync_details),
-            "sync_details": sync_details,
-            "url": remote_url,
-            "repo": repository,
-        }
-
+        # Find and set up to deal with any subtrees
         treeinfo = get_treeinfo_data(remote, remote_url)
-
         if treeinfo:
             treeinfo["repositories"] = {}
             for repodata in set(treeinfo["download"]["repodatas"]):
                 if repodata == DIST_TREE_MAIN_REPO_PATH:
                     treeinfo["repositories"].update({repodata: None})
                     continue
-                name = f"{repodata}-{treeinfo['hash']}"
+                name = f"{repodata}-{treeinfo['hash']}-{repository.pulp_id}"
                 sub_repo, created = RpmRepository.objects.get_or_create(name=name, user_hidden=True)
                 if created:
                     sub_repo.save()
@@ -530,6 +523,15 @@ def synchronize(remote_pk, repository_pk, sync_policy, skip_types, optimize, url
                     "repo": sub_repo,
                 }
 
+        # Set up to deal with the primary repository
+        sync_details = get_sync_details(remote, remote_url, sync_policy, repository)
+        repo_sync_config[PRIMARY_REPO] = {
+            "should_skip": should_optimize_sync(sync_details, repository.last_sync_details),
+            "sync_details": sync_details,
+            "url": remote_url,
+            "repo": repository,
+        }
+
         # If all repos are exactly the same, we should skip all further processing, even in
         # metadata-mirror mode
         if optimize and all([config["should_skip"] for config in repo_sync_config.values()]):
@@ -544,6 +546,8 @@ def synchronize(remote_pk, repository_pk, sync_policy, skip_types, optimize, url
         repo_sync_results = {}
 
         # If some repos need to be synced and others do not, we go through them all
+        # items() returns in insertion-order - make sure PRIMARY is the LAST thing we process
+        # here, or autopublish will fail to find any subrepo-content.
         for directory, repo_config in repo_sync_config.items():
             repo = repo_config["repo"]
             # If metadata_mirroring is enabled we cannot skip any syncs, because the generated
@@ -881,7 +885,10 @@ class RpmFirstStage(Stage):
                 )
                 d_artifacts.append(da)
 
-            self.treeinfo["distribution_tree"]["digest"] = self.treeinfo["hash"]
+            tree_digest = sha256(
+                f'{self.treeinfo["hash"]}-{self.repository.pulp_id}'.encode("utf-8")
+            ).hexdigest()
+            self.treeinfo["distribution_tree"]["digest"] = tree_digest
             distribution_tree = DistributionTree(**self.treeinfo["distribution_tree"])
             dc = DeclarativeContent(content=distribution_tree, d_artifacts=d_artifacts)
             dc.extra_data = self.treeinfo


### PR DESCRIPTION
DistributionTree digest and subrepo-names now both end with the pulp-id of the "owning" Repository, making them unique to that repo and therefore protected from concurrent-updates against anything that is changing that Repository.

Addon/Variant/Image are transitively made unique by virtue of having their DistributionTree be part of their unique-together.

Sub-repo **content** (e.g. Packages et al) are de-duplicated via their existing uniqueness constraints.

The end result is a minor increase in Content objects (i.e., DistTrees/Addons/Images/Variants that used to have only one instance are now one-per-containing-repo), and a small impact on subrepo-syncing (since previously-unique subrepos will now have a first-sync that would have been skipped). Content will continue to only be sync'd once.

fixes #2278.
[nocoverage]

(cherry picked from commit 52a9accc79e49991a8941622b60485e1845d23a2)