### PR TITLE
Allow "group" aka comps metadata to be compressed

### DIFF
--- a/CHANGES/2753.bugfix
+++ b/CHANGES/2753.bugfix
@@ -1,0 +1,1 @@
+Allow syncing repos with a compressed comps.xml "group" metadata declared in repomd.xml.

--- a/pulp_rpm/app/shared_utils.py
+++ b/pulp_rpm/app/shared_utils.py
@@ -1,4 +1,5 @@
 import os
+import createrepo_c as cr
 import tempfile
 import shutil
 from hashlib import sha256


### PR DESCRIPTION
DNF supports compressed comps metadata - compression type is determined by filename and happens transparently the same for comps as it does for any other file.

closes #2753

(cherry picked from commit 92f526c1d15039312257c713c22dec344e43dd88) (cherry picked from commit 632b414006e6fb4999bab18def27bcb0b11555eb)