### PR TITLE
[backport 3.27] Ensure Repository.package_signing_fingerprint doesnt return None

### DIFF
--- a/CHANGES/3995.bugfix
+++ b/CHANGES/3995.bugfix
@@ -1,0 +1,1 @@
+Ensure API responses for `Repository.package_signing_fingerprint` returns an empty string instead of null.


### PR DESCRIPTION
The serializer definition doesn't allow None for this field, but this is not enforced. Because of that, bindings generated from that spec with strict type checking will error if it receives a None.

The field shouldn't ever be set to None in the database, but this is hapenning in some migration paths.
I did not was able to track the root cause.

Closes #3995

(cherry picked from commit 40d7891e8b0e78a7a4b5e2f01613b641c12c672d)