### PR TITLE
[3.26] Fix ruby bindings AnyType error

### DIFF
--- a/CHANGES/3639.bugfix
+++ b/CHANGES/3639.bugfix
@@ -1,0 +1,1 @@
+Fixed the JSONField specification so it doesn't break ruby bindings.

--- a/pulp_rpm/app/fields.py
+++ b/pulp_rpm/app/fields.py
@@ -1,4 +1,6 @@
 from rest_framework import serializers
+from drf_spectacular.utils import extend_schema_field
+from drf_spectacular.types import OpenApiTypes
 from pulp_rpm.app.constants import ADVISORY_SUM_TYPE_TO_NAME
 from pulp_rpm.app.models import UpdateReference
 
@@ -73,3 +75,8 @@ class UpdateReferenceField(serializers.ListField):
                 }
             )
         return ret
+
+
+@extend_schema_field(OpenApiTypes.OBJECT)
+class CustomJSONField(serializers.JSONField):
+    """A (drf) JSONField override to force openapi schema to use 'object' type."""

--- a/pulp_rpm/app/serializers/advisory.py
+++ b/pulp_rpm/app/serializers/advisory.py
@@ -5,6 +5,7 @@ import json
 import createrepo_c
 from django.db import IntegrityError, transaction
 from rest_framework import serializers
+from pulp_rpm.app.fields import CustomJSONField
 
 from pulpcore.plugin.serializers import (
     ModelSerializer,
@@ -43,7 +44,7 @@ class UpdateCollectionSerializer(ModelSerializer):
         help_text=_("Collection short name."), allow_blank=True, allow_null=True
     )
 
-    module = serializers.JSONField(help_text=_("Collection modular NSVCA."), allow_null=True)
+    module = CustomJSONField(help_text=_("Collection modular NSVCA."), allow_null=True)
 
     packages = UpdateCollectionPackagesField(
         source="*", read_only=True, help_text=_("List of packages")

--- a/pulp_rpm/app/serializers/comps.py
+++ b/pulp_rpm/app/serializers/comps.py
@@ -1,6 +1,7 @@
 from gettext import gettext as _
 
 from rest_framework import serializers
+from pulp_rpm.app.fields import CustomJSONField
 
 from pulpcore.plugin.models import Repository
 from pulpcore.plugin.serializers import DetailRelatedField
@@ -31,14 +32,12 @@ class PackageGroupSerializer(NoArtifactContentSerializer):
     )
     name = serializers.CharField(help_text=_("PackageGroup name."), allow_blank=True)
     description = serializers.CharField(help_text=_("PackageGroup description."), allow_blank=True)
-    packages = serializers.JSONField(help_text=_("PackageGroup package list."), allow_null=True)
+    packages = CustomJSONField(help_text=_("PackageGroup package list."), allow_null=True)
     biarch_only = serializers.BooleanField(help_text=_("PackageGroup biarch only."), required=False)
-    desc_by_lang = serializers.JSONField(
+    desc_by_lang = CustomJSONField(
         help_text=_("PackageGroup description by language."), allow_null=True
     )
-    name_by_lang = serializers.JSONField(
-        help_text=_("PackageGroup name by language."), allow_null=True
-    )
+    name_by_lang = CustomJSONField(help_text=_("PackageGroup name by language."), allow_null=True)
     digest = serializers.CharField(
         help_text=_("PackageGroup digest."),
     )
@@ -73,11 +72,11 @@ class PackageCategorySerializer(NoArtifactContentSerializer):
     display_order = serializers.IntegerField(
         help_text=_("Category display order."), allow_null=True
     )
-    group_ids = serializers.JSONField(help_text=_("Category group list."), allow_null=True)
-    desc_by_lang = serializers.JSONField(
+    group_ids = CustomJSONField(help_text=_("Category group list."), allow_null=True)
+    desc_by_lang = CustomJSONField(
         help_text=_("Category description by language."), allow_null=True
     )
-    name_by_lang = serializers.JSONField(help_text=_("Category name by language."), allow_null=True)
+    name_by_lang = CustomJSONField(help_text=_("Category name by language."), allow_null=True)
     digest = serializers.CharField(
         help_text=_("Category digest."),
     )
@@ -109,14 +108,12 @@ class PackageEnvironmentSerializer(NoArtifactContentSerializer):
     display_order = serializers.IntegerField(
         help_text=_("Environment display order."), allow_null=True
     )
-    group_ids = serializers.JSONField(help_text=_("Environment group list."), allow_null=True)
-    option_ids = serializers.JSONField(help_text=_("Environment option ids"), allow_null=True)
-    desc_by_lang = serializers.JSONField(
+    group_ids = CustomJSONField(help_text=_("Environment group list."), allow_null=True)
+    option_ids = CustomJSONField(help_text=_("Environment option ids"), allow_null=True)
+    desc_by_lang = CustomJSONField(
         help_text=_("Environment description by language."), allow_null=True
     )
-    name_by_lang = serializers.JSONField(
-        help_text=_("Environment name by language."), allow_null=True
-    )
+    name_by_lang = CustomJSONField(help_text=_("Environment name by language."), allow_null=True)
     digest = serializers.CharField(help_text=_("Environment digest."))
 
     class Meta:
@@ -139,7 +136,7 @@ class PackageLangpacksSerializer(NoArtifactContentSerializer):
     PackageLangpacks serializer.
     """
 
-    matches = serializers.JSONField(help_text=_("Langpacks matches."), allow_null=True)
+    matches = CustomJSONField(help_text=_("Langpacks matches."), allow_null=True)
     digest = serializers.CharField(help_text=_("Langpacks digest."), allow_null=True)
 
     class Meta:

--- a/pulp_rpm/app/serializers/modulemd.py
+++ b/pulp_rpm/app/serializers/modulemd.py
@@ -3,6 +3,7 @@ from gettext import gettext as _
 
 from pulpcore.plugin.serializers import DetailRelatedField, NoArtifactContentSerializer
 from rest_framework import serializers
+from pulp_rpm.app.fields import CustomJSONField
 
 from pulp_rpm.app.models import Modulemd, ModulemdDefaults, ModulemdObsolete, Package
 
@@ -31,8 +32,8 @@ class ModulemdSerializer(NoArtifactContentSerializer):
     arch = serializers.CharField(
         help_text=_("Modulemd architecture."),
     )
-    artifacts = serializers.JSONField(help_text=_("Modulemd artifacts."), allow_null=True)
-    dependencies = serializers.JSONField(help_text=_("Modulemd dependencies."), allow_null=True)
+    artifacts = CustomJSONField(help_text=_("Modulemd artifacts."), allow_null=True)
+    dependencies = CustomJSONField(help_text=_("Modulemd dependencies."), allow_null=True)
     # TODO: The performance of this is not great, there's a noticable difference in response
     # time before/after. Since this will only return Package content hrefs, we might benefit
     # from creating a specialized version of this Field that can skip some of the work.
@@ -45,7 +46,7 @@ class ModulemdSerializer(NoArtifactContentSerializer):
         view_name="content-rpm/packages-detail",
         many=True,
     )
-    profiles = serializers.JSONField(help_text=_("Modulemd profiles."), allow_null=True)
+    profiles = CustomJSONField(help_text=_("Modulemd profiles."), allow_null=True)
     snippet = serializers.CharField(help_text=_("Modulemd snippet"), write_only=True)
 
     def create(self, validated_data):
@@ -87,7 +88,7 @@ class ModulemdDefaultsSerializer(NoArtifactContentSerializer):
 
     module = serializers.CharField(help_text=_("Modulemd name."))
     stream = serializers.CharField(help_text=_("Modulemd default stream."))
-    profiles = serializers.JSONField(help_text=_("Default profiles for modulemd streams."))
+    profiles = CustomJSONField(help_text=_("Default profiles for modulemd streams."))
     snippet = serializers.CharField(help_text=_("Modulemd default snippet"), write_only=True)
 
     def create(self, validated_data):

--- a/pulp_rpm/app/serializers/package.py
+++ b/pulp_rpm/app/serializers/package.py
@@ -11,6 +11,7 @@ from pulpcore.plugin.serializers import (
     SingleArtifactContentUploadSerializer,
 )
 from pulpcore.plugin.util import get_domain_pk
+from pulp_rpm.app.fields import CustomJSONField
 
 from pulp_rpm.app.models import Package
 from pulp_rpm.app.shared_utils import read_crpackage_from_artifact, format_nvra
@@ -80,62 +81,62 @@ class PackageSerializer(SingleArtifactContentUploadSerializer, ContentChecksumSe
         read_only=True,
     )
 
-    changelogs = serializers.JSONField(
+    changelogs = CustomJSONField(
         help_text=_("Changelogs that package contains"),
         default="[]",
         required=False,
         read_only=True,
     )
-    files = serializers.JSONField(
+    files = CustomJSONField(
         help_text=_("Files that package contains"),
         default="[]",
         required=False,
         read_only=True,
     )
 
-    requires = serializers.JSONField(
+    requires = CustomJSONField(
         help_text=_("Capabilities the package requires"),
         default="[]",
         required=False,
         read_only=True,
     )
-    provides = serializers.JSONField(
+    provides = CustomJSONField(
         help_text=_("Capabilities the package provides"),
         default="[]",
         required=False,
         read_only=True,
     )
-    conflicts = serializers.JSONField(
+    conflicts = CustomJSONField(
         help_text=_("Capabilities the package conflicts"),
         default="[]",
         required=False,
         read_only=True,
     )
-    obsoletes = serializers.JSONField(
+    obsoletes = CustomJSONField(
         help_text=_("Capabilities the package obsoletes"),
         default="[]",
         required=False,
         read_only=True,
     )
-    suggests = serializers.JSONField(
+    suggests = CustomJSONField(
         help_text=_("Capabilities the package suggests"),
         default="[]",
         required=False,
         read_only=True,
     )
-    enhances = serializers.JSONField(
+    enhances = CustomJSONField(
         help_text=_("Capabilities the package enhances"),
         default="[]",
         required=False,
         read_only=True,
     )
-    recommends = serializers.JSONField(
+    recommends = CustomJSONField(
         help_text=_("Capabilities the package recommends"),
         default="[]",
         required=False,
         read_only=True,
     )
-    supplements = serializers.JSONField(
+    supplements = CustomJSONField(
         help_text=_("Capabilities the package supplements"),
         default="[]",
         required=False,

--- a/pulp_rpm/app/serializers/repository.py
+++ b/pulp_rpm/app/serializers/repository.py
@@ -16,6 +16,7 @@ from pulpcore.plugin.serializers import (
 )
 from pulpcore.plugin.util import get_domain
 from rest_framework import serializers
+from pulp_rpm.app.fields import CustomJSONField
 
 from pulp_rpm.app.constants import (
     ALLOWED_CHECKSUM_ERROR_MSG,
@@ -114,7 +115,7 @@ class RpmRepositorySerializer(RepositorySerializer):
         ),
         read_only=True,
     )
-    repo_config = serializers.JSONField(
+    repo_config = CustomJSONField(
         required=False,
         help_text=_("A JSON document describing config.repo file"),
     )
@@ -375,7 +376,7 @@ class RpmPublicationSerializer(PublicationSerializer):
         ),
         read_only=True,
     )
-    repo_config = serializers.JSONField(
+    repo_config = CustomJSONField(
         required=False,
         help_text=_("A JSON document describing config.repo file"),
     )
@@ -514,7 +515,7 @@ class CopySerializer(ValidateFieldsMixin, serializers.Serializer):
     A serializer for Content Copy API.
     """
 
-    config = serializers.JSONField(
+    config = CustomJSONField(
         help_text=_("A JSON document describing sources, destinations, and content to be copied"),
     )
 


### PR DESCRIPTION
The JSONField was yielding an empty type on the schema, which broke bindings generation.

This replaces drf serializers.JSONField with a custom one that is an OpenApi 'object' type.

Closes: #3639
(cherry picked from commit 2e0c2933675c0ce41d8ac5c801f8d0dbc54349d8)