### PR TITLE
[3.19] Add highter test-timeout to sync-test w/ amazon mirror

### DIFF
--- a/pulp_rpm/tests/functional/api/test_crud_content_unit.py
+++ b/pulp_rpm/tests/functional/api/test_crud_content_unit.py
@@ -173,9 +173,10 @@ class ContentUnitRemoveTestCase(PulpTestCase):
         repo_content = get_content(repo.to_dict())
         base_addr = self.cfg.get_host_settings()[0]["url"]
 
+        basic_auth = requests.auth.HTTPBasicAuth("admin", "password")
         for content_type in repo_content.keys():
             response = requests.delete(
-                urljoin(base_addr, repo_content[content_type][0]["pulp_href"])
+                urljoin(base_addr, repo_content[content_type][0]["pulp_href"]), auth=basic_auth
             )
             self.assertEqual(response.status_code, 405)
 

--- a/pulp_rpm/tests/functional/api/test_sync.py
+++ b/pulp_rpm/tests/functional/api/test_sync.py
@@ -751,6 +751,7 @@ def test_one_nevra_two_locations_and_checksums(init_and_sync):
     pass
 
 
+@pytest.mark.timeout(3600)
 @pytest.mark.parallel
 def test_requires_urlencoded_paths(init_and_sync):
     """Sync a repository known to FAIL when an RPM has non-urlencoded characters in its path.


### PR DESCRIPTION
The pytest-timeout plugin was introduced to catch hanging tests, but the global timeout value is too low for the "test_requires_urlencoded_paths", which uses an amazon mirror (see [here](https://github.com/pulp/pulp_rpm/actions/runs/11655593637/job/32450523943)).

Edit: also added backport fix we had for 3.18 where we would do a request without auth, getting a 403 instead of 405 (bc957d1c)

Bakported from: 500793f6