### PR TITLE
[3.22] Remove drpm test and fix borked CI (#3323)

### DIFF
--- a/.github/workflows/scripts/post_before_script.sh
+++ b/.github/workflows/scripts/post_before_script.sh
@@ -6,7 +6,7 @@ if [[ "$TEST" == "upgrade" ]]; then
     exit
 fi
 
-cmd_stdin_prefix bash -c "cat > /var/lib/pulp/scripts/sign-metadata.sh" < "$GITHUB_WORKSPACE"/pulp_rpm/tests/functional/sign-metadata.sh
+cmd_stdin_prefix bash -c "cat > /var/lib/pulp/scripts/sign-metadata.sh" < pulp_rpm/tests/functional/sign-metadata.sh
 
 curl -L https://github.com/pulp/pulp-fixtures/raw/master/common/GPG-KEY-fixture-signing | cmd_stdin_prefix su pulp -c "cat > /tmp/GPG-KEY-fixture-signing"
 curl -L https://github.com/pulp/pulp-fixtures/raw/master/common/GPG-PRIVATE-KEY-fixture-signing | cmd_stdin_prefix su pulp -c "gpg --import"

--- a/functest_requirements.txt
+++ b/functest_requirements.txt
@@ -1,3 +1,4 @@
+django  # TODO: test_sync.py has a dependency on date parsing functions
 git+https://github.com/pulp/pulp-smash.git#egg=pulp-smash
 productmd>=1.25
 pytest
@@ -5,4 +6,5 @@ dictdiffer
 xmltodict
 pyyaml
 lxml
-django  # TODO: test_sync.py has a dependency on date parsing functions
+pyzstd
+requests

--- a/pulp_rpm/tests/functional/api/test_character_encoding.py
+++ b/pulp_rpm/tests/functional/api/test_character_encoding.py
@@ -1,6 +1,8 @@
 """Tests for Pulp's characters encoding."""
-import pytest
 import uuid
+
+import pytest
+import requests
 
 from pulpcore.tests.functional.utils import PulpTaskError
 from pulp_rpm.tests.functional.constants import (
@@ -21,11 +23,11 @@ This test targets the following issues:
 
 
 def test_upload_non_ascii(
-    tmp_path, artifacts_api_client, http_get, rpm_package_api, monitor_task, delete_orphans_pre
+    tmp_path, artifacts_api_client, rpm_package_api, monitor_task, delete_orphans_pre
 ):
     """Test whether one can upload an RPM with non-ascii metadata."""
     temp_file = tmp_path / str(uuid.uuid4())
-    temp_file.write_bytes(http_get(RPM_WITH_NON_ASCII_URL))
+    temp_file.write_bytes(requests.get(RPM_WITH_NON_ASCII_URL).content)
     artifact = artifacts_api_client.create(temp_file)
     response = rpm_package_api.create(
         artifact=artifact.pulp_href,
@@ -36,11 +38,11 @@ def test_upload_non_ascii(
 
 
 def test_upload_non_utf8(
-    tmp_path, artifacts_api_client, http_get, rpm_package_api, monitor_task, delete_orphans_pre
+    tmp_path, artifacts_api_client, rpm_package_api, monitor_task, delete_orphans_pre
 ):
     """Test whether an exception is raised when non-utf-8 is uploaded."""
     temp_file = tmp_path / str(uuid.uuid4())
-    temp_file.write_bytes(http_get(RPM_WITH_NON_UTF_8_URL))
+    temp_file.write_bytes(requests.get(RPM_WITH_NON_UTF_8_URL).content)
     artifact = artifacts_api_client.create(temp_file)
     with pytest.raises(PulpTaskError) as ctx:
         response = rpm_package_api.create(

--- a/pulp_rpm/tests/functional/api/test_consume_content.py
+++ b/pulp_rpm/tests/functional/api/test_consume_content.py
@@ -1,13 +1,14 @@
 """Verify whether package manager, yum/dnf, can consume content from Pulp."""
-import pytest
 import subprocess
 import itertools
+
+import pytest
+import requests
 
 from pulp_rpm.tests.functional.constants import (
     # REPO_WITH_XML_BASE_URL,
     RPM_UNSIGNED_FIXTURE_URL,
 )
-
 
 dnf_installed = subprocess.run(("which", "dnf")).returncode == 0
 
@@ -189,7 +190,6 @@ def test_config_dot_repo(
     has_signing_service,
     rpm_metadata_signing_service,
     create_distribution,
-    http_get,
 ):
     """Test if the generated config.repo has the right content."""
     if has_signing_service and rpm_metadata_signing_service is None:
@@ -198,7 +198,7 @@ def test_config_dot_repo(
     distribution = create_distribution(
         gpgcheck=gpgcheck, repo_gpgcheck=repo_gpgcheck, has_signing_service=has_signing_service
     )
-    content = http_get(f"{distribution.base_url}config.repo").decode("utf-8")
+    content = requests.get(f"{distribution.base_url}config.repo").text
 
     assert f"[{distribution.name}]\n" in content
     assert f"baseurl={distribution.base_url}\n" in content

--- a/pulp_rpm/tests/functional/api/test_download_content.py
+++ b/pulp_rpm/tests/functional/api/test_download_content.py
@@ -1,8 +1,10 @@
 """Tests that verify download of content served by Pulp."""
-import pytest
 import hashlib
 from random import choice
 from urllib.parse import urljoin
+
+import pytest
+import requests
 
 from pulp_rpm.tests.functional.constants import RPM_UNSIGNED_FIXTURE_URL
 from pulp_rpm.tests.functional.utils import (
@@ -18,7 +20,6 @@ def test_all(
     rpm_publication_api,
     rpm_distribution_factory,
     download_content_unit,
-    http_get,
     gen_object_with_cleanup,
 ):
     """Verify whether content served by pulp can be downloaded.
@@ -40,11 +41,6 @@ def test_all(
     2. Select a random content unit in the distribution. Download that
        content unit from Pulp, and verify that the content unit has the
        same checksum when fetched directly from Pulp-Fixtures.
-
-    This test targets the following issues:
-
-    * `Pulp #2895 <https://pulp.plan.io/issues/2895>`_
-    * `Pulp Smash #872 <https://github.com/pulp/pulp-smash/issues/872>`_
     """
     # Sync a Repository
     repo = rpm_unsigned_repo_immediate
@@ -61,7 +57,7 @@ def test_all(
     package_paths = [p.location_href for p in packages.results]
     unit_path = choice(package_paths)
     fixture_hash = hashlib.sha256(
-        http_get(urljoin(RPM_UNSIGNED_FIXTURE_URL, unit_path))
+        requests.get(urljoin(RPM_UNSIGNED_FIXTURE_URL, unit_path)).content
     ).hexdigest()
 
     # …and Pulp.

--- a/pulp_rpm/tests/functional/api/test_fips_workflow.py
+++ b/pulp_rpm/tests/functional/api/test_fips_workflow.py
@@ -1,7 +1,9 @@
 """Tests that create/sync/distribute/publish MANY rpm plugin repositories."""
-import pytest
 import os
 import re
+
+import pytest
+import requests
 
 
 @pytest.fixture
@@ -178,7 +180,6 @@ def test_fips_workflow(
     rpm_publication_factory,
     rpm_distribution_factory,
     cdn_certs_and_keys,
-    http_get,
 ):
     # Convert a url into a name-string
     name = _name_from_url(url)
@@ -208,5 +209,5 @@ def test_fips_workflow(
     assert distribution is not None
 
     # Test we can access the index of the distribution
-    response = http_get(distribution.base_url)
+    response = requests.get(distribution.base_url)
     assert response is not None

--- a/pulp_rpm/tests/functional/api/test_sync.py
+++ b/pulp_rpm/tests/functional/api/test_sync.py
@@ -19,7 +19,6 @@ from pulp_smash.pulp3.utils import (
 
 from pulp_rpm.tests.functional.constants import (
     AMAZON_MIRROR,
-    DRPM_UNSIGNED_FIXTURE_URL,
     CENTOS7_OPSTOOLS_URL,
     PULP_TYPE_ADVISORY,
     PULP_TYPE_MODULEMD,
@@ -858,6 +857,9 @@ def test_complete_mirror_with_external_location_href_fails(init_and_sync):
     assert "features which are incompatible with 'mirror' sync" in error_description
 
 
+# We can restore this test when we are able to generate repositories on-demand. We just need to
+# create a "prestodelta" entry in the repomd.xml, we need not have it actually be a valid one.
+@pytest.mark.skip("No DRPM fixture repo.")
 @pytest.mark.parallel
 def test_complete_mirror_with_delta_metadata_fails(init_and_sync):
     """
@@ -866,7 +868,8 @@ def test_complete_mirror_with_delta_metadata_fails(init_and_sync):
     Otherwise we would be mirroring the metadata without mirroring the DRPM packages.
     """
     with pytest.raises(PulpTaskError) as exc:
-        init_and_sync(url=DRPM_UNSIGNED_FIXTURE_URL, sync_policy="mirror_complete")
+        pass
+        # init_and_sync(url=DRPM_UNSIGNED_FIXTURE_URL, sync_policy="mirror_complete")
 
     error_description = exc.value.task.to_dict()["error"]["description"]
     assert "features which are incompatible with 'mirror' sync" in error_description

--- a/pulp_rpm/tests/functional/api/test_upload.py
+++ b/pulp_rpm/tests/functional/api/test_upload.py
@@ -1,8 +1,9 @@
 """Tests that perform actions over content unit."""
 import os
-import pytest
-
 from tempfile import NamedTemporaryFile
+
+import pytest
+import requests
 
 from pulpcore.tests.functional.utils import PulpTaskError
 from pulp_rpm.tests.functional.constants import (
@@ -30,7 +31,7 @@ CENTOS8_CONTENT = BIG_GROUPS + BIG_CATEGORY + BIG_LANGPACK + BIG_ENVIRONMENTS
 
 
 def test_single_request_unit_and_duplicate_unit(
-    delete_orphans_pre, http_get, rpm_package_api, monitor_task, tasks_api_client
+    delete_orphans_pre, rpm_package_api, monitor_task, tasks_api_client
 ):
     """Test single request upload unit.
 
@@ -41,7 +42,7 @@ def test_single_request_unit_and_duplicate_unit(
     file_to_use = os.path.join(RPM_UNSIGNED_FIXTURE_URL, RPM_PACKAGE_FILENAME)
 
     with NamedTemporaryFile() as file_to_upload:
-        file_to_upload.write(http_get(file_to_use))
+        file_to_upload.write(requests.get(file_to_use).content)
         upload_attrs = {"file": file_to_upload.name}
         upload = rpm_package_api.create(**upload_attrs)
 
@@ -51,7 +52,7 @@ def test_single_request_unit_and_duplicate_unit(
 
     # Duplicate unit
     with NamedTemporaryFile() as file_to_upload:
-        file_to_upload.write(http_get(file_to_use))
+        file_to_upload.write(requests.get(file_to_use).content)
         upload_attrs = {"file": file_to_upload.name}
         upload = rpm_package_api.create(**upload_attrs)
 
@@ -63,11 +64,11 @@ def test_single_request_unit_and_duplicate_unit(
     assert task_report.created_resources[0] == package.pulp_href
 
 
-def test_upload_non_ascii(delete_orphans_pre, rpm_package_api, http_get, monitor_task):
+def test_upload_non_ascii(delete_orphans_pre, rpm_package_api, monitor_task):
     """Test whether one can upload an RPM with non-ascii metadata."""
     packages_count = rpm_package_api.list().count
     with NamedTemporaryFile() as file_to_upload:
-        file_to_upload.write(http_get(RPM_WITH_NON_ASCII_URL))
+        file_to_upload.write(requests.get(RPM_WITH_NON_ASCII_URL).content)
         upload_attrs = {"file": file_to_upload.name}
         upload = rpm_package_api.create(**upload_attrs)
 

--- a/pulp_rpm/tests/functional/constants.py
+++ b/pulp_rpm/tests/functional/constants.py
@@ -19,9 +19,6 @@ PULP_FIXTURES_BASE_URL = config.get_config().get_fixtures_url()
 
 DOWNLOAD_POLICIES = ["immediate", "on_demand", "streamed"]
 
-DRPM_UNSIGNED_FIXTURE_URL = urljoin(PULP_FIXTURES_BASE_URL, "drpm-unsigned/")
-"""The URL to a repository with unsigned DRPM packages."""
-
 RPM_PACKAGE_CONTENT_NAME = "rpm.package"
 
 RPM_PACKAGECATEGORY_CONTENT_NAME = "rpm.packagecategory"

--- a/pulp_rpm/tests/functional/content_handler/test_config_repo.py
+++ b/pulp_rpm/tests/functional/content_handler/test_config_repo.py
@@ -1,6 +1,5 @@
 import pytest
-
-from aiohttp import ClientResponseError
+import requests
 
 
 @pytest.fixture
@@ -15,20 +14,20 @@ def setup_empty_distribution(
 
 
 @pytest.mark.parallel
-def test_config_repo_in_listing_unsigned(setup_empty_distribution, http_get):
+def test_config_repo_in_listing_unsigned(setup_empty_distribution):
     """Whether the served resources are in the directory listing."""
     _, _, dist = setup_empty_distribution
-    content = http_get(dist.base_url)
+    content = requests.get(dist.base_url).content
 
     assert b"config.repo" in content
     assert b"repomd.xml.key" not in content
 
 
 @pytest.mark.parallel
-def test_config_repo_unsigned(setup_empty_distribution, http_get):
+def test_config_repo_unsigned(setup_empty_distribution):
     """Whether config.repo can be downloaded and has the right content."""
     _, _, dist = setup_empty_distribution
-    content = http_get(f"{dist.base_url}config.repo")
+    content = requests.get(f"{dist.base_url}config.repo").content
 
     assert bytes(f"[{dist.name}]\n", "utf-8") in content
     assert bytes(f"baseurl={dist.base_url}\n", "utf-8") in content
@@ -38,7 +37,7 @@ def test_config_repo_unsigned(setup_empty_distribution, http_get):
 
 @pytest.mark.parallel
 def test_config_repo_auto_distribute(
-    setup_empty_distribution, http_get, rpm_publication_api, rpm_distribution_api, monitor_task
+    setup_empty_distribution, rpm_publication_api, rpm_distribution_api, monitor_task
 ):
     """Whether config.repo is properly served using auto-distribute."""
     repo, pub, dist = setup_empty_distribution
@@ -49,7 +48,7 @@ def test_config_repo_auto_distribute(
     dist = rpm_distribution_api.read(dist.pulp_href)
     assert repo.pulp_href == dist.repository
     assert dist.publication is None
-    content = http_get(f"{dist.base_url}config.repo")
+    content = requests.get(f"{dist.base_url}config.repo").content
 
     assert bytes(f"[{dist.name}]\n", "utf-8") in content
     assert bytes(f"baseurl={dist.base_url}\n", "utf-8") in content
@@ -58,6 +57,4 @@ def test_config_repo_auto_distribute(
 
     # Delete publication and check that 404 is now returned
     rpm_publication_api.delete(pub.pulp_href)
-    with pytest.raises(ClientResponseError) as ctx:
-        http_get(f"{dist.base_url}config.repo")
-    assert ctx.value.status == 404
+    assert requests.get(f"{dist.base_url}config.repo").status_code == 404

--- a/pulp_rpm/tests/functional/utils.py
+++ b/pulp_rpm/tests/functional/utils.py
@@ -2,11 +2,12 @@
 import gzip
 import os
 import subprocess
-
-from functools import partial
 from io import StringIO
+from functools import partial
 from unittest import SkipTest
-from tempfile import NamedTemporaryFile
+
+import pyzstd
+import requests
 
 from pulp_smash import api, cli, config, selectors
 from pulp_smash.pulp3.utils import gen_remote, get_content, require_pulp_3, require_pulp_plugins
@@ -218,20 +219,18 @@ def get_package_repo_path(package_filename):
     return os.path.join(PACKAGES_DIRECTORY, package_filename.lower()[0], package_filename)
 
 
-def read_xml_gz(content):
-    """
-    Read xml and xml.gz.
+def download_and_decompress_file(url):
+    # Tests work normally but fails for S3 due '.gz'
+    # Why is it only compressed for S3?
+    resp = requests.get(url)
+    decompression = None
+    if url.endswith(".gz"):
+        decompression = gzip.decompress
+    elif url.endswith(".zst"):
+        decompression = pyzstd.decompress
 
-    Tests work normally but fails for S3 due '.gz'
-    Why is it only compressed for S3?
-    """
-    with NamedTemporaryFile() as temp_file:
-        temp_file.write(content)
-        temp_file.seek(0)
-
-        try:
-            content_xml = gzip.open(temp_file.name).read()
-        except OSError:
-            # FIXME: fix this as in CI primary/update_info.xml has '.gz' but it is not gzipped
-            content_xml = temp_file.read()
-        return content_xml
+    if decompression:
+        return decompression(resp.content)
+    else:
+        # FIXME: fix this as in CI primary/update_info.xml has '.gz' but it is not gzipped
+        return resp.content


### PR DESCRIPTION
* Skip test that uses DRPM fixture, for now. It's not worth maintaining the fixture, and in the future we ought to be able to do this test without it.
* Made metadata downloading util agnostic to compression type
* Ditch all usages of http_get and http_get_headers for requests
* Fix CI after working directory adjustment in the template