### PR TITLE
[812][Experiment] Use Django 5.2

### DIFF
--- a/.ci/scripts/check_requirements.py
+++ b/.ci/scripts/check_requirements.py
@@ -14,7 +14,7 @@ CHECK_MATRIX = [
     ("pyproject.toml", True, True, True),
     ("requirements.txt", True, True, True),
     ("dev_requirements.txt", False, True, False),
-    ("ci_requirements.txt", False, True, True),
+    # ("ci_requirements.txt", False, True, True),
     ("doc_requirements.txt", False, True, False),
     ("lint_requirements.txt", False, True, True),
     ("unittest_requirements.txt", False, True, True),

--- a/ci_requirements.txt
+++ b/ci_requirements.txt
@@ -1,0 +1,1 @@
+git+https://github.com/pulp/pulpcore@refs/heads/main

--- a/pulp_rpm/app/tasks/prune.py
+++ b/pulp_rpm/app/tasks/prune.py
@@ -1,9 +1,8 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from logging import getLogger, DEBUG
 
 from django.conf import settings
 from django.db.models import F, Subquery
-from django.utils import timezone
 
 from pulpcore.plugin.models import ProgressReport
 from pulpcore.plugin.constants import TASK_STATES

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
 ]
 requires-python = ">=3.11"
 dependencies = [
+    # "Django~=5.2.0",
     "createrepo_c~=1.2.1",
     "django_readonly_field~=1.1.1",
     "jsonschema>=4.6,<5.0",
@@ -70,6 +71,7 @@ ignore = [
     "CONTRIBUTING.rst",
     "dev_requirements.txt",
     "doc_requirements.txt",
+    "ci_requirements.txt",
     "docs/**",
     "staging_docs/**",
     "template_config.yml",


### PR DESCRIPTION
Lets see what breaks.

* `django.utils.timezone.utc` was deprecated in django 4.1 and [removed in django 5.0](https://docs.djangoproject.com/en/5.0/releases/5.0/#features-removed-in-5-0). The recommendation is to use datetime.timezone.utc directly. See [reference](https://docs.djangoproject.com/en/5.2/releases/4.1/#id2).