### PR TITLE
Remove gettext from one small warning message

### DIFF
--- a/pulp_rpm/app/tasks/synchronizing.py
+++ b/pulp_rpm/app/tasks/synchronizing.py
@@ -1212,7 +1212,7 @@ class RpmFirstStage(Stage):
             nonlocal latest_build_time_by_nevra
             nonlocal skipped_packages
 
-            WARN_MSG = _(
+            WARN_MSG = (
                 "The repository metadata being synced into Pulp is erroneous in a way that "
                 "makes it ambiguous (duplicate {}). Yum, DNF and Pulp try to handle these "
                 "problems, but unexpected things may happen.\n\n"


### PR DESCRIPTION
Because of how many times this is called (once per package), this ends up having an unreasonable performance impact / memory leaks compared to its value.

We don't really want gettext in errors/warnings much anyway, it makes things less searchable.