### PR TITLE
Fixed an issue where the value of gpgcheck wasn't set appropriately

### DIFF
--- a/CHANGES/3462.bugfix
+++ b/CHANGES/3462.bugfix
@@ -1,0 +1,1 @@
+Fixed an issue where the value of `gpgcheck` wasn't appropriately set on some publications.


### PR DESCRIPTION
On publications created by `mirror_complete` sync.

closes #3462