### PR TITLE
Have RPM package signing use rpm_package location

### DIFF
--- a/CHANGES/4189.feature
+++ b/CHANGES/4189.feature
@@ -1,0 +1,1 @@
+Updated pulp_rpm package signing code to use "rpm_package" location instead of expecting the original file to be signed.

--- a/pulp_rpm/app/models/content.py
+++ b/pulp_rpm/app/models/content.py
@@ -62,11 +62,14 @@ class RpmPackageSigningService(SigningService):
             temp_file = RpmTool.get_empty_rpm(temp_directory_name)
             return_value = self.sign(temp_file, pubkey_fingerprint=self.pubkey_fingerprint)
             try:
-                return_value["rpm_package"]
+                result = Path(return_value["rpm_package"])
             except KeyError:
                 raise PulpException(f"Malformed output from signing script: {return_value}")
+
+            if not result.exists():
+                raise PulpException(f"Signed package not found: {result}")
 
             # verify with rpm tool
             rpm_tool = RpmTool(root=Path(temp_directory_name))
             rpm_tool.import_pubkey_string(self.public_key)
-            rpm_tool.verify_signature(temp_file)
+            rpm_tool.verify_signature(result)


### PR DESCRIPTION
The package signing code in pulp_rpm expects the signing service to return the file path as "rpm_package" but it doesn't look like it uses it. Instead, it expects the original file to be signed. This is sort of at odds with how metadata signing works since it [uses the "signature" value returns by the signing service](https://github.com/pulp/pulpcore/blob/880448474be103bb3fc9aa6b485e1c8fe8608667/pulpcore/app/models/content.py#L920). Even pulp_deb which has files with embedded signatures [does this](https://github.com/pulp/pulp_deb/blob/68ded91edaf729e40d5e37bbf3d3074e809bcfdd/pulp_deb/app/tasks/publishing.py#L567).

I think that pulp_rpm expects users to be using rpmsign which signs the file in place and thus using the original file path location makes sense. But this is not true for us. We hand the rpm file over to a service to be signed, and then the file is returned via an API call and stored at a new location.

Using "rpm_package" instead of expecting the original file to be signed would give users greater flexibility. Users can still update the existing file in place if they choose and just return the original file path as "rpm_package". I also think that using "rpm_package" is more consistent with how metadata signing works as well.

fixes #4189 