### PR TITLE
[PULP-1263][backport/3.27] Fix package_signing_fingerprint field type to be str or None

### DIFF
--- a/CHANGES/4007.bugfix
+++ b/CHANGES/4007.bugfix
@@ -1,0 +1,1 @@
+Fixed `RpmRepository.package_signing_fingerprint` field to accept and default to `null` instead of empty string.

--- a/pulp_rpm/app/management/commands/rpm-datarepair.py
+++ b/pulp_rpm/app/management/commands/rpm-datarepair.py
@@ -5,6 +5,12 @@ from django.core.management import BaseCommand, CommandError
 
 from pulp_rpm.app.models import Package  # noqa
 from pulp_rpm.app.models.advisory import UpdateCollection, UpdateRecord  # noqa
+from pulp_rpm.app.models.repository import RpmRepository  # noqa
+
+
+def raise_if_dry_run(issue, dry_run):
+    if dry_run:
+        raise CommandError(_("--dry-run is not supported for issue #{}.").format(issue))
 
 
 class Command(BaseCommand):
@@ -17,20 +23,29 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         """Set up arguments."""
         parser.add_argument("issue", help=_("The github issue # of the issue to be fixed."))
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help=_("Run without making changes."),
+        )
 
     def handle(self, *args, **options):
         """Implement the command."""
         issue = options["issue"]
+        dry_run = options["dry_run"]
 
         if issue == "2460":
-            self.repair_2460()
-        if issue == "3127":
-            self.repair_3127()
+            self.repair_2460(dry_run)
+        elif issue == "3127":
+            self.repair_3127(dry_run)
+        elif issue == "4007":
+            self.repair_4007(dry_run)
         else:
             raise CommandError(_("Unknown issue: '{}'").format(issue))
 
-    def repair_2460(self):
+    def repair_2460(self, dry_run):
         """Perform data repair for issue #2460."""
+        raise_if_dry_run("2460", dry_run)
 
         def fix_package(package):
             def fix_requirement(require):
@@ -50,9 +65,20 @@ class Command(BaseCommand):
             fix_package(package)
             package.save()
 
-    def repair_3127(self):
+    def repair_3127(self, dry_run):
         """Perform data repair for issue #3127."""
+        raise_if_dry_run("3127", dry_run)
         update_collections = UpdateCollection.objects.exclude(name__isnull=False)
         for collection in update_collections:
             collection.name = "collection-autofill-" + uuid.uuid4().hex[:12]
             collection.save()
+
+    def repair_4007(self, dry_run):
+        """Perform data repair for issue #4007."""
+        affected = RpmRepository.objects.filter(package_signing_fingerprint="")
+        count = affected.count()
+        if not dry_run:
+            affected.update(package_signing_fingerprint=None)
+            self.stdout.write(f"Fixed {count} repositories with empty package_signing_fingerprint.")
+        else:
+            self.stdout.write(f"{count} repositories have an empty package_signing_fingerprint.")

--- a/pulp_rpm/app/serializers/repository.py
+++ b/pulp_rpm/app/serializers/repository.py
@@ -78,8 +78,8 @@ class RpmRepositorySerializer(RepositorySerializer):
         ),
         max_length=40,
         required=False,
-        allow_blank=True,
-        default="",
+        allow_null=True,
+        default=None,
     )
     retain_package_versions = serializers.IntegerField(
         help_text=_(
@@ -158,14 +158,11 @@ class RpmRepositorySerializer(RepositorySerializer):
             "package_checksum_type",
             "compression_type",
             "layout",
+            "package_signing_fingerprint",
         ):
             field_data = data.get(field)
             if field_data == "":
                 data[field] = None
-        # The current API field definition expects empty string for nullable values,
-        # but some migration paths can set an empty string to none in the database.
-        if "package_signing_fingerprint" in data and data["package_signing_fingerprint"] is None:
-            data["package_signing_fingerprint"] = ""
         return data
 
     def validate(self, data):


### PR DESCRIPTION
Change the serializer field from allow_blank/default="" to allow_null/default=None, normalize empty strings to null in to_representation, and add a `pulpcore-manager rpm-datarepair 4007` command to fix existing empty strings in the database.

Closes: #4007 
Assisted-By: Claude Sonnet 4.6 <noreply@anthropic.com>

> [!WARNING]
> The branch didn't contain dry-run option, so I added one for this issue only.

(cherry picked from commit 37b41a4cc151593865fc5050c8b337d0b13d1b06) (cherry picked from commit 4c42932caba1bb0f9ec2d8ac7d242ea19a50216a)

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
