### PR TITLE
[3.18] Add basic auth to content removal test

### DIFF
--- a/pulp_rpm/tests/functional/api/test_crud_content_unit.py
+++ b/pulp_rpm/tests/functional/api/test_crud_content_unit.py
@@ -173,9 +173,10 @@ class ContentUnitRemoveTestCase(PulpTestCase):
         repo_content = get_content(repo.to_dict())
         base_addr = self.cfg.get_host_settings()[0]["url"]
 
+        basic_auth = requests.auth.HTTPBasicAuth("admin", "password")
         for content_type in repo_content.keys():
             response = requests.delete(
-                urljoin(base_addr, repo_content[content_type][0]["pulp_href"])
+                urljoin(base_addr, repo_content[content_type][0]["pulp_href"]), auth=basic_auth
             )
             self.assertEqual(response.status_code, 405)
 


### PR DESCRIPTION
We were getting failed tests on ContentUnitRemoveTestCase because the delete was being made by the requests library client without any credentials.

Then, we would get 403 (forbidden) instead of 405 (method now allowed).

This assumes the delete requires auth in the first place.

[noissue]