### PR TITLE
Change JSONFields to more specific Fields

### DIFF
--- a/pulp_rpm/app/serializers/package.py
+++ b/pulp_rpm/app/serializers/package.py
@@ -77,64 +77,54 @@ class PackageSerializer(SingleArtifactContentUploadSerializer, ContentChecksumSe
         read_only=True,
     )
 
-    changelogs = serializers.JSONField(
+    changelogs = serializers.ListField(
         help_text=_("Changelogs that package contains"),
-        default="[]",
         required=False,
         read_only=True,
     )
-    files = serializers.JSONField(
+    files = serializers.ListField(
         help_text=_("Files that package contains"),
-        default="[]",
         required=False,
         read_only=True,
     )
 
-    requires = serializers.JSONField(
+    requires = serializers.ListField(
         help_text=_("Capabilities the package requires"),
-        default="[]",
         required=False,
         read_only=True,
     )
-    provides = serializers.JSONField(
+    provides = serializers.ListField(
         help_text=_("Capabilities the package provides"),
-        default="[]",
         required=False,
         read_only=True,
     )
-    conflicts = serializers.JSONField(
+    conflicts = serializers.ListField(
         help_text=_("Capabilities the package conflicts"),
-        default="[]",
         required=False,
         read_only=True,
     )
-    obsoletes = serializers.JSONField(
+    obsoletes = serializers.ListField(
         help_text=_("Capabilities the package obsoletes"),
-        default="[]",
         required=False,
         read_only=True,
     )
-    suggests = serializers.JSONField(
+    suggests = serializers.ListField(
         help_text=_("Capabilities the package suggests"),
-        default="[]",
         required=False,
         read_only=True,
     )
-    enhances = serializers.JSONField(
+    enhances = serializers.ListField(
         help_text=_("Capabilities the package enhances"),
-        default="[]",
         required=False,
         read_only=True,
     )
-    recommends = serializers.JSONField(
+    recommends = serializers.ListField(
         help_text=_("Capabilities the package recommends"),
-        default="[]",
         required=False,
         read_only=True,
     )
-    supplements = serializers.JSONField(
+    supplements = serializers.ListField(
         help_text=_("Capabilities the package supplements"),
-        default="[]",
         required=False,
         read_only=True,
     )

--- a/pulp_rpm/app/serializers/repository.py
+++ b/pulp_rpm/app/serializers/repository.py
@@ -139,7 +139,7 @@ class RpmRepositorySerializer(RepositorySerializer):
         ),
         read_only=True,
     )
-    repo_config = serializers.JSONField(
+    repo_config = serializers.DictField(
         required=False,
         help_text=_("A JSON document describing config.repo file"),
     )
@@ -402,7 +402,7 @@ class RpmPublicationSerializer(PublicationSerializer):
         ),
         read_only=True,
     )
-    repo_config = serializers.JSONField(
+    repo_config = serializers.DictField(
         required=False,
         help_text=_("A JSON document describing config.repo file"),
     )
@@ -536,13 +536,33 @@ class RpmRepositorySyncURLSerializer(RepositorySyncURLSerializer):
         return data
 
 
+copy_config_example = """
+[
+    {
+    "source_repo_version": {{ version-href }},
+    "dest_repo": {{ repo-href }},
+    "content": [ {{ item-1.href }}, {{ item-2.href }} ]
+    },
+    {
+    "source_repo_version": {{ version-href }},
+    "dest_repo": {{ repo-href }},
+    "dest_base_version": 0,
+    "content": [ {{ item-1.href }}, {{ item-2.href }} ]
+    }
+]
+"""
+
+
 class CopySerializer(ValidateFieldsMixin, serializers.Serializer):
     """
     A serializer for Content Copy API.
     """
 
-    config = serializers.JSONField(
-        help_text=_("A JSON document describing sources, destinations, and content to be copied"),
+    config = serializers.ListField(
+        help_text=_(
+            "A JSON List of Objects describing sources, destinations, and content to be copied. "
+            f"E.g:\n```{copy_config_example}```"
+        ),
     )
 
     dependency_solving = serializers.BooleanField(


### PR DESCRIPTION
Closes: #3657 

---

<details><summary>Previous Problem this was trying to solve</summary>
<p>

## Problem
As mentioned in #3639, the [DRF JSONFields ](https://www.django-rest-framework.org/api-guide/fields/#jsonfield) are too generic and can be any JSON primitive (str, bool, etc), not just dicts or lists (as our codebase appears to be interpreting it).

After drf-spectacular fixed that interpretation on their side, our openapi schema broke because `Object` from JSONField became `Any`, which matches what JSON Fields are in DRF but not what we think it meant before.

## Approaches considered

1. **Change all `JSONField`** to some other fields that represents better what the field actually is. Example, `repo_config` is a `DictField`, some listy object should be `ListField`, etc.
2. **Use `extend_schema`** to modify how the openapi schema will be generated. It affect only schema generation, AFAIK.
3. **Force JSONField to be a OA 'object'**, as suggested [here](https://github.com/tfranzel/drf-spectacular/issues/1242#issuecomment-2123492057). The downside is that the representation of our fields would continue to be inaccurate.

</p>
</details> 
