### PR TITLE
Downgrade openapi-spec version to 3.0.1

### DIFF
--- a/CHANGES/4125.bugfix
+++ b/CHANGES/4125.bugfix
@@ -1,0 +1,1 @@
+Downgraded openapi spec version from 3.1 to 3.0 to revert regression in the published Ruby bindings.

--- a/pulp_rpm/app/settings.py
+++ b/pulp_rpm/app/settings.py
@@ -17,3 +17,5 @@ SOLVER_DEBUG_LOGS = True
 RPM_METADATA_USE_REPO_PACKAGE_TIME = False
 NOCACHE_LIST = ["repomd.xml", "repomd.xml.asc", "repomd.xml.key"]
 PRUNE_WORKERS_MAX = 5
+# workaround for: https://github.com/pulp/pulp_rpm/issues/4125
+SPECTACULAR_SETTINGS__OAS_VERSION = "3.0.1"


### PR DESCRIPTION
closes: #4125

This should only matter for rpm branches that uses pulpcore `>=3.85`.

Backports:
- https://github.com/pulp/pulp_rpm/pull/4134