### PR TITLE
Fix server error when using gpgcheck/repo_gpgcheck

### DIFF
--- a/CHANGES/3357.bugfix
+++ b/CHANGES/3357.bugfix
@@ -1,0 +1,1 @@
+Fixed server error when trying to create repository with deprecated `gpgcheck` and `repo_gpgcheck`.

--- a/pulp_rpm/app/serializers/repository.py
+++ b/pulp_rpm/app/serializers/repository.py
@@ -179,9 +179,8 @@ class RpmRepositorySerializer(RepositorySerializer):
         """
         # gpg options are deprecated in favour of repo_config
         # acting as shim layer between old and new api
-        gpgcheck = validated_data.get("gpgcheck")
-        repo_gpgcheck = validated_data.get("repo_gpgcheck")
-
+        gpgcheck = validated_data.pop("gpgcheck", None)
+        repo_gpgcheck = validated_data.pop("repo_gpgcheck", None)
         gpgcheck_options = {}
         if gpgcheck is not None:
             gpgcheck_options["gpgcheck"] = gpgcheck
@@ -197,6 +196,36 @@ class RpmRepositorySerializer(RepositorySerializer):
         repo = super().create(validated_data)
         repo.repo_config = repo_config
         return repo
+
+    def update(self, instance, validated_data):
+        """
+        Update the repo and handle gpg options
+
+        Args:
+            validated_data (dict): A dict of validated data to update the repo
+
+        Returns:
+            repo: the updated repo
+        """
+        # gpg options are deprecated in favour of repo_config
+        # acting as shim layer between old and new api
+        gpgcheck = validated_data.pop("gpgcheck", None)
+        repo_gpgcheck = validated_data.pop("repo_gpgcheck", None)
+        gpgcheck_options = {}
+        if gpgcheck is not None:
+            gpgcheck_options["gpgcheck"] = gpgcheck
+        if repo_gpgcheck is not None:
+            gpgcheck_options["repo_gpgcheck"] = repo_gpgcheck
+        if gpgcheck_options.keys():
+            logging.getLogger("pulp_rpm.deprecation").info(
+                "Support for gpg options will be removed from a future release of pulp_rpm."
+            )
+        repo_config = (
+            gpgcheck_options if gpgcheck_options else validated_data.get("repo_config", {})
+        )
+        instance.repo_config = repo_config
+        instance = super().update(instance, validated_data)
+        return instance
 
     class Meta:
         fields = RepositorySerializer.Meta.fields + (

--- a/pulp_rpm/tests/functional/api/test_crud_repository.py
+++ b/pulp_rpm/tests/functional/api/test_crud_repository.py
@@ -1,0 +1,55 @@
+import pytest
+
+
+@pytest.mark.parametrize(
+    "factory_kwargs,repo_config_result",
+    [
+        ({}, {}),
+        ({"gpgcheck": 0}, {"gpgcheck": 0}),
+        ({"repo_gpgcheck": 0}, {"repo_gpgcheck": 0}),
+        ({"gpgcheck": 0, "repo_gpgcheck": 0}, {"gpgcheck": 0, "repo_gpgcheck": 0}),
+        ({"gpgcheck": 1, "repo_gpgcheck": 1}, {"gpgcheck": 1, "repo_gpgcheck": 1}),
+    ],
+)
+def test_create_repo_with_deprecated_gpg_options_3357(
+    rpm_repository_factory, factory_kwargs, repo_config_result
+):
+    """Can create repository with deprecated gpgcheck and repo_gpgcheck options."""
+    repo = rpm_repository_factory(**factory_kwargs)
+    assert repo.repo_config == repo_config_result
+
+
+@pytest.mark.parametrize(
+    "original_repo_config,update_kwargs,repo_config_result",
+    [
+        ({}, {}, {}),
+        ({}, {"gpgcheck": 0}, {"gpgcheck": 0}),
+        ({}, {"repo_gpgcheck": 0}, {"repo_gpgcheck": 0}),
+        ({}, {"gpgcheck": 0, "repo_gpgcheck": 0}, {"gpgcheck": 0, "repo_gpgcheck": 0}),
+        ({}, {"gpgcheck": 1, "repo_gpgcheck": 1}, {"gpgcheck": 1, "repo_gpgcheck": 1}),
+        (
+            {"gpgcheck": 0, "repo_gpgcheck": 0},
+            {"gpgcheck": 1, "repo_gpgcheck": 1},
+            {"gpgcheck": 1, "repo_gpgcheck": 1},
+        ),
+    ],
+)
+def test_update_repo_with_deprecated_gpg_options_3357(
+    rpm_repository_factory,
+    rpm_repository_api,
+    original_repo_config,
+    update_kwargs,
+    repo_config_result,
+):
+    """Can update repository with deprecated gpgcheck and repo_gpgcheck options."""
+    original_repo = rpm_repository_factory(description="old", **original_repo_config)
+    assert original_repo.repo_config == original_repo_config
+    assert original_repo.description == "old"  # control group
+
+    body = {"name": original_repo.name}
+    body.update(update_kwargs)
+    body.update({"description": "new"})
+    rpm_repository_api.update(original_repo.pulp_href, body)
+    updated_repo = rpm_repository_api.read(original_repo.pulp_href)
+    assert updated_repo.repo_config == repo_config_result
+    assert updated_repo.description == "new"  # control group


### PR DESCRIPTION
https://github.com/pulp/pulp_rpm/pull/3298 moved gpg options to a single field called "repo_config", but the deprecated "gpgcheck" and "repo_gpgcheck" were still being passed to the models, which caused a TypeError when trying to use them.

closes #3357