### PR TITLE
[3.19 manual backport] Remove CentOS 7 tests

### DIFF
--- a/pulp_rpm/tests/functional/api/test_sync.py
+++ b/pulp_rpm/tests/functional/api/test_sync.py
@@ -20,7 +20,6 @@ from pulp_smash.pulp3.utils import (
 
 from pulp_rpm.tests.functional.constants import (
     AMAZON_MIRROR,
-    CENTOS7_OPSTOOLS_URL,
     PULP_TYPE_ADVISORY,
     PULP_TYPE_MODULEMD,
     PULP_TYPE_PACKAGE,
@@ -741,13 +740,15 @@ def test_sha_checksum(init_and_sync):
     init_and_sync(url=RPM_SHA_FIXTURE_URL)
 
 
+@pytest.mark.skip("TODO: Need a new test fixture")
 @pytest.mark.parallel
 def test_one_nevra_two_locations_and_checksums(init_and_sync):
     """Sync a repository known to have one nevra, in two locations, with different content.
 
     While 'odd', this is a real-world occurrence.
     """
-    init_and_sync(url=CENTOS7_OPSTOOLS_URL, policy="on_demand")
+    # init_and_sync(url=CENTOS7_OPSTOOLS_URL, policy="on_demand")
+    pass
 
 
 @pytest.mark.parallel

--- a/pulp_rpm/tests/functional/constants.py
+++ b/pulp_rpm/tests/functional/constants.py
@@ -604,13 +604,11 @@ RPM_DIFF_NAME_SAME_CONTENT_URL = urljoin(PULP_FIXTURES_BASE_URL, "diff-name-same
 RPM_ONLY_METADATA_REPO_URL = urljoin(PULP_FIXTURES_BASE_URL, "rpm-unsigned-meta-only")
 
 AMAZON_MIRROR = "http://amazonlinux.us-east-1.amazonaws.com/2/core/latest/x86_64/mirror.list"
-CENTOS7_URL = "http://mirror.centos.org/centos-7/7/os/x86_64/"
-CENTOS7_OPSTOOLS_URL = "http://mirror.centos.org/centos/7/opstools/x86_64/"
 CENTOS8_STREAM_BASEOS_URL = "http://vault.centos.org/centos/8-stream/BaseOS/x86_64/os/"
 CENTOS8_STREAM_APPSTREAM_URL = "http://vault.centos.org/centos/8-stream/AppStream/x86_64/os/"
 CENTOS9_STREAM_BASEOS_URL = "http://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/"
 CENTOS9_STREAM_APPSTREAM_URL = "http://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/"
-EPEL7_URL = "https://dl.fedoraproject.org/pub/epel/7/x86_64/"
+EPEL8_URL = "https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/"
 EPEL8_MIRRORLIST_URL = "https://mirrors.fedoraproject.org/mirrorlist?repo=epel-8&arch=x86_64"
 F36_KICKSTART_URL = "https://dl.fedoraproject.org/pub/fedora/linux/releases/36/Server/x86_64/os/"
 RHEL6_KICKSTART_CDN_URL = "https://cdn.redhat.com/content/dist/rhel/server/6/6.10/x86_64/kickstart/"

--- a/pulp_rpm/tests/performance/test_publish.py
+++ b/pulp_rpm/tests/performance/test_publish.py
@@ -19,16 +19,15 @@ from pulp_smash.pulp3.utils import (
 )
 
 from pulp_rpm.tests.functional.constants import (
+    EPEL8_URL,
     RPM_DISTRIBUTION_PATH,
     RPM_PACKAGE_CONTENT_NAME,
     RPM_KICKSTART_FIXTURE_URL,
     RPM_PUBLICATION_PATH,
     RPM_REMOTE_PATH,
     RPM_REPO_PATH,
-    CENTOS7_URL,
     CENTOS8_STREAM_APPSTREAM_URL,
     CENTOS8_STREAM_BASEOS_URL,
-    EPEL7_URL,
 )
 from pulp_rpm.tests.functional.utils import gen_rpm_remote
 from pulp_rpm.tests.functional.utils import set_up_module as setUpModule  # noqa:F401
@@ -150,13 +149,9 @@ class PublishTestCase(unittest.TestCase):
         )
         return publish_task["created_resources"][0]
 
-    def test_epel7(self):
-        """Publish EPEL 7."""
-        self.rpm_publish(url=EPEL7_URL)
-
-    def test_centos7(self):
-        """Publish CentOS 7."""
-        self.rpm_publish(url=CENTOS7_URL)
+    def test_epel8(self):
+        """Publish EPEL 8."""
+        self.rpm_publish(url=EPEL8_URL)
 
     def test_centos_8stream_baseos(self):
         """Publish CentOS 8 BaseOS."""
@@ -195,7 +190,3 @@ class PublishTestCase(unittest.TestCase):
     def test_centos8_appstream(self):
         """Publish CentOS 8 AppStream."""
         self.rpm_publish(url=CENTOS8_STREAM_APPSTREAM_URL)
-
-    def test_centos8_baseos(self):
-        """Publish CentOS 8 BaseOS."""
-        self.rpm_publish(url=CENTOS8_STREAM_BASEOS_URL)

--- a/pulp_rpm/tests/performance/test_pulp_to_pulp.py
+++ b/pulp_rpm/tests/performance/test_pulp_to_pulp.py
@@ -11,7 +11,6 @@ from pulp_smash.pulp3.utils import (
 )
 
 from pulp_rpm.tests.functional.constants import (
-    CENTOS7_URL,
     CENTOS8_STREAM_BASEOS_URL,
     CENTOS8_STREAM_APPSTREAM_URL,
 )
@@ -127,10 +126,6 @@ class SynctoSyncTestCase(unittest.TestCase):
         added = get_added_content_summary(repo.to_dict())
         added2 = get_added_content_summary(repo2.to_dict())
         self.assertDictEqual(added, added2)
-
-    def test_centos7_on_demand(self):
-        """Sync CentOS 7."""
-        self.do_test(url=CENTOS7_URL)
 
     def test_centos8_baseos_on_demand(self):
         """Sync CentOS 8 BaseOS."""

--- a/pulp_rpm/tests/performance/test_sync.py
+++ b/pulp_rpm/tests/performance/test_sync.py
@@ -22,7 +22,6 @@ from pulp_rpm.tests.functional.constants import (
     RPM_KICKSTART_FIXTURE_URL,
     RPM_REMOTE_PATH,
     RPM_REPO_PATH,
-    CENTOS7_URL,
     CENTOS8_STREAM_APPSTREAM_URL,
     CENTOS8_STREAM_BASEOS_URL,
     EPEL8_MIRRORLIST_URL,
@@ -143,14 +142,10 @@ class SyncTestCase(unittest.TestCase):
             # Check that nothing has changed since the last sync.
             self.assertEqual(latest_version_href, repo["latest_version_href"])
 
-    def test_centos7_on_demand(self):
-        """Sync CentOS 7."""
-        self.rpm_sync(url=CENTOS7_URL)
-
     @unittest.skip("Skip to avoid failing due to running out of disk space")
-    def test_centos7_immediate(self):
-        """Sync CentOS 7 with the immediate policy."""
-        self.rpm_sync(url=CENTOS7_URL, policy="immediate")
+    def test_centos8_baseos_immediate(self):
+        """Sync CentOS 8 Stream with the immediate policy."""
+        self.rpm_sync(url=CENTOS8_STREAM_BASEOS_URL, policy="immediate")
 
     def test_centos8_baseos_on_demand(self):
         """Sync CentOS 8 BaseOS."""

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
     version="3.19.13.dev",
     description="RPM plugin for the Pulp Project",
     long_description=long_description,
+    long_description_content_type="text/x-rst",
     license="GPLv2+",
     author="Pulp Project Developers",
     author_email="pulp-list@redhat.com",


### PR DESCRIPTION
CentOS 7 is EOL, and using the vault URLs is somewhat impolite as they aren't cached.

[noissue]