### PR TITLE
Fix broken link to pulp_file ACS docs

### DIFF
--- a/docs/user/guides/alternate-content-source.md
+++ b/docs/user/guides/alternate-content-source.md
@@ -6,7 +6,7 @@ the remote content, Alternate Content Sources will allow you to substitute
 this content, allowing for faster data transfer.
 
 *Alternate Content Sources* base is provided by pulpcore.
-You can learn more about its general usage [here](site:pulp_file/docs/admin/guides/02-alternate-content-sources/).
+You can learn more about its general usage [here](site:pulp_file/docs/admin/guides/alternate-content-sources/).
 
 To use an Alternate Content Source you need a `RPMRemote` with path of your ACS.
 


### PR DESCRIPTION
Noticed that a link is broken here: https://pulpproject.org/pulp_rpm/docs/user/guides/alternate-content-source/

The correct link should take us here: https://pulpproject.org/pulp_file/docs/admin/guides/alternate-content-sources/

I did not build local docs to test my source change actually fixes the link, but I believe it should work.