### PR TITLE
Remove CentOS 7 tests

### DIFF
--- a/pulp_rpm/tests/functional/api/test_sync.py
+++ b/pulp_rpm/tests/functional/api/test_sync.py
@@ -21,7 +21,6 @@ from pulp_smash.pulp3.utils import (
 
 from pulp_rpm.tests.functional.constants import (
     AMAZON_MIRROR,
-    CENTOS7_OPSTOOLS_URL,
     PULP_TYPE_ADVISORY,
     PULP_TYPE_MODULEMD,
     PULP_TYPE_PACKAGE,
@@ -742,13 +741,15 @@ def test_sha_checksum(init_and_sync):
     init_and_sync(url=RPM_SHA_FIXTURE_URL)
 
 
+@pytest.mark.skip("TODO: Need a new test fixture")
 @pytest.mark.parallel
 def test_one_nevra_two_locations_and_checksums(init_and_sync):
     """Sync a repository known to have one nevra, in two locations, with different content.
 
     While 'odd', this is a real-world occurrence.
     """
-    init_and_sync(url=CENTOS7_OPSTOOLS_URL, policy="on_demand")
+    # init_and_sync(url=CENTOS7_OPSTOOLS_URL, policy="on_demand")
+    pass
 
 
 @pytest.mark.parallel

--- a/pulp_rpm/tests/functional/constants.py
+++ b/pulp_rpm/tests/functional/constants.py
@@ -609,13 +609,11 @@ RPM_DIFF_NAME_SAME_CONTENT_URL = urljoin(PULP_FIXTURES_BASE_URL, "diff-name-same
 RPM_ONLY_METADATA_REPO_URL = urljoin(PULP_FIXTURES_BASE_URL, "rpm-unsigned-meta-only")
 
 AMAZON_MIRROR = "http://amazonlinux.us-east-1.amazonaws.com/2/core/latest/x86_64/mirror.list"
-CENTOS7_URL = "http://mirror.centos.org/centos-7/7/os/x86_64/"
-CENTOS7_OPSTOOLS_URL = "http://mirror.centos.org/centos/7/opstools/x86_64/"
 CENTOS8_STREAM_BASEOS_URL = "http://vault.centos.org/centos/8-stream/BaseOS/x86_64/os/"
 CENTOS8_STREAM_APPSTREAM_URL = "http://vault.centos.org/centos/8-stream/AppStream/x86_64/os/"
 CENTOS9_STREAM_BASEOS_URL = "http://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/"
 CENTOS9_STREAM_APPSTREAM_URL = "http://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/"
-EPEL7_URL = "https://dl.fedoraproject.org/pub/epel/7/x86_64/"
+EPEL8_URL = "https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/"
 EPEL8_MIRRORLIST_URL = "https://mirrors.fedoraproject.org/mirrorlist?repo=epel-8&arch=x86_64"
 RAWHIDE_KICKSTART_URL = (
     "https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Server/x86_64/os/"

--- a/pulp_rpm/tests/performance/test_publish.py
+++ b/pulp_rpm/tests/performance/test_publish.py
@@ -11,10 +11,8 @@ from productmd.treeinfo import TreeInfo
 
 from pulp_rpm.tests.functional.constants import (
     RPM_PACKAGE_CONTENT_NAME,
-    CENTOS7_URL,
     CENTOS8_STREAM_APPSTREAM_URL,
     CENTOS8_STREAM_BASEOS_URL,
-    EPEL7_URL,
 )
 
 
@@ -83,8 +81,6 @@ def centos_8stream_baseos_extra_tests(rpm_distribution_factory):
 @pytest.mark.parametrize(
     "url,extra_tests",
     [
-        (EPEL7_URL, None),
-        (CENTOS7_URL, None),
         (CENTOS8_STREAM_BASEOS_URL, "centos_8stream_baseos_extra_tests"),
         (CENTOS8_STREAM_APPSTREAM_URL, None),
         (CENTOS8_STREAM_BASEOS_URL, None),

--- a/pulp_rpm/tests/performance/test_pulp_to_pulp.py
+++ b/pulp_rpm/tests/performance/test_pulp_to_pulp.py
@@ -3,16 +3,13 @@
 import pytest
 
 from pulp_rpm.tests.functional.constants import (
-    CENTOS7_URL,
     CENTOS8_STREAM_BASEOS_URL,
     CENTOS8_STREAM_APPSTREAM_URL,
 )
 
 
 @pytest.mark.parallel
-@pytest.mark.parametrize(
-    "url", [CENTOS7_URL, CENTOS8_STREAM_BASEOS_URL, CENTOS8_STREAM_APPSTREAM_URL]
-)
+@pytest.mark.parametrize("url", [CENTOS8_STREAM_BASEOS_URL, CENTOS8_STREAM_APPSTREAM_URL])
 def test_pulp_to_pulp(
     url,
     init_and_sync,

--- a/pulp_rpm/tests/performance/test_sync.py
+++ b/pulp_rpm/tests/performance/test_sync.py
@@ -10,7 +10,6 @@ from pulp_rpm.tests.functional.constants import (
     RHEL8_BASEOS_CDN_URL,
     RPM_KICKSTART_CONTENT_NAME,
     RPM_KICKSTART_COUNT,
-    CENTOS7_URL,
     CENTOS8_STREAM_APPSTREAM_URL,
     CENTOS8_STREAM_BASEOS_URL,
     EPEL8_MIRRORLIST_URL,
@@ -34,9 +33,8 @@ def parse_date_from_string(s, parse_format="%Y-%m-%dT%H:%M:%S.%fZ"):
 @pytest.mark.parametrize(
     "url,policy,check_dist_tree,resync",
     [
-        (CENTOS7_URL, "on_demand", True, True),
         pytest.param(
-            CENTOS7_URL,
+            CENTOS8_STREAM_BASEOS_URL,
             "immediate",
             True,
             True,


### PR DESCRIPTION
CentOS 7 is EOL, and using the vault URLs is somewhat impolite as they aren't cached.

[noissue]