### PR TITLE
[3.26] Significantly improve publish performance

### DIFF
--- a/CHANGES/+publish-perf.bugfix
+++ b/CHANGES/+publish-perf.bugfix
@@ -1,0 +1,1 @@
+Significantly improved publish performance (more than double in some cases) by fixing some Django queries.

--- a/pulp_rpm/app/models/package.py
+++ b/pulp_rpm/app/models/package.py
@@ -18,6 +18,9 @@ from pulp_rpm.app.constants import (
 )
 from pulp_rpm.app.shared_utils import format_nevra, format_nevra_short, format_nvra
 
+# avoid calling into dynaconf many times
+ALLOWED_CONTENT_CHECKSUMS = settings.ALLOWED_CONTENT_CHECKSUMS
+KEEP_CHANGELOG_LIMIT = settings.KEEP_CHANGELOG_LIMIT
 
 log = getLogger(__name__)
 
@@ -317,9 +320,9 @@ class Package(Content):
         # make sure the changelogs are sorted by date
         changelogs.sort(key=lambda t: t[1])
 
-        if settings.KEEP_CHANGELOG_LIMIT is not None:
+        if KEEP_CHANGELOG_LIMIT is not None:
             # always keep at least one changelog, even if the limit is set to 0
-            changelog_limit = settings.KEEP_CHANGELOG_LIMIT or 1
+            changelog_limit = KEEP_CHANGELOG_LIMIT or 1
             # changelogs are listed in chronological order, grab the last N changelogs from the list
             changelogs = changelogs[-changelog_limit:]
         files = getattr(package, CR_PACKAGE_ATTRS.FILES, [])

--- a/pulp_rpm/app/serializers/repository.py
+++ b/pulp_rpm/app/serializers/repository.py
@@ -31,6 +31,9 @@ from pulp_rpm.app.models import RpmDistribution, RpmPublication, RpmRemote, RpmR
 from pulp_rpm.app.schema import COPY_CONFIG_SCHEMA
 from urllib.parse import urlparse
 
+# avoid calling into dynaconf many times
+ALLOWED_CONTENT_CHECKSUMS = settings.ALLOWED_CONTENT_CHECKSUMS
+
 
 class RpmRepositorySerializer(RepositorySerializer):
     """
@@ -124,7 +127,7 @@ class RpmRepositorySerializer(RepositorySerializer):
         """Validate data."""
         for field in ("checksum_type", "metadata_checksum_type", "package_checksum_type"):
             if field in data and data[field]:
-                if data[field] not in settings.ALLOWED_CONTENT_CHECKSUMS:
+                if data[field] not in ALLOWED_CONTENT_CHECKSUMS:
                     raise serializers.ValidationError({field: _(ALLOWED_CHECKSUM_ERROR_MSG)})
 
                 if data[field] not in ALLOWED_PUBLISH_CHECKSUMS:
@@ -385,7 +388,7 @@ class RpmPublicationSerializer(PublicationSerializer):
         """Validate data."""
         for field in ("checksum_type", "metadata_checksum_type", "package_checksum_type"):
             if field in data and data[field]:
-                if data[field] not in settings.ALLOWED_CONTENT_CHECKSUMS:
+                if data[field] not in ALLOWED_CONTENT_CHECKSUMS:
                     raise serializers.ValidationError({field: _(ALLOWED_CHECKSUM_ERROR_MSG)})
 
                 if data[field] not in ALLOWED_PUBLISH_CHECKSUMS:

--- a/pulp_rpm/app/tasks/synchronizing.py
+++ b/pulp_rpm/app/tasks/synchronizing.py
@@ -111,6 +111,8 @@ MIRROR_INCOMPATIBLE_REPO_ERR_MSG = (
     "This repository uses features which are incompatible with 'mirror' sync. "
     "Please sync without mirroring enabled."
 )
+# lift dynaconf lookups outside of loops
+ALLOWED_CONTENT_CHECKSUMS = settings.ALLOWED_CONTENT_CHECKSUMS
 
 
 def store_metadata_for_mirroring(repo, md_path, relative_path):
@@ -851,7 +853,7 @@ class RpmFirstStage(Stage):
                                     filtered_checksums = {
                                         digest: value
                                         for digest, value in data["checksums"].items()
-                                        if digest in settings.ALLOWED_CONTENT_CHECKSUMS
+                                        if digest in ALLOWED_CONTENT_CHECKSUMS
                                     }
                                     downloader = self.remote.get_downloader(
                                         url=urlpath_sanitize(self.remote_url, data["file"]),


### PR DESCRIPTION
.only() is a tricky beast. MasterModel __init__() was using the pulp_type field, therefore failing to include it led to deferred attribute lookups.

Dynaconf caching is currently unreliable, so we lift usages of settings values out of any important loops and assign them to constants.

(cherry picked from commit 7ea323918e510cd4f1716890c7fab44a2b4cff3c)