### PR TITLE
Fix a flaw that allowing duplicate advisories in repo version

### DIFF
--- a/CHANGES/3587.bugfix
+++ b/CHANGES/3587.bugfix
@@ -1,0 +1,1 @@
+Fix a flaw that still allowed to add duplicate advisories to a repository version.

--- a/pulp_rpm/app/advisory.py
+++ b/pulp_rpm/app/advisory.py
@@ -118,6 +118,11 @@ def resolve_advisories(version, previous_version):
             if pk_to_add:
                 new_advisory = UpdateRecord.objects.filter(pk=pk_to_add[0]).get()
                 tmp_advisories.append(new_advisory)
+            # If the first duplicate advisory is ended up in to_remove or to_exclude then
+            # set the one it was compared against as the one to keep.
+            # See https://github.com/pulp/pulp_rpm/pull/3588
+            elif new_advisory.pk in pk_to_remove or new_advisory.pk in pk_to_exclude:
+                new_advisory = adv
             content_pks_to_exclude.update(pk_to_exclude)
             content_pks_to_remove.update(pk_to_remove)
         added_advisories_by_id[adv_id] = [new_advisory]


### PR DESCRIPTION
This fix (https://github.com/pulp/pulp_rpm/issues/2821) should make the duplicate advisories in a repository version impossible. However, the fix is not covering all the cases. In a rare case, the incoming duplicate advisories are not merged/removed.

Please refer to code below:
https://github.com/pulp/pulp_rpm/blob/main/pulp_rpm/app/advisory.py#L114-L117 

To meet the rare case, the following 2 conditions need to be met:

    There are at least 3 incoming duplicate advisories.
    The first duplicate advisory is always the one to be removed by resolve_advisory_conflict()

For example:
conflict_advisories = [dup1, dup2, dup3]
[], [dup1], []= resolve_advisory_conflict(dup1, dup2)
[], [dup1], [] = resolve_advisory_conflict(dup1, dup3)

then the end result of set "content_pks_to_remove" will be equal to [{dup1}]
and the end result of set "content_pks_to_add" will be equal to [{dup1}]

and we will end up having dup2 and dup3 associated to the repository version.

Closes #3587


**Tests:**
3 incoming duplicate advisories in the repository version as below:
~~~
pulpcore=# select content_id, repository_id, version_added_id, version_removed_id from core_repositorycontent where repository_id = '766735f2-3d59-46d1-adda-438db984ef9d' and content_id in (select content_ptr_id from rpm_updaterecord where id = 'RHBA-2023:4044');
              content_id              |            repository_id             |           version_added_id           | version_removed_id 
--------------------------------------+--------------------------------------+--------------------------------------+--------------------
 7c29e6db-7f37-42fb-90d0-56181aedea76 | 766735f2-3d59-46d1-adda-438db984ef9d | aed114d3-e391-450a-9a3b-11a97abb931c | 
 b7e01d8d-22d0-4adb-b4c8-9536e68499ee | 766735f2-3d59-46d1-adda-438db984ef9d | aed114d3-e391-450a-9a3b-11a97abb931c | 
 e4aa4a01-88bd-471e-8d30-9fa8ce5e4e4b | 766735f2-3d59-46d1-adda-438db984ef9d | aed114d3-e391-450a-9a3b-11a97abb931c | 
(3 rows)
~~~

Results **without** this PR is:
~~~
              content_id              |            repository_id             |           version_added_id           | version_removed_id 
--------------------------------------+--------------------------------------+--------------------------------------+--------------------
 7c29e6db-7f37-42fb-90d0-56181aedea76 | 766735f2-3d59-46d1-adda-438db984ef9d | aed114d3-e391-450a-9a3b-11a97abb931c | 
 e4aa4a01-88bd-471e-8d30-9fa8ce5e4e4b | 766735f2-3d59-46d1-adda-438db984ef9d | aed114d3-e391-450a-9a3b-11a97abb931c | 
(2 rows)
~~~


Results **with** this PR is:
~~~
              content_id              |            repository_id             |           version_added_id           | version_removed_id 
--------------------------------------+--------------------------------------+--------------------------------------+--------------------
 7c29e6db-7f37-42fb-90d0-56181aedea76 | 766735f2-3d59-46d1-adda-438db984ef9d | aed114d3-e391-450a-9a3b-11a97abb931c | 
(1 row)
~~~

Test script:
~~~
PULP_SETTINGS=/etc/pulp/settings.py pulpcore-manager shell
from pulpcore.app.models import Repository
from pulp_rpm.app.advisory import resolve_advisories
repo = Repository.objects.get(pk="766735f2-3d59-46d1-adda-438db984ef9d")
version = repo.latest_version()
previous_version = version.previous()
version.complete = False
version.save()
resolve_advisories(version, previous_version)
version.complete = False
version.save()
~~~
~~~