### PR TITLE
[PULP-276] Add support for prns

### DIFF
--- a/CHANGES/3853.bugfix
+++ b/CHANGES/3853.bugfix
@@ -1,0 +1,1 @@
+Extended PRN support to Advanced Copy API and DistributionTree.

--- a/pulp_rpm/app/serializers/distribution.py
+++ b/pulp_rpm/app/serializers/distribution.py
@@ -150,6 +150,7 @@ class DistributionTreeSerializer(MultipleArtifactContentSerializer):
         model = DistributionTree
         fields = (
             "pulp_href",
+            "prn",
             "header_version",
             "release_name",
             "release_short",

--- a/pulp_rpm/tests/functional/api/test_prn.py
+++ b/pulp_rpm/tests/functional/api/test_prn.py
@@ -1,12 +1,5 @@
 import pytest
-import requests
 
-
-
-# @pytest.fixture(scope="session")
-# def pulp_openapi_schema_rpm(pulp_api_v3_url):
-#     COMPONENT="rpm"
-#     return requests.get(f"{pulp_api_v3_url}docs/api.json?bindings&component={COMPONENT}").json()
 
 @pytest.mark.parallel
 def test_prn_schema(pulp_openapi_schema):

--- a/pulp_rpm/tests/functional/api/test_prn.py
+++ b/pulp_rpm/tests/functional/api/test_prn.py
@@ -1,0 +1,24 @@
+import pytest
+import requests
+
+
+
+# @pytest.fixture(scope="session")
+# def pulp_openapi_schema_rpm(pulp_api_v3_url):
+#     COMPONENT="rpm"
+#     return requests.get(f"{pulp_api_v3_url}docs/api.json?bindings&component={COMPONENT}").json()
+
+@pytest.mark.parallel
+def test_prn_schema(pulp_openapi_schema):
+    """Test that PRN is a part of every serializer with a pulp_href."""
+    failed = []
+    for name, schema in pulp_openapi_schema["components"]["schemas"].items():
+        if name.endswith("Response"):
+            if "pulp_href" in schema["properties"]:
+                if "prn" in schema["properties"]:
+                    prn_schema = schema["properties"]["prn"]
+                    if prn_schema["type"] == "string" and prn_schema["readOnly"]:
+                        continue
+                failed.append(name)
+
+    assert len(failed) == 0

--- a/pulp_rpm/tests/functional/api/test_sync.py
+++ b/pulp_rpm/tests/functional/api/test_sync.py
@@ -971,6 +971,7 @@ def test_treeinfo_metadata(init_and_sync, rpm_content_distribution_trees_api):
     distribution_tree = distribution_tree.to_dict()
     # delete pulp-specific metadata
     distribution_tree.pop("pulp_href")
+    distribution_tree.pop("prn")
 
     # sort kickstart metadata so that we can compare the dicts properly
     for d in [distribution_tree, RPM_KICKSTART_DATA]:


### PR DESCRIPTION
Notes:

* The copy API used to check if objects belonged to the current domain. For PRN references, we'll have to do it in the task context to avoid response timeouts.