### PR TITLE
Add versioned prefix to signing fingerprints

### DIFF
--- a/CHANGES/+signing-fingerprint-prefix.feature
+++ b/CHANGES/+signing-fingerprint-prefix.feature
@@ -1,3 +1,3 @@
 Signing fingerprints now use a versioned prefix format (e.g. `v4:<hex>`, `keyid:<hex>`) for
-`package_signing_fingerprint` on repositories and `signing_keys` on packages. The repository
-serializer validates the format on input.
+`package_signing_fingerprint` on repositories and `signing_keys` on packages. The fingerprint prefix
+is passed to the signing script as the `PULP_SIGNING_FINGERPRINT_TYPE` environment variable.

--- a/pulp_rpm/app/migrations/0070_add_rpm_signing_keys.py
+++ b/pulp_rpm/app/migrations/0070_add_rpm_signing_keys.py
@@ -4,6 +4,58 @@ import django.contrib.postgres.fields
 from django.db import migrations, models
 
 
+def add_fingerprint_prefix(apps, schema_editor):
+    """Add 'v4:' prefix to package_signing_fingerprint values that lack a prefix."""
+    RpmRepository = apps.get_model("rpm", "RpmRepository")
+    RpmRepository.objects.filter(
+        package_signing_fingerprint__isnull=False,
+    ).exclude(
+        package_signing_fingerprint__contains=":",
+    ).update(
+        package_signing_fingerprint=models.functions.Concat(
+            models.Value("v4:"), "package_signing_fingerprint"
+        ),
+    )
+
+    RpmPackageSigningResult = apps.get_model("rpm", "RpmPackageSigningResult")
+    RpmPackageSigningResult.objects.exclude(
+        package_signing_fingerprint__contains=":",
+    ).update(
+        package_signing_fingerprint=models.functions.Concat(
+            models.Value("v4:"), "package_signing_fingerprint"
+        ),
+    )
+
+
+def remove_fingerprint_prefix(apps, schema_editor):
+    """Remove type prefix (e.g. 'v4:', 'keyid:') from package_signing_fingerprint values."""
+    RpmRepository = apps.get_model("rpm", "RpmRepository")
+    RpmRepository.objects.filter(
+        package_signing_fingerprint__contains=":",
+    ).update(
+        package_signing_fingerprint=models.Func(
+            "package_signing_fingerprint",
+            models.Value("^[^:]+:"),
+            models.Value(""),
+            function="REGEXP_REPLACE",
+            output_field=models.TextField(),
+        ),
+    )
+
+    RpmPackageSigningResult = apps.get_model("rpm", "RpmPackageSigningResult")
+    RpmPackageSigningResult.objects.filter(
+        package_signing_fingerprint__contains=":",
+    ).update(
+        package_signing_fingerprint=models.Func(
+            "package_signing_fingerprint",
+            models.Value("^[^:]+:"),
+            models.Value(""),
+            function="REGEXP_REPLACE",
+            output_field=models.TextField(),
+        ),
+    )
+
+
 class Migration(migrations.Migration):
     dependencies = [
         ("rpm", "0069_DATA_fix_signing_fingerprint"),
@@ -27,4 +79,5 @@ class Migration(migrations.Migration):
             name="package_signing_fingerprint",
             field=models.TextField(null=True),
         ),
+        migrations.RunPython(add_fingerprint_prefix, remove_fingerprint_prefix),
     ]

--- a/pulp_rpm/app/tasks/signing.py
+++ b/pulp_rpm/app/tasks/signing.py
@@ -80,8 +80,12 @@ def _update_signing_keys(package_file, keys):
 
 def _sign_file(package_file, signing_service, signing_fingerprint):
     """Sign a package and return the local path of the signed file."""
-    raw_fingerprint = signing_fingerprint.split(":", 1)[1]
-    result = signing_service.sign(package_file.name, pubkey_fingerprint=raw_fingerprint)
+    prefix, raw_fingerprint = signing_fingerprint.split(":", 1)
+    result = signing_service.sign(
+        package_file.name,
+        env_vars={"PULP_SIGNING_FINGERPRINT_TYPE": prefix},
+        pubkey_fingerprint=raw_fingerprint,
+    )
     signed_package_path = Path(result["rpm_package"])
     if not signed_package_path.exists():
         raise Exception(f"Signing script did not create the signed package: {result}")


### PR DESCRIPTION
- Data migration adds 'v4:' prefix to existing package_signing_fingerprint values on RpmRepository and RpmPackageSigningResult.
- The signing service script now receives the fingerprint version prefix (e.g. v4, keyid) via the PULP_SIGNING_FINGERPRINT_VERSION environment variable when signing packages.