### PR TITLE
Handle chunked uploads when signing rpms

### DIFF
--- a/CHANGES/3927.bugfix
+++ b/CHANGES/3927.bugfix
@@ -1,0 +1,1 @@
+Fixed RPM signing with chunked uploads

--- a/pulp_rpm/app/serializers/package.py
+++ b/pulp_rpm/app/serializers/package.py
@@ -344,9 +344,9 @@ class PackageSerializer(SingleArtifactContentUploadSerializer, ContentChecksumSe
                 )
             )
 
-        if not validated_data.get("file"):
+        if not validated_data.get("file") and not validated_data.get("upload"):
             raise serializers.ValidationError(
-                _("To sign a package on upload, a file must be provided.")
+                _("To sign a package on upload, a file or upload must be provided.")
             )
 
         return validated_data

--- a/pulp_rpm/app/tasks/signing.py
+++ b/pulp_rpm/app/tasks/signing.py
@@ -1,10 +1,24 @@
 from tempfile import NamedTemporaryFile
 
-from pulpcore.plugin.models import Artifact, CreatedResource, PulpTemporaryFile
+from pulpcore.plugin.models import Artifact, CreatedResource, PulpTemporaryFile, Upload, UploadChunk
 from pulpcore.plugin.tasking import general_create
 from pulpcore.plugin.util import get_url
 
 from pulp_rpm.app.models.content import RpmPackageSigningService
+
+
+def _save_file(fileobj, final_package):
+    with fileobj.file.open() as fd:
+        final_package.write(fd.read())
+    final_package.flush()
+
+
+def _save_upload(uploadobj, final_package):
+    chunks = UploadChunk.objects.filter(upload=uploadobj).order_by("offset")
+    for chunk in chunks:
+        final_package.write(chunk.file.read())
+        chunk.file.close()
+    final_package.flush()
 
 
 def sign_and_create(
@@ -21,11 +35,13 @@ def sign_and_create(
 
     # Get unsigned package file and sign it
     package_signing_service = RpmPackageSigningService.objects.get(pk=signing_service_pk)
-    uploaded_package = PulpTemporaryFile.objects.get(pk=temporary_file_pk)
     with NamedTemporaryFile(mode="wb", dir=".", delete=False) as final_package:
-        with uploaded_package.file.open() as fd:
-            final_package.write(fd.read())
-            final_package.flush()
+        try:
+            uploaded_package = PulpTemporaryFile.objects.get(pk=temporary_file_pk)
+            _save_file(uploaded_package, final_package)
+        except PulpTemporaryFile.DoesNotExist:
+            uploaded_package = Upload.objects.get(pk=temporary_file_pk)
+            _save_upload(uploaded_package, final_package)
 
         package_signing_service.sign(final_package.name, pubkey_fingerprint=signing_fingerprint)
         artifact = Artifact.init_and_validate(final_package.name)
@@ -39,4 +55,8 @@ def sign_and_create(
     # The Package serializer validation method have two branches: the signing and non-signing.
     # Here, the package is already signed, so we need to update the context for a proper validation.
     context["sign_package"] = False
+    # The request data is immutable when there's an upload, so we can't delete the upload out of the
+    # request data like we do for a file.  Instead, we'll delete it here.
+    if "upload" in data:
+        del data["upload"]
     general_create(app_label, serializer_name, data=data, context=context, *args, **kwargs)

--- a/pulp_rpm/app/viewsets/package.py
+++ b/pulp_rpm/app/viewsets/package.py
@@ -93,15 +93,18 @@ class PackageViewSet(SingleArtifactContentUploadViewSet):
             return super().create(request)
 
         # signing case
-        request.data.pop("file")
         validated_data = serializer.validated_data
-        temp_uploaded_file = validated_data["file"]
         signing_service_pk = validated_data["repository"].package_signing_service.pk
         signing_fingerprint = validated_data["repository"].package_signing_fingerprint
+        if "file" in validated_data:
+            request.data.pop("file")
+            temp_uploaded_file = validated_data["file"]
+            pulp_temp_file = PulpTemporaryFile(file=temp_uploaded_file.temporary_file_path())
+            pulp_temp_file.save()
+        else:
+            pulp_temp_file = validated_data["upload"]
 
         # dispatch signing task
-        pulp_temp_file = PulpTemporaryFile(file=temp_uploaded_file.temporary_file_path())
-        pulp_temp_file.save()
         task_args = {
             "app_label": self.queryset.model._meta.app_label,
             "serializer_name": serializer.__class__.__name__,

--- a/pulp_rpm/tests/functional/api/test_package_signing.py
+++ b/pulp_rpm/tests/functional/api/test_package_signing.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass
+import hashlib
 from pathlib import Path
+import uuid
 
 import pytest
 import requests
@@ -96,6 +98,130 @@ def test_sign_package_on_upload(
         )
         upload_response = rpm_package_api.create(
             file=str(file_to_upload.absolute()),
+            repository=repository.pulp_href,
+        )
+        package_href = monitor_task(upload_response.task).created_resources[2]
+        pkg_location_href = rpm_package_api.read(package_href).location_href
+
+        # Verify that the final served package is signed
+        publication = rpm_publication_factory(repository=repository.pulp_href)
+        distribution = rpm_distribution_factory(publication=publication.pulp_href)
+        downloaded_package = tmp_path / "package.rpm"
+        downloaded_package.write_bytes(
+            download_content_unit(distribution.base_path, get_package_repo_path(pkg_location_href))
+        )
+        assert rpm_tool.verify_signature(downloaded_package)
+
+
+@pytest.fixture
+def pulpcore_chunked_file_factory(tmp_path):
+    """Returns a function to create chunks from file to be uploaded."""
+
+    def _create_chunks(upload_path, chunk_size=512):
+        """Chunks file to be uploaded."""
+        chunks = {"chunks": []}
+        hasher = hashlib.new("sha256")
+        start = 0
+        with open(upload_path, "rb") as f:
+            data = f.read()
+        chunks["size"] = len(data)
+
+        while start < len(data):
+            content = data[start : start + chunk_size]
+            chunk_file = tmp_path / str(uuid.uuid4())
+            hasher.update(content)
+            chunk_file.write_bytes(content)
+            content_sha = hashlib.sha256(content).hexdigest()
+            end = start + len(content) - 1
+            chunks["chunks"].append(
+                (str(chunk_file), f"bytes {start}-{end}/{chunks['size']}", content_sha)
+            )
+            start += len(content)
+        chunks["digest"] = hasher.hexdigest()
+        return chunks
+
+    return _create_chunks
+
+
+@pytest.fixture
+def pulpcore_upload_chunks(
+    pulpcore_bindings,
+    gen_object_with_cleanup,
+    monitor_task,
+):
+    """Upload file in chunks."""
+
+    def _upload_chunks(size, chunks, sha256, include_chunk_sha256=False):
+        """
+        Chunks is a list of tuples in the form of (chunk_filename, "bytes-ranges", optional_sha256).
+        """
+        upload = gen_object_with_cleanup(pulpcore_bindings.UploadsApi, {"size": size})
+
+        for data in chunks:
+            kwargs = {"file": data[0], "content_range": data[1], "upload_href": upload.pulp_href}
+            if include_chunk_sha256:
+                if len(data) != 3:
+                    raise Exception(f"Chunk didn't include its sha256: {data}")
+                kwargs["sha256"] = data[2]
+
+            pulpcore_bindings.UploadsApi.update(**kwargs)
+
+        return upload
+
+    yield _upload_chunks
+
+
+@pytest.mark.parallel
+def test_sign_chunked_package_on_upload(
+    tmp_path,
+    pulpcore_bindings,
+    monitor_task,
+    gen_object_with_cleanup,
+    download_content_unit,
+    signing_gpg_extra,
+    rpm_package_signing_service,
+    rpm_package_api,
+    rpm_repository_factory,
+    rpm_publication_factory,
+    rpm_package_factory,
+    rpm_distribution_factory,
+    pulpcore_upload_chunks,
+    pulpcore_chunked_file_factory,
+):
+    """
+    Sign an Rpm Package with the Package Upload endpoint.
+
+    This ensures different
+    """
+    # Setup RPM tool and package to upload
+    gpg_a, gpg_b = signing_gpg_extra
+    fingerprint_set = set([gpg_a.fingerprint, gpg_b.fingerprint])
+    assert len(fingerprint_set) == 2
+
+    rpm_tool = RpmTool(tmp_path)
+    rpm_tool.import_pubkey_string(gpg_a.pubkey)
+    rpm_tool.import_pubkey_string(gpg_b.pubkey)
+
+    file_to_upload = tmp_path / RPM_PACKAGE_FILENAME
+    file_to_upload.write_bytes(requests.get(RPM_UNSIGNED_URL).content)
+    with pytest.raises(InvalidSignatureError, match="The package is not signed: .*"):
+        rpm_tool.verify_signature(file_to_upload)
+
+    # Upload Package to Repository
+    # The same file is uploaded, but signed with different keys each time
+    for fingerprint in fingerprint_set:
+        repository = rpm_repository_factory(
+            package_signing_service=rpm_package_signing_service.pulp_href,
+            package_signing_fingerprint=fingerprint,
+        )
+        file_chunks_data = pulpcore_chunked_file_factory(file_to_upload)
+        size = file_chunks_data["size"]
+        chunks = file_chunks_data["chunks"]
+        sha256 = file_chunks_data["digest"]
+
+        upload = pulpcore_upload_chunks(size, chunks, sha256, include_chunk_sha256=True)
+        upload_response = rpm_package_api.create(
+            upload=upload.pulp_href,
             repository=repository.pulp_href,
         )
         package_href = monitor_task(upload_response.task).created_resources[2]


### PR DESCRIPTION
Currently chunked uploads are rejected when signing rpms with the following message: "To sign a package on upload, a file must be provided."  This is because the pulp cli sends the ID for the upload rather than a file.

To fix this, I've extended the serializer and viewset to handle both a file and an upload, and have updated the signing task to properly deal with an upload.