### PR TITLE
Fix an import/export bug when domains are enabled.

### DIFF
--- a/pulp_rpm/tests/functional/api/test_pulpimport.py
+++ b/pulp_rpm/tests/functional/api/test_pulpimport.py
@@ -12,16 +12,11 @@ from collections import namedtuple
 
 from pulp_rpm.tests.functional.constants import RPM_KICKSTART_FIXTURE_URL, RPM_UNSIGNED_FIXTURE_URL
 
-from pulpcore.app import settings
-
 from pulpcore.client.pulp_rpm import RpmRepositorySyncURL
 
 NUM_REPOS = 2
 
 ExportFileInfo = namedtuple("ExportFileInfo", "output_file_info")
-
-if settings.DOMAIN_ENABLED:
-    pytest.skip("Domains do not support import.", allow_module_level=True)
 
 
 @pytest.fixture


### PR DESCRIPTION
Also enabled import/export tests when domains are enabled, and made it possible for pulp-rpm import/export to work when django-import-export==4.x is in use.