### PR TITLE
Fix package metadata fields not updated after signing

### DIFF
--- a/CHANGES/4383.bugfix
+++ b/CHANGES/4383.bugfix
@@ -1,0 +1,1 @@
+Updated package signing to refresh all RPM metadata fields from the signed package file, ensuring size, header offsets, and other fields stay consistent after signing.

--- a/docs/admin/reference/settings.md
+++ b/docs/admin/reference/settings.md
@@ -69,3 +69,10 @@ appears in the "file" field of the time element for each package in primary.xml.
 ## MAX_PACKAGE_SIGNING_WORKERS
 
 Sets the number of workers that pulp_rpm uses when concurrently signing packages. Defaults to 5.
+
+
+## RPM_SIGNING_COPY_LABELS
+
+When set to `True`, pulp_rpm will copy the `pulp_labels` from the original unsigned package
+to the newly created signed package during the package signing process. This is useful when
+labels should be preserved across signing operations. Defaults to `True`.

--- a/pulp_rpm/app/settings.py
+++ b/pulp_rpm/app/settings.py
@@ -20,3 +20,4 @@ PRUNE_WORKERS_MAX = 5
 # workaround for: https://github.com/pulp/pulp_rpm/issues/4125
 SPECTACULAR_SETTINGS__OAS_VERSION = "3.0.1"
 MAX_PACKAGE_SIGNING_WORKERS = 5
+RPM_SIGNING_COPY_LABELS = True

--- a/pulp_rpm/app/tasks/signing.py
+++ b/pulp_rpm/app/tasks/signing.py
@@ -5,6 +5,7 @@ import subprocess
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 
+import createrepo_c as cr
 from django.conf import settings
 
 from pulpcore.plugin.models import (
@@ -18,7 +19,6 @@ from pulpcore.plugin.models import (
 from pulpcore.plugin.tasking import add_and_remove, general_create
 from pulpcore.plugin.util import get_url
 
-from pulp_rpm.app.constants import CHECKSUM_TYPES
 from pulp_rpm.app.models.content import RpmPackageSigningResult, RpmPackageSigningService
 from pulp_rpm.app.models.package import Package
 from pulp_rpm.app.models.repository import RpmRepository
@@ -132,13 +132,20 @@ def _sign_package(package, signing_service, signing_fingerprint):
             str(signed_package_path),
             (package.signing_keys or []) + [signing_fingerprint],
         )
+        # Read all updated metadata from the signed RPM
+        cr_pkg = cr.package_from_rpm(str(signed_package_path))
+        new_pkg_dict = Package.createrepo_to_dict(cr_pkg)
         artifact = _save_artifact(signed_package_path)
-        signed_package = package
-        signed_package.pk = None
-        signed_package.pulp_id = None
-        signed_package.pkgId = artifact.sha256
-        signed_package.checksum_type = CHECKSUM_TYPES.SHA256
-        signed_package.signing_keys = signing_keys
+        extra_fields = {}
+        if settings.RPM_SIGNING_COPY_LABELS:
+            extra_fields["pulp_labels"] = package.pulp_labels
+        signed_package = Package(
+            **new_pkg_dict,
+            signing_keys=signing_keys,
+            is_modular=package.is_modular,
+            **extra_fields,
+        )
+        signed_package.location_href = signed_package.filename
         signed_package.save()
         ContentArtifact.objects.create(
             artifact=artifact,

--- a/pulp_rpm/tests/functional/api/test_package_signing.py
+++ b/pulp_rpm/tests/functional/api/test_package_signing.py
@@ -300,6 +300,7 @@ def test_signed_repo_modify(
     ).results[0]
     assert signed_package.pulp_href != created_package.pulp_href
     assert signed_package.signing_keys == [fingerprint]
+    assert signed_package.time_file != created_package.time_file
     assert sorted(task_result.created_resources) == sorted(
         [repository.latest_version_href, signed_package.pulp_href, signed_package.artifact]
     )


### PR DESCRIPTION
When creating a signed copy of a package, all RPM metadata fields are now refreshed from the signed file using createrepo_c, ensuring size_package, rpm_header_start, rpm_header_end, time_file, and other fields stay consistent.

fixes #4383