### PR TITLE
[backport][3.23] Fix modulemd_defaults not having digest set

### DIFF
--- a/CHANGES/3495.bugfix
+++ b/CHANGES/3495.bugfix
@@ -1,0 +1,1 @@
+Fixed modulemd_defaults create endpoint not setting the content digest.

--- a/pulp_rpm/app/serializers/modulemd.py
+++ b/pulp_rpm/app/serializers/modulemd.py
@@ -1,6 +1,7 @@
 from gettext import gettext as _
 
 from rest_framework import serializers
+import hashlib
 
 from pulpcore.plugin.serializers import (
     DetailRelatedField,
@@ -83,6 +84,11 @@ class ModulemdDefaultsSerializer(NoArtifactContentSerializer):
     stream = serializers.CharField(help_text=_("Modulemd default stream."))
     profiles = serializers.JSONField(help_text=_("Default profiles for modulemd streams."))
     snippet = serializers.CharField(help_text=_("Modulemd default snippet"), write_only=True)
+
+    def create(self, validated_data):
+        snippet = validated_data["snippet"]
+        validated_data["digest"] = hashlib.sha256(snippet.encode()).hexdigest()
+        return super().create(validated_data)
 
     class Meta:
         fields = NoArtifactContentSerializer.Meta.fields + (


### PR DESCRIPTION
ModulemdDefaults upload wouldn't set the digest field, so it was not possible to upload more than one ModulemdDefault due to uniquness constrains.

Original: https://github.com/pulp/pulp_rpm/pull/3503

[noissue]