### PR TITLE
Add support for `repository-size` command

### DIFF
--- a/CHANGES/3312.feature
+++ b/CHANGES/3312.feature
@@ -1,0 +1,1 @@
+Added support for ``repository-size`` management command.

--- a/pulp_rpm/tests/functional/api/test_pulpimport.py
+++ b/pulp_rpm/tests/functional/api/test_pulpimport.py
@@ -305,6 +305,7 @@ def test_create_missing_repos(
     gen_object_with_cleanup,
     importers_pulp_imports_api_client,
     monitor_task_group,
+    add_to_cleanup,
 ):
     """
     Tests for PulpImporter and create-missing-repos.
@@ -392,6 +393,8 @@ def test_create_missing_repos(
     # Find the repos we just created
     rpm_repo = rpm_repository_api.list(name=saved_entities["rpm-repo"].name).results[0]
     ks_repo = rpm_repository_api.list(name=saved_entities["ks-repo"].name).results[0]
+    add_to_cleanup(rpm_repository_api, rpm_repo.pulp_href)
+    add_to_cleanup(rpm_repository_api, ks_repo.pulp_href)
 
     # 7. Inspect the results
     # Step 7a

--- a/pulp_rpm/tests/functional/api/test_repo_sizes.py
+++ b/pulp_rpm/tests/functional/api/test_repo_sizes.py
@@ -1,0 +1,71 @@
+import json
+import subprocess
+
+from pulp_rpm.tests.functional.constants import (
+    RPM_UNSIGNED_FIXTURE_URL,
+    RPM_UNSIGNED_FIXTURE_SIZE,
+    RPM_KICKSTART_FIXTURE_URL,
+    RPM_KICKSTART_FIXTURE_SIZE,
+)
+
+
+def test_repo_size(init_and_sync, delete_orphans_pre, monitor_task, orphans_cleanup_api_client):
+    """Test that RPM repos correctly report their on-disk artifact sizes."""
+    monitor_task(orphans_cleanup_api_client.cleanup({"orphan_protection_time": 0}).task)
+    repo, _ = init_and_sync(url=RPM_UNSIGNED_FIXTURE_URL, policy="on_demand")
+
+    cmd = (
+        "pulpcore-manager",
+        "repository-size",
+        "--repositories",
+        repo.pulp_href,
+        "--include-on-demand",
+    )
+    run = subprocess.run(cmd, capture_output=True, check=True)
+    out = json.loads(run.stdout)
+
+    # Assert basic items of report and test on-demand sizing
+    assert len(out) == 1
+    report = out[0]
+    assert report["name"] == repo.name
+    assert report["href"] == repo.pulp_href
+    assert report["disk-size"] == 0
+    assert report["on-demand-size"] == RPM_UNSIGNED_FIXTURE_SIZE
+
+    _, _ = init_and_sync(repository=repo, url=RPM_UNSIGNED_FIXTURE_URL, policy="immediate")
+    run = subprocess.run(cmd, capture_output=True, check=True)
+    report = json.loads(run.stdout)[0]
+    assert report["disk-size"] == RPM_UNSIGNED_FIXTURE_SIZE
+    assert report["on-demand-size"] == 0
+
+
+def test_kickstart_repo_size(
+    init_and_sync, delete_orphans_pre, monitor_task, orphans_cleanup_api_client
+):
+    """Test that kickstart RPM repos correctly report their on-disk artifact sizes."""
+    monitor_task(orphans_cleanup_api_client.cleanup({"orphan_protection_time": 0}).task)
+    repo, _ = init_and_sync(url=RPM_KICKSTART_FIXTURE_URL, policy="on_demand")
+
+    cmd = (
+        "pulpcore-manager",
+        "repository-size",
+        "--repositories",
+        repo.pulp_href,
+        "--include-on-demand",
+    )
+    run = subprocess.run(cmd, capture_output=True, check=True)
+    out = json.loads(run.stdout)
+
+    # Assert basic items of report and test on-demand sizing
+    assert len(out) == 1
+    report = out[0]
+    assert report["name"] == repo.name
+    assert report["href"] == repo.pulp_href
+    assert report["disk-size"] == 2275  # One file is always downloaded
+    assert report["on-demand-size"] == 133810  # Not all remote artifacts have sizes
+
+    _, _ = init_and_sync(repository=repo, url=RPM_KICKSTART_FIXTURE_URL, policy="immediate")
+    run = subprocess.run(cmd, capture_output=True, check=True)
+    report = json.loads(run.stdout)[0]
+    assert report["disk-size"] == RPM_KICKSTART_FIXTURE_SIZE
+    assert report["on-demand-size"] == 0

--- a/pulp_rpm/tests/functional/constants.py
+++ b/pulp_rpm/tests/functional/constants.py
@@ -124,6 +124,9 @@ standard repositories, i.e. :data:`RPM_SIGNED_FIXTURE_URL` and
 "content_summary" field on "../repositories/../versions/../".
 """
 
+RPM_UNSIGNED_FIXTURE_SIZE = 79260
+"""Size in bytes of all the packages in the :data:`RPM_UNSIGNED_FIXTURE_URL`."""
+
 FEDORA_MIRRORLIST_BASE = "https://mirrors.fedoraproject.org/mirrorlist"
 FEDORA_MIRRORLIST_PARAMS = "?repo=epel-modular-8&arch=x86_64&infra=stock&content=centos"
 RPM_EPEL_MIRROR_URL = FEDORA_MIRRORLIST_BASE + FEDORA_MIRRORLIST_PARAMS
@@ -461,6 +464,8 @@ RPM_KICKSTART_FIXTURE_SUMMARY = {
     RPM_PACKAGEGROUP_CONTENT_NAME: 1,
     RPM_PACKAGELANGPACKS_CONTENT_NAME: 1,
 }
+
+RPM_KICKSTART_FIXTURE_SIZE = 9917733
 
 RPM_KICKSTART_REPOSITORY_ROOT_CONTENT = [
     ".treeinfo",


### PR DESCRIPTION
fixes: #3312

Is there an easy way to add tests for this (know repository sizes)?