### PR TITLE
Removed the ability to select md5, sha1, or sha224 as the checksum type

### DIFF
--- a/.github/workflows/scripts/install.sh
+++ b/.github/workflows/scripts/install.sh
@@ -66,7 +66,7 @@ VARSYAML
 
 cat >> vars/main.yaml << VARSYAML
 pulp_env: {}
-pulp_settings: {"allowed_content_checksums": ["sha1", "sha224", "sha256", "sha384", "sha512"], "allowed_export_paths": ["/tmp"], "allowed_import_paths": ["/tmp"], "orphan_protection_time": 0}
+pulp_settings: {"allowed_content_checksums": ["sha1", "sha224", "sha256", "sha512"], "allowed_export_paths": ["/tmp"], "allowed_import_paths": ["/tmp"], "orphan_protection_time": 0}
 pulp_scheme: https
 
 pulp_container_tag: "latest"

--- a/CHANGES/2488.removal
+++ b/CHANGES/2488.removal
@@ -1,0 +1,1 @@
+Removed support for publishing repos with a checksum type of md5, sha1, or sha224

--- a/pulp_rpm/app/constants.py
+++ b/pulp_rpm/app/constants.py
@@ -26,6 +26,12 @@ CHECKSUM_CHOICES = (
 ALLOWED_CHECKSUM_ERROR_MSG = """Checksum must be one of the allowed checksum types.
 You can adjust these with the 'ALLOWED_CONTENT_CHECKSUMS' setting."""
 
+ALLOWED_PUBLISH_CHECKSUMS = {CHECKSUM_TYPES.SHA256, CHECKSUM_TYPES.SHA384, CHECKSUM_TYPES.SHA512}
+
+ALLOWED_PUBLISH_CHECKSUM_ERROR_MSG = (
+    """Checksum must be one of the allowed checksum types: sha256, sha384, or sha512."""
+)
+
 SYNC_POLICIES = SimpleNamespace(
     ADDITIVE="additive",
     MIRROR_COMPLETE="mirror_complete",

--- a/pulp_rpm/app/models/repository.py
+++ b/pulp_rpm/app/models/repository.py
@@ -247,9 +247,9 @@ class RpmRepository(Repository, AutoAddObjPermsMixin):
                 repository_version_pk=version.pk,
                 metadata_signing_service=self.metadata_signing_service,
                 checksum_types={
+                    "general": self.checksum_type,
                     "metadata": self.metadata_checksum_type,
                     "package": self.package_checksum_type,
-                    "general": self.checksum_type,
                 },
                 repo_config=self.repo_config,
             )

--- a/pulp_rpm/tests/functional/api/test_download_policies.py
+++ b/pulp_rpm/tests/functional/api/test_download_policies.py
@@ -8,16 +8,6 @@ from pulp_rpm.tests.functional.constants import (
 from pulpcore.client.pulp_rpm import RpmRpmPublication
 
 
-"""Sync a repository with different download policies.
-
-This test targets the following issue:
-
-`Pulp #4126 <https://pulp.plan.io/issues/4126>`_
-`Pulp #4213 <https://pulp.plan.io/issues/4213>`_
-`Pulp #4418 <https://pulp.plan.io/issues/4418>`_
-"""
-
-
 @pytest.mark.parametrize("download_policy", DOWNLOAD_POLICIES)
 def test_download_policies(
     download_policy,

--- a/pulp_rpm/tests/functional/api/test_pulp_to_pulp.py
+++ b/pulp_rpm/tests/functional/api/test_pulp_to_pulp.py
@@ -32,8 +32,7 @@ def test_pulp_pulp_sync(
     # Create a publication.
     publish_data = RpmRpmPublication(
         repository=repo.pulp_href,
-        metadata_checksum_type="sha384",
-        package_checksum_type="sha224",
+        checksum_type="sha512",
     )
     publication = gen_object_with_cleanup(rpm_publication_api, publish_data)
 

--- a/template_config.yml
+++ b/template_config.yml
@@ -56,7 +56,6 @@ pulp_settings:
   - sha1
   - sha224
   - sha256
-  - sha384
   - sha512
   allowed_export_paths:
   - /tmp


### PR DESCRIPTION
Sha256 has been supported since at least RHEL 6.  We obviously still have to support syncing repos with md5, sha1, and sha224 checksums as they can theoretically exist in the wild (though less and less common over time) but there's really no reason to allow publishing with any weaker checksums.  Especially since Katello has never exposed it.