### PR TITLE
suggestion: get compression_type from repository if not specified

### DIFF
--- a/CHANGES/3614.feature
+++ b/CHANGES/3614.feature
@@ -1,0 +1,1 @@
+Honor repository's compression_type for publications unless overridden

--- a/pulp_rpm/app/viewsets/repository.py
+++ b/pulp_rpm/app/viewsets/repository.py
@@ -565,7 +565,9 @@ class RpmPublicationViewSet(PublicationViewSet, RolesMixin):
             )
         repo_config = serializer.validated_data.get("repo_config", repository.repo_config)
         repo_config = gpgcheck_options if gpgcheck_options else repo_config
-        compression_type = serializer.validated_data.get("compression_type")
+        compression_type = serializer.validated_data.get(
+            "compression_type", repository.compression_type
+        )
 
         if repository.metadata_signing_service:
             signing_service_pk = repository.metadata_signing_service.pk


### PR DESCRIPTION
When publishing manually (i.e. without auto_publish) the compression_type must either be passed or defaults to "None", falling back to gz.
It was kind of confusing to me that even though I had a compression_type specified in the repository, my repo metadata was compressed with gz.

This PR takes the compression_type from the repository if not passed otherwise.

fixes #3614 