### PR TITLE
Use createrepo_c flags to ensure we don't parse file digests

### DIFF
--- a/CHANGES/+dont-load-file-digests.misc
+++ b/CHANGES/+dont-load-file-digests.misc
@@ -1,0 +1,1 @@
+Set a flag during RPM parsing to ensure we don't load file digests.

--- a/pulp_rpm/app/constants.py
+++ b/pulp_rpm/app/constants.py
@@ -1,4 +1,5 @@
 from types import SimpleNamespace
+import createrepo_c as cr
 
 # metadata compression types supported
 COMPRESSION_TYPES = SimpleNamespace(
@@ -50,6 +51,8 @@ CHECKSUM_CHOICES = (
     (CHECKSUM_TYPES.SHA384, CHECKSUM_TYPES.SHA384),
     (CHECKSUM_TYPES.SHA512, CHECKSUM_TYPES.SHA512),
 )
+
+CR_HEADER_FLAGS = cr.HDRR_NOFILEDIGESTS
 
 ALLOWED_CHECKSUM_ERROR_MSG = """Checksum must be one of the allowed checksum types.
 You can adjust these with the 'ALLOWED_CONTENT_CHECKSUMS' setting."""

--- a/pulp_rpm/app/serializers/package.py
+++ b/pulp_rpm/app/serializers/package.py
@@ -21,6 +21,7 @@ from pulpcore.plugin.files import PulpTemporaryUploadedFile
 from tempfile import NamedTemporaryFile
 from pulpcore.plugin.util import get_domain_pk
 
+from pulp_rpm.app.constants import CR_HEADER_FLAGS
 from pulp_rpm.app.models import Package
 from pulp_rpm.app.shared_utils import format_nvra, read_crpackage_from_artifact
 
@@ -429,7 +430,9 @@ class PackageUploadSerializer(PackageSerializer):
         try:
             if uploaded_file:
                 cr_object = cr.package_from_rpm(
-                    uploaded_file.file.name, changelog_limit=settings.KEEP_CHANGELOG_LIMIT
+                    uploaded_file.file.name,
+                    changelog_limit=settings.KEEP_CHANGELOG_LIMIT,
+                    header_reading_flags=CR_HEADER_FLAGS,
                 )
                 new_pkg = Package.createrepo_to_dict(cr_object)
             elif upload:
@@ -446,7 +449,9 @@ class PackageUploadSerializer(PackageSerializer):
 
                 # Now we have a file, read metadata from it
                 cr_object = cr.package_from_rpm(
-                    temp_file.name, changelog_limit=settings.KEEP_CHANGELOG_LIMIT
+                    temp_file.name,
+                    changelog_limit=settings.KEEP_CHANGELOG_LIMIT,
+                    header_reading_flags=CR_HEADER_FLAGS,
                 )
                 new_pkg = Package.createrepo_to_dict(cr_object)
 

--- a/pulp_rpm/app/shared_utils.py
+++ b/pulp_rpm/app/shared_utils.py
@@ -10,7 +10,10 @@ import createrepo_c as cr
 from django.conf import settings
 from django.utils.dateparse import parse_datetime
 from importlib_resources import files
+
 from pulpcore.plugin.exceptions import InvalidSignatureError
+
+from pulp_rpm.app.constants import CR_HEADER_FLAGS
 from pulp_rpm.app.rpm_version import RpmVersion
 
 
@@ -97,7 +100,9 @@ def read_crpackage_from_artifact(artifact, working_dir="."):
         shutil.copyfileobj(artifact_file, temp_file)
         temp_file.flush()
         cr_pkginfo = cr.package_from_rpm(
-            temp_file.name, changelog_limit=settings.KEEP_CHANGELOG_LIMIT
+            temp_file.name,
+            changelog_limit=settings.KEEP_CHANGELOG_LIMIT,
+            header_reading_flags=CR_HEADER_FLAGS,
         )
 
     artifact_file.close()

--- a/pulp_rpm/app/tasks/signing.py
+++ b/pulp_rpm/app/tasks/signing.py
@@ -23,7 +23,6 @@ from pulp_rpm.app.models.content import RpmPackageSigningResult, RpmPackageSigni
 from pulp_rpm.app.models.package import Package
 from pulp_rpm.app.models.repository import RpmRepository
 
-
 log = logging.getLogger(__name__)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 requires-python = ">=3.11"
 dependencies = [
-    "createrepo_c~=1.2.1",
+    "createrepo_c~=1.2.3",
     "django_readonly_field~=1.1.1",
     "jsonschema>=4.6,<5.0",
     "libcomps>=0.1.23.post1,<0.2",


### PR DESCRIPTION
Parsing file digests changes the API, due to an accident. We've already handled that, but we can avoid it happening in the first place and save some memory while we're at it.

### 📜 Checklist

- [x] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [x] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [x] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [x] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
