### PR TITLE
[3.24 backport] Sanitize NSVCA values on modulemd YAML files

### DIFF
--- a/CHANGES/3285.bugfix
+++ b/CHANGES/3285.bugfix
@@ -1,0 +1,1 @@
+Added support for preventing unquoted NSVCA numerical values (e.g. ``"stream": 2.10``) of having zeros stripped on modulemd YAML files.

--- a/pulp_rpm/app/constants.py
+++ b/pulp_rpm/app/constants.py
@@ -166,7 +166,7 @@ PULP_MODULEOBSOLETES_ATTR = SimpleNamespace(
     CONTEXT="module_context",
     EOL="eol_date",
     OBSOLETE_BY_MODULE="obsoleted_by_module_name",
-    OBSOLETE_BY_STREAM="obsoleted_by_module_name",
+    OBSOLETE_BY_STREAM="obsoleted_by_module_stream",
 )
 
 # Mandatory fields for Modulemd types

--- a/pulp_rpm/app/tasks/synchronizing.py
+++ b/pulp_rpm/app/tasks/synchronizing.py
@@ -972,8 +972,13 @@ class RpmFirstStage(Stage):
                 await self.put(dc)
 
     async def parse_modules_metadata(self, modulemd_result):
-        """Parse modules' metadata which define what packages are built for specific releases."""
-        modulemd_all, defaults_all, obsoletes_all = parse_modular(modulemd_result)
+        """
+        Parse modules' metadata which define what packages are built for specific releases.
+
+        Args:
+            modulemd_result(pulpcore.download.base.DownloadResult): downloaded modulemd file
+        """
+        modulemd_all, defaults_all, obsoletes_all = parse_modular(modulemd_result.path)
 
         modulemd_dcs = []
 

--- a/pulp_rpm/tests/functional/constants.py
+++ b/pulp_rpm/tests/functional/constants.py
@@ -1589,8 +1589,8 @@ RPM_MODULEMD_OBSOLETES_DATA = [
         "override_previous": None,
         "module_context": "6c81f848",
         "eol_date": None,
-        "obsoleted_by_module_name": "10",
-        "obsoleted_by_module_stream": None,
+        "obsoleted_by_module_name": "nodejs",
+        "obsoleted_by_module_stream": "10",
     },
     {
         "modified": "2020-05-01T00:00Z",
@@ -1622,8 +1622,8 @@ RPM_MODULEMD_OBSOLETES_DATA = [
         "override_previous": None,
         "module_context": None,
         "eol_date": None,
-        "obsoleted_by_module_name": "5",
-        "obsoleted_by_module_stream": None,
+        "obsoleted_by_module_name": "nodejs",
+        "obsoleted_by_module_stream": "5",
     },
 ]
 

--- a/pulp_rpm/tests/unit/test_modulemd.py
+++ b/pulp_rpm/tests/unit/test_modulemd.py
@@ -1,0 +1,131 @@
+from pulp_rpm.app.modulemd import parse_modular
+import os
+
+sample_file_data = """
+---
+document: modulemd
+version: 2
+data:
+  name: kangaroo
+  stream: 1.10
+  version: 20180730223407
+  context: deadbeef
+  static_context: true
+  arch: noarch
+  summary: Kangaroo 0.3 module
+  description: >-
+    A module for the kangaroo 0.3 package
+  license:
+    module:
+      - MIT
+    content:
+      - MIT
+  profiles:
+    default:
+      rpms:
+        - kangaroo
+  artifacts:
+    rpms:
+      - kangaroo-0:0.3-1.noarch
+...
+---
+document: modulemd
+version: 2
+data:
+  name: kangaroo
+  stream: "1.10"
+  version: 20180704111719
+  context: deadbeef
+  static_context: false
+  arch: noarch
+  summary: Kangaroo 0.2 module
+  description: >-
+    A module for the kangaroo 0.2 package
+  license:
+    module:
+      - MIT
+    content:
+      - MIT
+  profiles:
+    default:
+      rpms:
+        - kangaroo
+  artifacts:
+    rpms:
+      - kangaroo-0:0.2-1.noarch
+...
+---
+document: modulemd-defaults
+version: 1
+data:
+  module: avocado
+  modified: 202002242100
+  profiles:
+    "5.30": [default]
+    "stream": [default]
+...
+---
+document: modulemd-obsoletes
+version: 1
+data:
+  modified: 2022-01-24T08:54Z
+  module: perl
+  stream: 5.30
+  eol_date: 2021-06-01T00:00Z
+  message: Module stream perl:5.30 is no longer supported. Please switch to perl:5.32
+  obsoleted_by:
+    module: perl
+    stream: 5.40
+...
+"""
+
+
+def test_parse_modular_preserves_literal_unquoted_values_3285(tmp_path):
+    """Unquoted yaml numbers with trailing/leading zeros are preserved on specific fields"""
+
+    # write data to test_file
+    os.chdir(tmp_path)
+    file_name = "modulemd.yaml"
+    with open(file_name, "w") as file:
+        file.write(sample_file_data)
+
+    all, defaults, obsoletes = parse_modular(file_name)
+
+    # check normal, defaults and obsoletes modulemds
+    kangoroo1 = all[0]  # unquoted
+    kangoroo2 = all[1]  # quoted
+    modulemd_defaults = defaults[0]
+    modulemd_obsoletes = obsoletes[0]
+
+    assert kangoroo1["name"] == "kangaroo"
+    assert kangoroo1["stream"] == "1.10"  # should not be 1.1
+    assert kangoroo1["version"] == "20180730223407"
+    assert kangoroo1["context"] == "deadbeef"
+    assert kangoroo1["static_context"] is True
+    assert kangoroo1["arch"] == "noarch"
+
+    assert kangoroo2["name"] == "kangaroo"
+    assert kangoroo2["stream"] == "1.10"
+    assert kangoroo2["version"] == "20180704111719"
+    assert kangoroo2["context"] == "deadbeef"
+    assert kangoroo2["static_context"] is False
+    assert kangoroo2["arch"] == "noarch"
+
+    # 'stream' keys which have non-scalar values (e.g. list) are parsed normally.
+    # Otherwise, weird results are produced (internal pyyaml objects)
+    assert modulemd_defaults["module"] == "avocado"
+    assert modulemd_defaults.get("modified") is None  # not present
+    assert modulemd_defaults["profiles"]["stream"] == ["default"]
+    assert modulemd_defaults["profiles"]["5.30"] == ["default"]
+
+    # parse_modular changes the structure and key names for obsoletes
+    assert modulemd_obsoletes["modified"] == "2022-01-24T08:54Z"
+    assert modulemd_obsoletes["module_name"] == "perl"
+    assert modulemd_obsoletes["module_stream"] == "5.30"
+    assert modulemd_obsoletes["eol_date"] == "2021-06-01T00:00Z"
+    assert (
+        modulemd_obsoletes["message"]
+        == "Module stream perl:5.30 is no longer supported. Please switch to perl:5.32"
+    )
+    assert modulemd_obsoletes["obsoleted_by_module_name"] == "perl"
+    assert modulemd_obsoletes["obsoleted_by_module_stream"] == "5.40"


### PR DESCRIPTION
- Replace yaml.safe_load by YAML loader that prevents unquoted numbers in NSVCA fields to loose trailing/heading zeros.
- Add unit test to `parse_modular` for the specific issue
- OBSOLETE_BY_STREAM attr was named as "obsoleted_by_module_name" instead of "obsoleted_by_name_stream". Fix tests accordingly.
- Refactor parse_modular, docstrings and small type annotations

closes #3285