### PR TITLE
[PULP-809] Improve yaml.SafeLoader implemenation against desserialization attacks

### DIFF
--- a/CHANGES/+yaml-safe-loading.misc
+++ b/CHANGES/+yaml-safe-loading.misc
@@ -1,0 +1,2 @@
+Improved safety of [#3285 bugfix implementation](https://github.com/pulp/pulp_rpm/issues/3285)
+against CWE-502 (Deserialization of Untrusted Data) attacks.

--- a/pulp_rpm/tests/functional/api/test_sync.py
+++ b/pulp_rpm/tests/functional/api/test_sync.py
@@ -1055,7 +1055,7 @@ def test_modular_metadata(
                 "vuln_report",
             },
         )
-        assert list(diff) == [], list(diff)
+        assert list(diff) == [], (m1["name"], list(diff))
 
     for m1, m2 in zip(module_defaults, RPM_MODULEMD_DEFAULTS_DATA):
         diff = dictdiffer.diff(
@@ -1070,7 +1070,7 @@ def test_modular_metadata(
                 "vuln_report",
             },
         )
-        assert list(diff) == [], list(diff)
+        assert list(diff) == [], (m1["name"], list(diff))
 
     for m1, m2 in zip(module_obsoletes, RPM_MODULEMD_OBSOLETES_DATA):
         diff = dictdiffer.diff(
@@ -1085,7 +1085,7 @@ def test_modular_metadata(
                 "vuln_report",
             },
         )
-        assert list(diff) == [], list(diff)
+        assert list(diff) == [], (m1["name"], list(diff))
 
     # assert all package from modular repo is marked as modular
     for pkg in get_content(repository)["present"][RPM_PACKAGE_CONTENT_NAME]:

--- a/pulp_rpm/tests/functional/constants.py
+++ b/pulp_rpm/tests/functional/constants.py
@@ -1773,7 +1773,7 @@ RPM_MODULEMDS_DATA = [
         "description": "Node.js is a platform built on Chrome''s JavaScript runtime for easily building fast, scalable network applications. Node.js uses an event-driven, non-blocking I/O model that makes it lightweight and efficient, perfect for data-intensive real-time applications that run across distributed devices.",
         "dependencies": [
             {
-                "requires": {"platform": ["f29"], "postgresql": [9.6]},
+                "requires": {"platform": ["f29"], "postgresql": ["9.6"]},
                 "buildrequires": {"platform": ["f29"]},
             }
         ],


### PR DESCRIPTION
Re-implement the bugfix for <https://github.com/pulp/pulp_rpm/issues/3285> in a way that `SafeLoader` is more transparently modified. `SafeLoader` is known to be safe against those attacks (CWE-502).

The previous patch to SafeLoader was too intrusive in the code and hard to audit (if it was still safe after the patch). This is a simpler patch and easier to audit.

**The behavior changes**, but still addresses the bug: Instead of preventing certain key's values to be casted, the new implementation prevents any casting from int and float unquoted values (regardless of the key).

This won't be a problem for NVSCA conflicts (as #3285), but maybe something else could go wrong?
Does dnf care about this? Example:

```diff
  dependencies:
  - buildrequires:
      platform: [f29]
    requires:
      platform: [f29]
-      postgresql: [9.6]
+      postgresql: ["9.6"]
```