### PR TITLE
Add dependency_upgrade flag to copy API

### DIFF
--- a/CHANGES/4368.feature
+++ b/CHANGES/4368.feature
@@ -1,0 +1,3 @@
+Added ``dependency_upgrade`` boolean field to the copy API. When enabled,
+transitive dependencies are resolved to their latest available versions
+instead of preferring versions already present in the destination repository.

--- a/coverage.md
+++ b/coverage.md
@@ -48,6 +48,7 @@ This file contains list of features and their test coverage.
 | As a user, I can copy any content by adding it to a repository with modify/ endpoint (but nothing is copied automatically, and invalid repositories will fail to validate for some definition of “invalid”) | NO |  |
 | As a user, I can copy any content by href using Copy API | PART |  |
 | As a user, I can copy RPM package and its dependencies (if depsolving=True) | YES | to empty and non-empty repository |
+| As a user, I can copy RPM packages and have their dependencies resolved to the latest available version (dependency_upgrade=True) | YES | |
 | As a user, I can copy Advisory and packages it refers to (and their dependencies if depsolving=True) by copying the Advisory | YES |  |
 | As a user, I can copy PackageCategories, PackageEnvironments and PackageGroups (and their dependencies) | PART | no packageenvironment test |
 | As a user, I can copy Modulemd and its artifacts by copying the Modulemd | NO |  |

--- a/docs/user/guides/modify.md
+++ b/docs/user/guides/modify.md
@@ -262,6 +262,16 @@ repositories.
     default is potentially subject to change in the future - until such a time as this API is
     stabilized.
 
+By default, dependency solving prefers package versions already present in the destination
+repository (i.e. it resolves only **missing** dependencies). If you want transitive dependencies
+to be upgraded to their latest available versions in the source repository, set the
+`dependency_upgrade` parameter to `True`. This is useful when refreshing a curated repository
+from an updated upstream source.
+
+For example: if the destination already contains `openssl-libs-3.5.1-3` and the source has
+`openssl-libs-3.5.1-7`, copying a package that depends on `openssl-libs` with
+`dependency_upgrade=True` will pull in `-7` instead of keeping `-3`.
+
 Dependency solving does have some restrictions to be aware of. The set of content contained by
 all repositories used in a copy operation must be "dependency closed", which is to say that no
 content in any repository may have a dependency which cannot be satisfied by any content present

--- a/pulp_rpm/app/depsolving.py
+++ b/pulp_rpm/app/depsolving.py
@@ -743,7 +743,7 @@ class Solver:
                         warnings.append(str(info))
         return warnings
 
-    def resolve_dependencies(self, unit_repo_map):
+    def resolve_dependencies(self, unit_repo_map, focus_installed=True):
         """Resolve the total set of packages needed for the packages passed in, as DNF would.
 
         Find the set of dependent units and return them in a dictionary where
@@ -819,7 +819,11 @@ class Solver:
         # Take a list of jobs, get a solution, return the set of solvables that needed to
         # be installed.
         solver = self._pool.Solver()
-        solver.set_flag(solv.Solver.SOLVER_FLAG_FOCUS_INSTALLED, 1)
+        solver.set_flag(solv.Solver.SOLVER_FLAG_FOCUS_INSTALLED, int(focus_installed))
+        # When not focusing on installed packages, also prefer the best (latest) version
+        # so that transitive dependencies are resolved to their newest available version.
+        if not focus_installed:
+            solver.set_flag(solv.Solver.SOLVER_FLAG_FOCUS_BEST, 1)
 
         raw_problems = solver.solve(install_jobs)
         # The solver is simply ignoring the problems encountered and proceeds associating

--- a/pulp_rpm/app/serializers/repository.py
+++ b/pulp_rpm/app/serializers/repository.py
@@ -546,6 +546,13 @@ class CopySerializer(ValidateFieldsMixin, serializers.Serializer):
     dependency_solving = serializers.BooleanField(
         help_text=_("Also copy dependencies of the content being copied."), default=True
     )
+    dependency_upgrade = serializers.BooleanField(
+        help_text=_(
+            "Resolve dependencies to their latest compatible versions instead of "
+            "preferring versions already in the destination."
+        ),
+        default=False,
+    )
 
     def validate(self, data):
         """

--- a/pulp_rpm/app/tasks/copy.py
+++ b/pulp_rpm/app/tasks/copy.py
@@ -126,13 +126,15 @@ def find_children_of_content(content, src_repo_version):
 
 
 @transaction.atomic
-def copy_content(config, dependency_solving):
+def copy_content(config, dependency_solving, dependency_upgrade=False):
     """
     Copy content from one repo to another.
 
     Args:
         config: Details of how the copy should be performed.
         dependency_solving: Use dependency solving to find additional content units to copy.
+        dependency_upgrade: Resolve dependencies to latest compatible versions instead of
+            preferring versions already in the destination.
 
     Config format details:
         source_repo_version_pk: repository version primary key to copy units from
@@ -227,7 +229,9 @@ def copy_content(config, dependency_solving):
 
         solver.finalize()
 
-        content_to_copy = solver.resolve_dependencies(content_to_copy)
+        content_to_copy = solver.resolve_dependencies(
+            content_to_copy, focus_installed=not dependency_upgrade
+        )
 
         for from_repo, units in content_to_copy.items():
             src_repo_version = libsolv_repo_names[from_repo]

--- a/pulp_rpm/app/viewsets/repository.py
+++ b/pulp_rpm/app/viewsets/repository.py
@@ -719,6 +719,7 @@ class CopyViewSet(viewsets.ViewSet):
         serializer.is_valid(raise_exception=True)
 
         dependency_solving = serializer.validated_data["dependency_solving"]
+        dependency_upgrade = serializer.validated_data["dependency_upgrade"]
         config = serializer.validated_data["config"]
 
         config, shared_repos, exclusive_repos = self._process_config(config)
@@ -727,7 +728,7 @@ class CopyViewSet(viewsets.ViewSet):
             tasks.copy_content,
             shared_resources=shared_repos,
             exclusive_resources=exclusive_repos,
-            args=[config, dependency_solving],
+            args=[config, dependency_solving, dependency_upgrade],
             kwargs={},
         )
         return OperationPostponedResponse(async_result, request)

--- a/pulp_rpm/tests/functional/api/test_copy.py
+++ b/pulp_rpm/tests/functional/api/test_copy.py
@@ -416,6 +416,119 @@ class TestCopyWithUnsignedRepoSyncedImmediate:
         content_summary = repository_version.to_dict()["content_summary"]
         assert content_summary["added"][PULP_TYPE_PACKAGE]["count"] == 2
 
+    def test_dependency_upgrade_keeps_installed_dependency_version(
+        self,
+        monitor_task,
+        rpm_copy_api,
+        rpm_package_api,
+        rpm_repository_api,
+        rpm_repository_factory,
+        rpm_unsigned_repo_immediate,
+    ):
+        """Without dependency_upgrade, copy keeps the already-installed dependency version.
+
+        - Create empty dest repo and seed it with kangaroo-0.2 (old version)
+        - Copy elephant (requires kangaroo, any version) with dependency_upgrade=False
+        - Assert kangaroo-0.3 was NOT copied (kangaroo-0.2 already satisfies the requirement)
+        """
+        src = rpm_unsigned_repo_immediate
+        dest = rpm_repository_factory()
+
+        # Seed dest with kangaroo-0.2 (old version)
+        kangaroos = rpm_package_api.list(
+            repository_version=src.latest_version_href, name="kangaroo"
+        ).results
+        kangaroo_02 = next(p for p in kangaroos if p.version == "0.2")
+        monitor_task(
+            rpm_repository_api.modify(
+                dest.pulp_href, {"add_content_units": [kangaroo_02.pulp_href]}
+            ).task
+        )
+        dest = rpm_repository_api.read(dest.pulp_href)
+
+        elephant = rpm_package_api.list(
+            repository_version=src.latest_version_href, name="elephant"
+        ).results[0]
+        data = Copy(
+            config=[
+                {
+                    "source_repo_version": src.latest_version_href,
+                    "dest_repo": dest.pulp_href,
+                    "content": [elephant.pulp_href],
+                }
+            ],
+            dependency_solving=True,
+            dependency_upgrade=False,
+        )
+        monitor_task(rpm_copy_api.copy_content(data).task)
+
+        dest = rpm_repository_api.read(dest.pulp_href)
+        kangaroo_versions = [
+            p.version
+            for p in rpm_package_api.list(
+                repository_version=dest.latest_version_href, name="kangaroo"
+            ).results
+        ]
+        # kangaroo-0.2 already satisfied the requirement; kangaroo-0.3 should not be pulled in
+        assert "0.2" in kangaroo_versions
+        assert "0.3" not in kangaroo_versions
+
+    def test_dependency_upgrade_pulls_latest_dependency_version(
+        self,
+        monitor_task,
+        rpm_copy_api,
+        rpm_package_api,
+        rpm_repository_api,
+        rpm_repository_factory,
+        rpm_unsigned_repo_immediate,
+    ):
+        """With dependency_upgrade, copy resolves dependencies to the latest available version.
+
+        - Create empty dest repo and seed it with kangaroo-0.2 (old version)
+        - Copy elephant (requires kangaroo, any version) with dependency_upgrade=True
+        - Assert kangaroo-0.3 was copied (solver preferred the latest version)
+        """
+        src = rpm_unsigned_repo_immediate
+        dest = rpm_repository_factory()
+
+        # Seed dest with kangaroo-0.2 (old version)
+        kangaroos = rpm_package_api.list(
+            repository_version=src.latest_version_href, name="kangaroo"
+        ).results
+        kangaroo_02 = next(p for p in kangaroos if p.version == "0.2")
+        monitor_task(
+            rpm_repository_api.modify(
+                dest.pulp_href, {"add_content_units": [kangaroo_02.pulp_href]}
+            ).task
+        )
+        dest = rpm_repository_api.read(dest.pulp_href)
+
+        elephant = rpm_package_api.list(
+            repository_version=src.latest_version_href, name="elephant"
+        ).results[0]
+        data = Copy(
+            config=[
+                {
+                    "source_repo_version": src.latest_version_href,
+                    "dest_repo": dest.pulp_href,
+                    "content": [elephant.pulp_href],
+                }
+            ],
+            dependency_solving=True,
+            dependency_upgrade=True,
+        )
+        monitor_task(rpm_copy_api.copy_content(data).task)
+
+        dest = rpm_repository_api.read(dest.pulp_href)
+        kangaroo_versions = [
+            p.version
+            for p in rpm_package_api.list(
+                repository_version=dest.latest_version_href, name="kangaroo"
+            ).results
+        ]
+        # dependency_upgrade should have pulled in kangaroo-0.3 (latest available)
+        assert "0.3" in kangaroo_versions
+
 
 class TestCopyWithKickstartRepoSyncedImmediate:
     def test_kickstart_content(


### PR DESCRIPTION
When dependency_upgrade=True, the solver resolves transitive dependencies to their latest available versions instead of preferring versions already present in the destination repository. This is achieved by setting SOLVER_FLAG_FOCUS_INSTALLED=0 and SOLVER_FLAG_FOCUS_BEST=1 in libsolv.

ref #4368

Assisted By: Claude (Anthropic)

### 📜 Checklist

- [X] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [X] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [X] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [X] (For new features) - User documentation and test coverage has been added
