### PR TITLE
feat: Add support for uncompressed metadata (NO_COMPRESSION)

### DIFF
--- a/pulp_rpm/app/constants.py
+++ b/pulp_rpm/app/constants.py
@@ -4,11 +4,13 @@ from types import SimpleNamespace
 COMPRESSION_TYPES = SimpleNamespace(
     ZSTD="zstd",
     GZ="gz",
+    NONE="none",
 )
 
 COMPRESSION_CHOICES = (
     (COMPRESSION_TYPES.ZSTD, COMPRESSION_TYPES.ZSTD),
     (COMPRESSION_TYPES.GZ, COMPRESSION_TYPES.GZ),
+    (COMPRESSION_TYPES.NONE, COMPRESSION_TYPES.NONE),
 )
 
 # publication layout

--- a/pulp_rpm/app/tasks/publishing.py
+++ b/pulp_rpm/app/tasks/publishing.py
@@ -730,7 +730,12 @@ def generate_repo_metadata(
         repodata_path = os.path.join(sub_folder, repodata_path)
 
     # Prepare metadata files
-    cr_compression_type = cr.ZSTD if compression_type == COMPRESSION_TYPES.ZSTD else cr.GZ
+    if compression_type == COMPRESSION_TYPES.ZSTD:
+        cr_compression_type = cr.ZSTD
+    elif compression_type == COMPRESSION_TYPES.NONE:
+        cr_compression_type = cr.NO_COMPRESSION
+    else:
+        cr_compression_type = cr.GZ
     total_packages = len(retained_packages)
 
     if RPM_METADATA_USE_REPO_PACKAGE_TIME:


### PR DESCRIPTION
Some clients (like the z/OS port of DNF5) require uncompressed metadata. 

This PR adds support for 'none' as a compression type for RPM metadata. 

Verified manually by creating a repository with compression_type='none' and verifying repomd.xml links to uncompressed files.