### PR TITLE
Replace django.utils.timezone.utc by datetime.timezone.utc

### DIFF
--- a/CHANGES/+update-timezone.misc
+++ b/CHANGES/+update-timezone.misc
@@ -1,0 +1,1 @@
+Replaced the deprecated `django.utils.timezone.utc` by `datetime.timzone.utc`.

--- a/pulp_rpm/app/tasks/prune.py
+++ b/pulp_rpm/app/tasks/prune.py
@@ -1,9 +1,8 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from logging import getLogger, DEBUG
 
 from django.conf import settings
 from django.db.models import F, Subquery
-from django.utils import timezone
 
 from pulpcore.plugin.models import ProgressReport
 from pulpcore.plugin.constants import TASK_STATES


### PR DESCRIPTION
Django 4 derpecates and 5 removes django.utils.timezone.utc.
The recommended action is the stdlib directly.

Found about that one [this experiment PR](https://github.com/pulp/pulp_rpm/pull/4145).