### PR TITLE
[3.27] Reduce worst-case memory consumption for sync and publish

### DIFF
--- a/CHANGES/4086.bugfix
+++ b/CHANGES/4086.bugfix
@@ -1,0 +1,1 @@
+Significantly improved worst-case sync memory consumption and moderately improved worst-case publish memory consumption for most repos.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -12,3 +12,5 @@ include requirements.txt
 include test_requirements.txt
 include unittest_requirements.txt
 exclude releasing.md
+exclude AGENTS.md
+exclude CLAUDE.md

--- a/pulp_rpm/app/tasks/publishing.py
+++ b/pulp_rpm/app/tasks/publishing.py
@@ -567,7 +567,7 @@ def generate_repo_metadata(
         repo_pkg_times = {pk: created.timestamp() for pk, created in repo_content}
 
     # Process all packages
-    for package in packages.order_by("name", "evr").iterator():
+    for package in packages.order_by("name", "evr").iterator(chunk_size=200):
         if package.pk in pkg_pks_to_ignore:  # Temporary!
             continue
         pkg = package.to_createrepo_c()


### PR DESCRIPTION
Use string internment / caching to improve worst-case memory consumption during sync, by exploiting refcounting.

As repositories often contain long runs of consecutive packages of similar likeness (same name, different arch or version), we globally cache strings but flush the caches once we see a new package name. This avoids keeping data around longer than it is needed.

Reduce the batch size for publish operations to likewise improve worst-case memory consumption.

closes #4086

Assisted By: Claude Code (score_grouping() only)

(cherry picked from commit 8cc41fa25a171cfb5c1bf42ac475cd9b0e3dd5ab)
