### PR TITLE
Fixed create_modulemd() stacktrace when handling malformed modulmd.

### DIFF
--- a/CHANGES/3756.bugfix
+++ b/CHANGES/3756.bugfix
@@ -1,0 +1,1 @@
+Fixed stacktrace from create_modulemd() when trying to report an error.

--- a/pulp_rpm/app/modulemd.py
+++ b/pulp_rpm/app/modulemd.py
@@ -121,13 +121,13 @@ def create_modulemd(modulemd, snippet):
                     "Got unexpected data for module {}-{}-{}-{}-{}: "
                     "profiles failed to parse properly"
                 ).format(
-                    data[PULP_MODULE_ATTR.NAME],
-                    data[PULP_MODULE_ATTR.STREAM],
-                    data[PULP_MODULE_ATTR.VERSION],
-                    data[PULP_MODULE_ATTR.CONTEXT],
-                    data[PULP_MODULE_ATTR.ARCH],
+                    new_module[PULP_MODULE_ATTR.NAME],
+                    new_module[PULP_MODULE_ATTR.STREAM],
+                    new_module[PULP_MODULE_ATTR.VERSION],
+                    new_module[PULP_MODULE_ATTR.CONTEXT],
+                    new_module[PULP_MODULE_ATTR.ARCH],
                 )
-                log.warn(msg)
+                log.warning(msg)
             else:
                 profiles[name] = rpms
 


### PR DESCRIPTION
fixes #3756.