### PR TITLE
(Hopefully) resolve flaky tests

### DIFF
--- a/pulp_rpm/tests/functional/api/test_pulpimport.py
+++ b/pulp_rpm/tests/functional/api/test_pulpimport.py
@@ -245,6 +245,8 @@ def test_distribution_tree_import(
         assert trees.count == 1
 
 
+# Runs orphan cleanup to create a content-free zone; conflicts with parallel tests
+@pytest.mark.serial
 def test_clean_import(
     rpm_repository_api,
     import_export_repositories,
@@ -286,6 +288,8 @@ def test_clean_import(
     assert rpm_repository_api.list().count == existing_repos
 
 
+# Runs orphan cleanup to create a content-free zone; conflicts with parallel tests
+@pytest.mark.serial
 def test_create_missing_repos(
     init_and_sync,
     rpm_rpmremote_api,

--- a/pulp_rpm/tests/functional/api/test_repo_sizes.py
+++ b/pulp_rpm/tests/functional/api/test_repo_sizes.py
@@ -1,6 +1,8 @@
 import json
 import subprocess
 
+import pytest
+
 from pulp_rpm.tests.functional.constants import (
     RPM_UNSIGNED_FIXTURE_URL,
     RPM_UNSIGNED_FIXTURE_SIZE,
@@ -9,6 +11,8 @@ from pulp_rpm.tests.functional.constants import (
 )
 
 
+# Asserts exact disk-size; parallel immediate syncs share artifacts and inflate it
+@pytest.mark.serial
 def test_repo_size(init_and_sync, delete_orphans_pre, monitor_task, pulpcore_bindings):
     """Test that RPM repos correctly report their on-disk artifact sizes."""
     monitor_task(pulpcore_bindings.OrphansCleanupApi.cleanup({"orphan_protection_time": 0}).task)
@@ -39,6 +43,8 @@ def test_repo_size(init_and_sync, delete_orphans_pre, monitor_task, pulpcore_bin
     assert report["on-demand-size"] == 0
 
 
+# Asserts exact disk-size; parallel immediate syncs share artifacts and inflate it
+@pytest.mark.serial
 def test_kickstart_repo_size(init_and_sync, delete_orphans_pre, monitor_task, pulpcore_bindings):
     """Test that kickstart RPM repos correctly report their on-disk artifact sizes."""
     monitor_task(pulpcore_bindings.OrphansCleanupApi.cleanup({"orphan_protection_time": 0}).task)


### PR DESCRIPTION
Mark tests that rely on global state as serial-execution-only

Assisted-By: claude-opus-4.6

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [x] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [x] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
