### PR TITLE
[PULP-809] Update shell script to comply with shellcheck

### DIFF
--- a/pulp_rpm/tests/functional/sign-metadata.sh
+++ b/pulp_rpm/tests/functional/sign-metadata.sh
@@ -7,12 +7,12 @@ GPG_KEY_ID="pulp-fixture-signing-key"
 
 # Create a detached signature
 gpg --quiet --batch --homedir ~/.gnupg/ --detach-sign --local-user "${GPG_KEY_ID}" \
-   --armor --output ${SIGNATURE_PATH} ${FILE_PATH}
+   --armor --output "${SIGNATURE_PATH}" "${FILE_PATH}"
 
 # Check the exit status
 STATUS=$?
 if [[ ${STATUS} -eq 0 ]]; then
-   echo {\"file\": \"${FILE_PATH}\", \"signature\": \"${SIGNATURE_PATH}\"}
+   echo "{\"file\": \"${FILE_PATH}\", \"signature\": \"${SIGNATURE_PATH}\"}"
 else
    exit ${STATUS}
 fi


### PR DESCRIPTION
Addressing mainly this:

```bash
/usr/lib/python3.12/site-packages/pulp_rpm/tests/functional/sign-metadata.sh:15:74: warning[[SC1083](https://github.com/koalaman/shellcheck/wiki/SC1083)]: This } is literal. Check expression (missing ;/\n?) or quote it.
#   13|   STATUS=$?
#   14|   if [[ ${STATUS} -eq 0 ]]; then
#   15|->    echo {\"file\": \"${FILE_PATH}\", \"signature\": \"${SIGNATURE_PATH}\"}
#   16|   else
#   17|      exit ${STATUS}
```