### PR TITLE
Made sync more tolerant of poorly configured webservers

### DIFF
--- a/CHANGES/3599.bugfix
+++ b/CHANGES/3599.bugfix
@@ -1,0 +1,1 @@
+Made sync more tolerant of poorly configured webservers.

--- a/pulp_rpm/app/kickstart/treeinfo.py
+++ b/pulp_rpm/app/kickstart/treeinfo.py
@@ -17,13 +17,13 @@ class PulpTreeInfo(TreeInfo):
 
     """
 
-    def load(self, f):
+    def loads(self, s):
         """
-        Load data from a file.
+        Load data from a string.
 
         """
         try:
-            super().load(f)
+            super().loads(s)
         except MissingSectionHeaderError:
             raise TypeError(_("Treeinfo file should have INI format"))
 

--- a/pulp_rpm/app/tasks/synchronizing.py
+++ b/pulp_rpm/app/tasks/synchronizing.py
@@ -404,8 +404,9 @@ def synchronize(remote_pk, repository_pk, sync_policy, skip_types, optimize, url
 
         namespaces = [".treeinfo", "treeinfo"]
         for namespace in namespaces:
+            treeinfo_url = urlpath_sanitize(remote_url, namespace)
             downloader = remote.get_downloader(
-                url=urlpath_sanitize(remote_url, namespace),
+                url=treeinfo_url,
                 silence_errors_for_response_status_codes={403, 404},
             )
 
@@ -415,7 +416,19 @@ def synchronize(remote_pk, repository_pk, sync_policy, skip_types, optimize, url
                 continue
 
             treeinfo = PulpTreeInfo()
-            treeinfo.load(f=result.path)
+            with open(result.path, "r") as f:
+                treeinfo_str = f.read()
+                # some impolitely configured webservers return HTTP 200 with an HTML error page
+                # when a resource isn't found, instead of returning an HTTP 404 code
+                if treeinfo_str.startswith("<"):
+                    # in the event that the response looks like HTML rather than an INI file,
+                    # let's just pretend it returned 404
+                    log.debug(
+                        f"Server returned 200 for {treeinfo_url}, but the result looks like HTML"
+                        " rather than treeinfo. Ignoring it."
+                    )
+                    continue
+                treeinfo.loads(treeinfo_str)
             sha256 = result.artifact_attributes["sha256"]
             treeinfo_data = TreeinfoData(treeinfo.parsed_sections())
 


### PR DESCRIPTION
Treeinfo download will ignore results that look like HTML. Some webservers return 200 with an HTML error page rather than 404.

closes #3599