### PR TITLE
Fix regression on error-msg matching on functests

### DIFF
--- a/pulp_rpm/tests/functional/api/test_domains.py
+++ b/pulp_rpm/tests/functional/api/test_domains.py
@@ -161,7 +161,7 @@ def test_object_creation(
     assert e.value.status == 400
     # What key should this error be under? non-field-errors seems wrong
     assert json.loads(e.value.body) == {
-        "non_field_errors": [f"Objects must all be apart of the {domain_name} domain."]
+        "non_field_errors": [f"Objects must all be a part of the {domain_name} domain."]
     }
 
     with pytest.raises(ApiException) as e:
@@ -169,7 +169,7 @@ def test_object_creation(
         rpm_repository_api.sync(repo.pulp_href, sync_body)
     assert e.value.status == 400
     assert json.loads(e.value.body) == {
-        "non_field_errors": [f"Objects must all be apart of the {domain_name} domain."]
+        "non_field_errors": [f"Objects must all be a part of the {domain_name} domain."]
     }
 
 


### PR DESCRIPTION
The error message comes from pulpcore and contained a typo. When it was fixed [0], our test failed to match.

Ideally we would want to have Error Codes, but at this point it would be too costly to implement that.

[0] https://github.com/pulp/pulpcore/pull/5935