### PR TITLE
[PULP-604] Ensure Repository.package_signing_fingerprint doesnt return None

### DIFF
--- a/CHANGES/3995.bugfix
+++ b/CHANGES/3995.bugfix
@@ -1,0 +1,1 @@
+Ensure API responses for `Repository.package_signing_fingerprint` returns an empty string instead of null.

--- a/pulp_rpm/app/serializers/repository.py
+++ b/pulp_rpm/app/serializers/repository.py
@@ -191,6 +191,10 @@ class RpmRepositorySerializer(RepositorySerializer):
             field_data = data.get(field)
             if field_data == "":
                 data[field] = None
+        # The current API field definition expects empty string for nullable values,
+        # but some migration paths can set an empty string to none in the database.
+        if data["package_signing_fingerprint"] is None:
+            data["package_signing_fingerprint"] = ""
         return data
 
     def validate(self, data):


### PR DESCRIPTION
The serializer definition doesn't allow None for this field, but this is not enforced. Because of that, bindings generated from that spec with strict type checking will error if it receives a None.

The field shouldn't ever be set to None in the database, but this is happening in some migration paths.
Unfortunately, I was not able to track down the root cause.

Closes #3995