### PR TITLE
[3.19] Wrong advisory count investigation

### DIFF
--- a/.github/workflows/scripts/script.sh
+++ b/.github/workflows/scripts/script.sh
@@ -145,11 +145,11 @@ if [ -f "$FUNC_TEST_SCRIPT" ]; then
 else
   if [[ "$GITHUB_WORKFLOW" =~ "Nightly" ]]
   then
-    cmd_user_prefix bash -c "pytest -v -r sx --color=yes --suppress-no-test-exit-code --pyargs pulp_rpm.tests.functional -m parallel -n 8 --nightly"
-    cmd_user_prefix bash -c "pytest -v -r sx --color=yes --suppress-no-test-exit-code --pyargs pulp_rpm.tests.functional -m 'not parallel' --nightly"
+    cmd_user_prefix bash -c "pytest -v -r sx --color=yes --suppress-no-test-exit-code --pyargs pulp_rpm.tests.functional -m run_only_this -n 8 --nightly"
+    # cmd_user_prefix bash -c "pytest -v -r sx --color=yes --suppress-no-test-exit-code --pyargs pulp_rpm.tests.functional -m 'not parallel' --nightly"
   else
-    cmd_user_prefix bash -c "pytest -v -r sx --color=yes --suppress-no-test-exit-code --pyargs pulp_rpm.tests.functional -m parallel -n 8"
-    cmd_user_prefix bash -c "pytest -v -r sx --color=yes --suppress-no-test-exit-code --pyargs pulp_rpm.tests.functional -m 'not parallel'"
+    cmd_user_prefix bash -c "pytest -v -r sx --color=yes --suppress-no-test-exit-code --pyargs pulp_rpm.tests.functional -m run_only_this -n 8"
+    # cmd_user_prefix bash -c "pytest -v -r sx --color=yes --suppress-no-test-exit-code --pyargs pulp_rpm.tests.functional -m 'not parallel'"
   fi
 fi
 export PULP_FIXTURES_URL="http://pulp-fixtures:8080"

--- a/pulp_rpm/tests/functional/api/test_rbac_crud.py
+++ b/pulp_rpm/tests/functional/api/test_rbac_crud.py
@@ -336,6 +336,7 @@ def test_rbac_publication(
         assert not any(p.repository != repository.pulp_href for p in publications)
 
 
+@pytest.mark.run_only_this
 @pytest.mark.parallel
 def test_rbac_distribution(
     gen_user,
@@ -442,6 +443,7 @@ def test_rbac_distribution(
         assert rpm_rpmremote_api.list(name=remote.name).count == 0
 
 
+@pytest.mark.run_only_this
 @pytest.mark.parallel
 def test_rbac_content_scoping(
     gen_user,


### PR DESCRIPTION
This PR is for sharing some observations on the problem of wrong number of advisories count on branch 3.19:

## Error

```
        # Test content visibility
        # TODO: modules
        with user_creator:
            _assert_listed_content()
    
        with user_viewer:
>           _assert_listed_content()

usr/local/lib/python3.8/site-packages/pulp_rpm/tests/functional/api/test_rbac_crud.py:517: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

    def _assert_listed_content():
        packages_count = rpm_package_api.list(repository_version=repo.latest_version_href).count
        assert RPM_FIXTURE_SUMMARY["rpm.package"] == packages_count
    
        advisories_count = rpm_advisory_api.list(repository_version=repo.latest_version_href).count
>       assert RPM_FIXTURE_SUMMARY["rpm.advisory"] == advisories_count
E       assert 4 == 20

usr/local/lib/python3.8/site-packages/pulp_rpm/tests/functional/api/test_rbac_crud.py:494: AssertionError
```

## Observations

- Basic failure setup:
  - run only `test_rbac_content_scoping` + one of other test that sync from the same fixture (apparently). E.g `test_rbac_dsitribution`.
  - run them in parallel with any number of workers.
- Locally, something like: `oci-env test -p pulp_rpm functional -n 8 -vk test_rbac_crud`
- Only happens under `user_viewer` context
- Reverting the last obvious advisory-related commits didnt make any difference. They are:
  ```bash
  8d6dc66b Fix a flaw that allowing duplicate advisories in repo version  # 11 June 2024
  3158fd0b Addressed an edge-case around advisory-collection name collisions.  # 25 Jan 2024
  ```
- Looks related to the problem presented here: https://github.com/pulp/pulpcore/pull/3642
