### PR TITLE
Remove docs/conf.py from bumpversion config file

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -17,5 +17,3 @@ values =
 [bumpversion:file:./pulp_rpm/app/__init__.py]
 
 [bumpversion:file:./setup.py]
-
-[bumpversion:file:./docs/conf.py]


### PR DESCRIPTION
We dont use sphinx config anymore