### PR TITLE
Fix leftovers from sqlite-removal

### DIFF
--- a/CHANGES/3351.bugfix
+++ b/CHANGES/3351.bugfix
@@ -1,0 +1,1 @@
+Fixed bug about malformed tuple introduced on the removal of sqlite-metadata support (PR #3328).

--- a/pulp_rpm/app/tasks/publishing.py
+++ b/pulp_rpm/app/tasks/publishing.py
@@ -107,7 +107,7 @@ class PublicationData:
                 path = os.path.join(folder, path)
             with open(path, "wb") as new_file:
                 shutil.copyfileobj(current_file, new_file)
-                repomdrecords.append((repo_metadata_file.data_type, new_file.name, None))
+                repomdrecords.append((repo_metadata_file.data_type, new_file.name))
 
         return repomdrecords
 

--- a/pulp_rpm/tests/functional/api/test_publish.py
+++ b/pulp_rpm/tests/functional/api/test_publish.py
@@ -18,6 +18,7 @@ from pulp_rpm.tests.functional.constants import (
     RPM_COMPLEX_FIXTURE_URL,
     RPM_KICKSTART_FIXTURE_URL,
     RPM_KICKSTART_REPOSITORY_ROOT_CONTENT,
+    RPM_REPO_METADATA_FIXTURE_URL,
     RPM_LONG_UPDATEINFO_FIXTURE_URL,
     RPM_MODULAR_FIXTURE_URL,
     RPM_NAMESPACES,
@@ -149,6 +150,12 @@ def test_publish_rpm_rich_weak(assert_created_publication):
 def test_publish_rpm_long_updateinfo(assert_created_publication):
     """Sync and publish an RPM long updateinfo repository."""
     assert_created_publication(RPM_LONG_UPDATEINFO_FIXTURE_URL)
+
+
+@pytest.mark.parallel
+def test_publish_rpm_custom_metadata(assert_created_publication):
+    """Sync and publish an RPM with custom metadata files."""
+    assert_created_publication(RPM_REPO_METADATA_FIXTURE_URL)
 
 
 @pytest.mark.parallel


### PR DESCRIPTION
- Finish cleanup after sqlite-metadata support removal (#3328)
- Test publishing repo with custom metadata

fixes #3351

## Observations

I've assured that the test would fail without the fix.
Also, I've manually tested the publish workflow w/ RHEL7