### PR TITLE
Fix the RPM part of the "prune" / memoziation bug

### DIFF
--- a/CHANGES/+fix-prune.bugfix
+++ b/CHANGES/+fix-prune.bugfix
@@ -1,0 +1,1 @@
+Fixed problems with the prune operation. Additional remediation may be required: see https://github.com/pulp/pulpcore/issues/7272


### PR DESCRIPTION
Need to ensure that only querysets of the Content class or its subclasses are ever passed to add/remove_content()

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
