### PR TITLE
[PULP-1263][backport/3.35] Fix package_signing_fingerprint field type to be str or None

### DIFF
--- a/CHANGES/4007.bugfix
+++ b/CHANGES/4007.bugfix
@@ -1,0 +1,1 @@
+Fixed `RpmRepository.package_signing_fingerprint` field to accept and default to `null` instead of empty string.

--- a/pulp_rpm/app/serializers/repository.py
+++ b/pulp_rpm/app/serializers/repository.py
@@ -94,8 +94,8 @@ class RpmRepositorySerializer(RepositorySerializer):
         ),
         max_length=40,
         required=False,
-        allow_blank=True,
-        default="",
+        allow_null=True,
+        default=None,
     )
     retain_package_versions = serializers.IntegerField(
         help_text=_(
@@ -187,14 +187,11 @@ class RpmRepositorySerializer(RepositorySerializer):
             "package_checksum_type",
             "compression_type",
             "layout",
+            "package_signing_fingerprint",
         ):
             field_data = data.get(field)
             if field_data == "":
                 data[field] = None
-        # The current API field definition expects empty string for nullable values,
-        # but some migration paths can set an empty string to none in the database.
-        if "package_signing_fingerprint" in data and data["package_signing_fingerprint"] is None:
-            data["package_signing_fingerprint"] = ""
         return data
 
     def validate(self, data):


### PR DESCRIPTION
Change the serializer field from allow_blank/default="" to allow_null/default=None, normalize empty strings to null in to_representation, and add a `pulpcore-manager rpm-datarepair 4007` command to fix existing empty strings in the database.

Closes: #4007
Assisted-By: Claude Sonnet 4.6 <noreply@anthropic.com>

(cherry picked from commit 37b41a4cc151593865fc5050c8b337d0b13d1b06)

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
