### PR TITLE
[3.29] Significantly improve publish performance

### DIFF
--- a/CHANGES/+publish-perf.bugfix
+++ b/CHANGES/+publish-perf.bugfix
@@ -1,0 +1,1 @@
+Significantly improved publish performance (more than double in some cases) by fixing some Django queries.

--- a/pulp_rpm/app/models/package.py
+++ b/pulp_rpm/app/models/package.py
@@ -18,6 +18,9 @@ from pulp_rpm.app.constants import (
 )
 from pulp_rpm.app.shared_utils import format_nevra, format_nevra_short, format_nvra
 
+# avoid calling into dynaconf many times
+ALLOWED_CONTENT_CHECKSUMS = settings.ALLOWED_CONTENT_CHECKSUMS
+KEEP_CHANGELOG_LIMIT = settings.KEEP_CHANGELOG_LIMIT
 
 log = getLogger(__name__)
 
@@ -317,9 +320,9 @@ class Package(Content):
         # make sure the changelogs are sorted by date
         changelogs.sort(key=lambda t: t[1])
 
-        if settings.KEEP_CHANGELOG_LIMIT is not None:
+        if KEEP_CHANGELOG_LIMIT is not None:
             # always keep at least one changelog, even if the limit is set to 0
-            changelog_limit = settings.KEEP_CHANGELOG_LIMIT or 1
+            changelog_limit = KEEP_CHANGELOG_LIMIT or 1
             # changelogs are listed in chronological order, grab the last N changelogs from the list
             changelogs = changelogs[-changelog_limit:]
         files = getattr(package, CR_PACKAGE_ATTRS.FILES, [])

--- a/pulp_rpm/app/serializers/repository.py
+++ b/pulp_rpm/app/serializers/repository.py
@@ -45,6 +45,9 @@ from pulp_rpm.app.schema import COPY_CONFIG_SCHEMA
 from urllib.parse import urlparse
 from textwrap import dedent
 
+# avoid calling into dynaconf many times
+ALLOWED_CONTENT_CHECKSUMS = settings.ALLOWED_CONTENT_CHECKSUMS
+
 
 class RpmRepositorySerializer(RepositorySerializer):
     """
@@ -178,7 +181,7 @@ class RpmRepositorySerializer(RepositorySerializer):
         """Validate data."""
         for field in ("checksum_type", "metadata_checksum_type", "package_checksum_type"):
             if field in data and data[field]:
-                if data[field] not in settings.ALLOWED_CONTENT_CHECKSUMS:
+                if data[field] not in ALLOWED_CONTENT_CHECKSUMS:
                     raise serializers.ValidationError({field: _(ALLOWED_CHECKSUM_ERROR_MSG)})
 
                 if data[field] not in ALLOWED_PUBLISH_CHECKSUMS:
@@ -448,7 +451,7 @@ class RpmPublicationSerializer(PublicationSerializer):
         """Validate data."""
         for field in ("checksum_type", "metadata_checksum_type", "package_checksum_type"):
             if field in data and data[field]:
-                if data[field] not in settings.ALLOWED_CONTENT_CHECKSUMS:
+                if data[field] not in ALLOWED_CONTENT_CHECKSUMS:
                     raise serializers.ValidationError({field: _(ALLOWED_CHECKSUM_ERROR_MSG)})
 
                 if data[field] not in ALLOWED_PUBLISH_CHECKSUMS:

--- a/pulp_rpm/app/tasks/publishing.py
+++ b/pulp_rpm/app/tasks/publishing.py
@@ -43,10 +43,15 @@ from pulp_rpm.app.models import (
     RpmPublication,
     UpdateRecord,
 )
+from pulp_rpm.app.shared_utils import format_nevra
 
 log = logging.getLogger(__name__)
 
 REPODATA_PATH = "repodata"
+
+# lift dynaconf lookups outside of loops
+ALLOWED_CONTENT_CHECKSUMS = settings.ALLOWED_CONTENT_CHECKSUMS
+RPM_METADATA_USE_REPO_PACKAGE_TIME = settings.RPM_METADATA_USE_REPO_PACKAGE_TIME
 
 
 class PublicationData:
@@ -455,7 +460,7 @@ def generate_repo_metadata(
         cwd = os.path.join(cwd, sub_folder)
         repodata_path = os.path.join(sub_folder, repodata_path)
 
-    if package_checksum_type and package_checksum_type not in settings.ALLOWED_CONTENT_CHECKSUMS:
+    if package_checksum_type and package_checksum_type not in ALLOWED_CONTENT_CHECKSUMS:
         raise ValueError(
             "Repository contains disallowed package checksum type '{}', "
             "thus can't be published. {}".format(package_checksum_type, ALLOWED_CHECKSUM_ERROR_MSG)
@@ -495,7 +500,7 @@ def generate_repo_metadata(
             pkgid = ca.get(artifact_checksum, None)
 
         if not package_checksum_type or not pkgid:
-            if ca["content__rpm_package__checksum_type"] not in settings.ALLOWED_CONTENT_CHECKSUMS:
+            if ca["content__rpm_package__checksum_type"] not in ALLOWED_CONTENT_CHECKSUMS:
                 raise ValueError(
                     "Package with pkgId {} as content unit {} contains forbidden checksum type "
                     "'{}', thus can't be published. {}".format(
@@ -515,10 +520,17 @@ def generate_repo_metadata(
     pkg_pks_to_ignore = set()
     latest_build_time_by_nevra = defaultdict(list)
     packages = Package.objects.filter(pk__in=content)
-    for pkg in packages.only(
-        "pk", "name", "epoch", "version", "release", "arch", "time_build"
+    for pkg in packages.values(
+        "pk",
+        "name",
+        "epoch",
+        "version",
+        "release",
+        "arch",
+        "time_build",
     ).iterator():
-        latest_build_time_by_nevra[pkg.nevra].append((pkg.time_build, pkg.pk))
+        nevra = format_nevra(pkg["name"], pkg["epoch"], pkg["version"], pkg["release"], pkg["arch"])
+        latest_build_time_by_nevra[nevra].append((pkg["time_build"], pkg["pk"]))
     for nevra, pkg_data in latest_build_time_by_nevra.items():
         # sort the packages by when they were built
         if len(pkg_data) > 1:
@@ -533,7 +545,7 @@ def generate_repo_metadata(
 
     total_packages = packages.count() - len(pkg_pks_to_ignore)
 
-    if settings.RPM_METADATA_USE_REPO_PACKAGE_TIME:
+    if RPM_METADATA_USE_REPO_PACKAGE_TIME:
         # gather the times the packages were added to the repo
         repo_content = (
             RepositoryContent.objects.filter(
@@ -584,7 +596,7 @@ def generate_repo_metadata(
 
             pkg.location_href = pkg_path
 
-            if settings.RPM_METADATA_USE_REPO_PACKAGE_TIME:
+            if RPM_METADATA_USE_REPO_PACKAGE_TIME:
                 pkg.time_file = repo_pkg_times[package.pk]
 
             writer.add_pkg(pkg)

--- a/pulp_rpm/app/tasks/synchronizing.py
+++ b/pulp_rpm/app/tasks/synchronizing.py
@@ -110,6 +110,8 @@ MIRROR_INCOMPATIBLE_REPO_ERR_MSG = (
     "This repository uses features which are incompatible with 'mirror' sync. "
     "Please sync without mirroring enabled."
 )
+# lift dynaconf lookups outside of loops
+ALLOWED_CONTENT_CHECKSUMS = settings.ALLOWED_CONTENT_CHECKSUMS
 
 
 def store_metadata_for_mirroring(repo, md_path, relative_path):
@@ -848,7 +850,7 @@ class RpmFirstStage(Stage):
                                     filtered_checksums = {
                                         digest: value
                                         for digest, value in data["checksums"].items()
-                                        if digest in settings.ALLOWED_CONTENT_CHECKSUMS
+                                        if digest in ALLOWED_CONTENT_CHECKSUMS
                                     }
                                     downloader = self.remote.get_downloader(
                                         url=urlpath_sanitize(self.remote_url, data["file"]),


### PR DESCRIPTION
.only() is a tricky beast. MasterModel __init__() was using the pulp_type field, therefore failing to include it led to deferred attribute lookups.

Dynaconf caching is currently unreliable, so we lift usages of settings values out of any important loops and assign them to constants.

(cherry picked from commit eae35737fc318757792fbe20bcc355b9878e8252)