### PR TITLE
Sort packages in metadata to improve compression [RHELDST-15791]

### DIFF
--- a/plugins/pulp_rpm/plugins/distributors/yum/publish.py
+++ b/plugins/pulp_rpm/plugins/distributors/yum/publish.py
@@ -471,6 +471,17 @@ class PublishRpmStep(platform_steps.UnitModelPluginStep):
         for context in (self.file_lists_context, self.other_context, self.primary_context):
             context.initialize()
 
+    @property
+    def unit_querysets(self):
+        """
+           Return querysets sorted by name, which helps gzip with compression
+
+           :return:    generator of mongoengine.QuerySet objects
+           :rtype:     generator
+        """
+        querysets = super(PublishRpmStep, self).unit_querysets
+        return (qs.order_by('+name') for qs in querysets)
+
     def finalize(self):
         """
         Close each context and write it to the repomd file


### PR DESCRIPTION
It was noticed the lack of ordering of packages in yum repo metadata files reduced compression efficiency. These compressed files also account for over half of the downloads. Improving the efficiency of compression would thus reduce the overall cost of CDN.

This change sorts the unit_queryset. This will only apply to force / full pushes, but investigation showed it would be challenging to make this work with FastForward pushes.