### PR TITLE
Make the relative_path option on package upload no-op

### DIFF
--- a/CHANGES/+relative-path.bugfix
+++ b/CHANGES/+relative-path.bugfix
@@ -1,0 +1,1 @@
+Made the `relative_path` argument to package upload no-op. In #4073 we started enforcing that the value of `location_href` and `relative_path` should be the canonicalized filename of the package.

--- a/pulp_rpm/app/serializers/package.py
+++ b/pulp_rpm/app/serializers/package.py
@@ -283,12 +283,8 @@ class PackageSerializer(SingleArtifactContentUploadSerializer, ContentChecksumSe
             )
             + ".rpm"
         )
-        if not data.get("relative_path"):
-            data["relative_path"] = filename
-            new_pkg["location_href"] = filename
-        else:
-            new_pkg["location_href"] = data["relative_path"]
-
+        data["relative_path"] = filename
+        new_pkg["location_href"] = filename
         data.update(new_pkg)
         return data
 


### PR DESCRIPTION
In #4073 we started enforcing that location_href == relative_path == filename, but we missed a spot where the user can break that assumption accidentally.