### PR TITLE
Bump minimum supported pulpcore to 3.49

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ django_readonly_field~=1.1.1
 jsonschema>=4.6,<5.0
 libcomps>=0.1.20.post1,<0.2
 productmd~=1.33.0
-pulpcore>=3.44.1,<3.70
+pulpcore>=3.49.0,<3.70
 solv~=0.7.21
 aiohttp_xmlrpc~=1.5.0


### PR DESCRIPTION
It's the cleanest (though not ideal) solution to some CI issues, which fortunately should not impact our stakeholders.

[noissue]