### PR TITLE
Remove deprecated TaskGroup.finish calls

### DIFF
--- a/CHANGES/3985.misc
+++ b/CHANGES/3985.misc
@@ -1,0 +1,1 @@
+Removed deprecated `TaskGroup.finish` calls.

--- a/pulp_rpm/app/tasks/prune.py
+++ b/pulp_rpm/app/tasks/prune.py
@@ -166,4 +166,3 @@ def prune_packages(
             ),
             task_group=task_group,
         )
-    task_group.finish()

--- a/pulp_rpm/app/viewsets/acs.py
+++ b/pulp_rpm/app/viewsets/acs.py
@@ -171,9 +171,6 @@ class RpmAlternateContentSourceViewSet(AlternateContentSourceViewSet, RolesMixin
                 },
             )
 
-        # Update TaskGroup that all child task are dispatched
-        task_group.finish()
-
         acs.last_refreshed = now()
         acs.save()
 


### PR DESCRIPTION
This calls never worked as intended and removing it shouldn't cause any problem. See:
https://github.com/pulp/pulpcore/commit/e0d999a66b751fa5a88a099207ff2971997a62fe

Closes #3985