### PR TITLE
Adding simple check for empty signature files. Closes #3526

### DIFF
--- a/CHANGES/3526.feature
+++ b/CHANGES/3526.feature
@@ -1,0 +1,1 @@
+Added check for empty signature files before publish.

--- a/pulp_rpm/app/tasks/publishing.py
+++ b/pulp_rpm/app/tasks/publishing.py
@@ -695,6 +695,12 @@ def generate_repo_metadata(
         )
         sign_results = signing_service.sign(repomd_path)
 
+        # https://github.com/pulp/pulp_rpm/issues/3526
+        signature_file_path = sign_results["signature"]
+        if os.stat(signature_file_path).st_size == 0:
+            log.error(f"{signature_file_path} is 0 bytes! sign_results: {sign_results}")
+            raise Exception("Signature file is 0 bytes")
+
         # publish a signed file
         with open(sign_results["file"], "rb") as signed_file_fd:
             PublishedMetadata.create_from_file(


### PR DESCRIPTION
Check to confirm signature files are not 0 bytes before publishing
#3526 