### PR TITLE
[PULP-1172] Fix sync from repositories with duplicate NEVRAS same build tag

### DIFF
--- a/CHANGES/4341.bugfix
+++ b/CHANGES/4341.bugfix
@@ -1,0 +1,1 @@
+Fixed a bug where two packages with the same NEVRA and identical build times but different checksums could both pass the sync tie-breaker and be added to the repository version. The first-seen package now wins deterministically.

--- a/pulp_rpm/app/tasks/synchronizing.py
+++ b/pulp_rpm/app/tasks/synchronizing.py
@@ -121,6 +121,9 @@ DUPLICATE_WARN_MSG = (
 # lift dynaconf lookups outside of loops
 ALLOWED_CONTENT_CHECKSUMS = settings.ALLOWED_CONTENT_CHECKSUMS
 
+# sentinel
+ALREADY_SEEN = object()
+
 
 def store_metadata_for_mirroring(repo, md_path, relative_path):
     """Used to store data about the downloaded metadata for mirror-publishing after the sync.
@@ -1391,9 +1394,12 @@ class RpmFirstStage(Stage):
                 if package_skip_nevras and pkg_nevra in package_skip_nevras:
                     continue
                 # Same heuristic as DNF / Yum / Zypper - in the event we encounter multiple package
-                # entries with the same NEVRA, pick the one with the larger build time
+                # entries with the same NEVRA, pick the one with the larger build time. Ties are
+                # broken by first-seen: after the first package passes, the entry is replaced with
+                # a sentinel so that any subsequent package with the same NEVRA is filtered out.
                 elif pkg.time_build != latest_build_time_by_nevra[pkg_nevra]:
                     continue
+                latest_build_time_by_nevra[pkg_nevra] = ALREADY_SEEN
                 # Typically (not always, but 90% of the time) like (same name, different arch
                 # or version) packages are grouped together metadata - this means that re-using
                 # the cache for runs of consecutive like packages is highly effective at saving

--- a/pulp_rpm/tests/functional/api/test_publish.py
+++ b/pulp_rpm/tests/functional/api/test_publish.py
@@ -28,7 +28,10 @@ from pulp_rpm.tests.functional.constants import (
     RPM_UNSIGNED_FIXTURE_URL,
     SRPM_UNSIGNED_FIXTURE_URL,
 )
-from pulp_rpm.tests.functional.utils import download_and_decompress_file
+from pulp_rpm.tests.functional.utils import (
+    download_and_decompress_file,
+    get_metadata_content_helper,
+)
 
 from pulpcore.client.pulp_rpm import RpmRepositorySyncURL, RpmRpmPublication
 from pulpcore.client.pulp_rpm.exceptions import ApiException
@@ -227,34 +230,9 @@ def test_publish_references_update(assert_created_publication):
     assert_created_publication(RPM_REFERENCES_UPDATEINFO_URL)
 
 
-def get_metadata_content_helper(base_url, repomd_elem, meta_type):
-    """Return the text contents of metadata file.
-
-    Provided a url, a repomd root element, and a metadata type, locate the metadata
-    file's location href, download it from the provided url, un-gzip it, parse it, and
-    return the root element node.
-
-    Don't use this with large repos because it will blow up.
-    """
-    # <ns0:repomd xmlns:ns0="http://linux.duke.edu/metadata/repo">
-    #     <ns0:data type="primary">
-    #         <ns0:checksum type="sha256">[…]</ns0:checksum>
-    #         <ns0:location href="repodata/[…]-primary.xml.gz" />
-    #         …
-    #     </ns0:data>
-    #     …
-    xpath = "{{{}}}data".format(RPM_NAMESPACES["metadata/repo"])
-    data_elems = [elem for elem in repomd_elem.findall(xpath) if elem.get("type") == meta_type]
-    if not data_elems:
-        return None
-
-    xpath = "{{{}}}location".format(RPM_NAMESPACES["metadata/repo"])
-    location_href = data_elems[0].find(xpath).get("href")
-
-    return download_and_decompress_file(os.path.join(base_url, location_href))
-
-
-@pytest.mark.parametrize("layout", ["flat", "nested_alphabetically", "nested_by_digest"])
+@pytest.mark.parametrize(
+    "layout", ["flat", "nested_alphabetically", "nested_by_digest"]
+)
 def test_repo_layout(
     layout,
     init_and_sync,

--- a/pulp_rpm/tests/functional/api/test_publish.py
+++ b/pulp_rpm/tests/functional/api/test_publish.py
@@ -230,9 +230,7 @@ def test_publish_references_update(assert_created_publication):
     assert_created_publication(RPM_REFERENCES_UPDATEINFO_URL)
 
 
-@pytest.mark.parametrize(
-    "layout", ["flat", "nested_alphabetically", "nested_by_digest"]
-)
+@pytest.mark.parametrize("layout", ["flat", "nested_alphabetically", "nested_by_digest"])
 def test_repo_layout(
     layout,
     init_and_sync,

--- a/pulp_rpm/tests/functional/api/test_sync.py
+++ b/pulp_rpm/tests/functional/api/test_sync.py
@@ -1193,6 +1193,7 @@ def test_config_repo_mirror_sync(
         assert bytes("repo_gpgcheck=0", "utf-8") in content
 
 
+@pytest.mark.parallel
 def test_repo_with_different_nevra_same_location_href(
     repository_builder: RepositoryBuilder,
     package_listing: PackageListFetcher,
@@ -1239,3 +1240,49 @@ def test_repo_with_different_nevra_same_location_href(
     metadata_packages = package_listing.from_repository_metadata(url=distribution.base_url)
     assert normalized_location(pkg_1) in metadata_packages
     assert normalized_location(pkg_2) in metadata_packages
+
+
+@pytest.mark.parallel
+@pytest.mark.parametrize("invert", [False, True])
+def test_repo_with_duplicate_nevra_same_build_id(
+    repository_builder: RepositoryBuilder,
+    package_listing: PackageListFetcher,
+    invert: bool,
+    init_and_sync,
+    rpm_publication_factory,
+    rpm_distribution_factory,
+):
+    # given a remote repository with bad data
+    common_nevra = MetaPackage.generate_nevra(1)
+    common_build_time = 1
+    package_1 = MetaPackage(
+        nevra=common_nevra,
+        time_build=common_build_time,
+        digest=MetaPackage.generate_digest(1),
+        location="{nvra}.rpm".format(nvra=common_nevra.to_nvra()),
+    )
+    package_2 = MetaPackage(
+        nevra=common_nevra,
+        time_build=common_build_time,
+        digest=MetaPackage.generate_digest(2),
+        location="{nvra}-dup.rpm".format(nvra=common_nevra.to_nvra()),
+    )
+
+    original_packages = [package_2, package_1] if invert else [package_1, package_2]
+    remote_repo = repository_builder.build(packages=original_packages)
+
+    # when we do a sync, publish and distribute
+    repository, _ = init_and_sync(url=remote_repo.url, policy="on_demand")
+    publication = rpm_publication_factory(repository=repository.pulp_href)
+    distribution = rpm_distribution_factory(publication=publication.pulp_href)
+
+    # then the first package wins in the repository version
+    first_package = original_packages[0]
+    repover_packages = package_listing.from_pulp_repoversion(repository.latest_version_href)
+    assert len(repover_packages) == 1
+    assert repover_packages[0].digest == first_package.digest
+
+    # and in the published metadata
+    metadata_packages = package_listing.from_repository_metadata(url=distribution.base_url)
+    assert len(metadata_packages) == 1
+    assert metadata_packages[0].digest == first_package.digest

--- a/pulp_rpm/tests/functional/api/test_sync.py
+++ b/pulp_rpm/tests/functional/api/test_sync.py
@@ -3,15 +3,18 @@
 import pytest
 from random import choice
 
-from urllib.parse import urljoin
 import dictdiffer
 import requests
-from pathlib import Path
 from django.conf import settings
 from django.utils.dateparse import parse_datetime
-import createrepo_c as cr
-
 from pulpcore.tests.functional.utils import PulpTaskError
+
+from pulp_rpm.tests.functional.utils import (
+    MetaPackage,
+    PackageListFetcher,
+    RepositoryBuilder,
+    normalized_location,
+)
 
 from pulp_rpm.tests.functional.constants import (
     AMAZON_MIRROR,
@@ -1190,102 +1193,49 @@ def test_config_repo_mirror_sync(
         assert bytes("repo_gpgcheck=0", "utf-8") in content
 
 
-@pytest.fixture
-def repo_4073_url(
-    tmp_path,
-    rpm_repository_factory,
-    rpm_rpmremote_factory,
-    rpm_publication_factory,
-    rpm_distribution_factory,
-    init_and_sync,
-):
-    REPODIR = tmp_path / "repo_4073"
-
-    def download_fixture(fixture_name: str, to_relative_path: str) -> Path:
-        url = urljoin(RPM_UNSIGNED_FIXTURE_URL, fixture_name)
-        response = requests.get(url)
-        response.raise_for_status()
-        pkg = REPODIR / to_relative_path
-        pkg.parent.mkdir(parents=True, exist_ok=True)
-        pkg.write_bytes(response.content)
-        return pkg
-
-    def get_package_list_from_repodata(repodata_dir: Path):
-        assert repodata_dir.exists()
-        primary_xml_file = next(repodata_dir.glob("*primary.xml*"))
-        result_repo = cr.RepositoryReader.from_metadata_files(str(primary_xml_file), None, None)
-        parsed = result_repo.parse_packages(only_primary=True)[0]  # {<checksum>: <cr.Package>}
-        return list(parsed.values())
-
-    # Setup repository packages layout
-    BEAR_FILENAME = "bear-4.1-1.noarch.rpm"
-    BEAR_RELATIVE_PATH = f"bear/{BEAR_FILENAME}"
-    CAMEL_FILENAME = "camel-0.1-1.noarch.rpm"
-    CAMEL_RELATIVE_PATH = f"camel/{BEAR_FILENAME}"  # yes, we're faking the filename
-
-    bear_rpm = download_fixture(BEAR_FILENAME, to_relative_path=BEAR_RELATIVE_PATH)
-    camel_rpm = download_fixture(CAMEL_FILENAME, to_relative_path=CAMEL_RELATIVE_PATH)
-    bear_pkg = cr.package_from_rpm(str(bear_rpm), location_href=BEAR_RELATIVE_PATH)
-    camel_pkg = cr.package_from_rpm(str(camel_rpm), location_href=CAMEL_RELATIVE_PATH)
-    BEAR_NAME = bear_pkg.name
-    CAMEL_NAME = camel_pkg.name
-
-    # Create repository with messed location_hrefs
-    with cr.RepositoryWriter(str(REPODIR), compression=cr.NO_COMPRESSION) as writer:
-        writer.set_num_of_pkgs(2)
-        writer.add_pkg(bear_pkg)
-        writer.add_pkg(camel_pkg)
-
-    # Assert it's what we expect
-    repodata_dir = REPODIR / "repodata"
-    packages_from_repodata = get_package_list_from_repodata(repodata_dir)
-    name_location_pkg_map = [(p.name, p.location_href) for p in packages_from_repodata]
-
-    assert (BEAR_NAME, BEAR_RELATIVE_PATH) in name_location_pkg_map
-    assert (CAMEL_NAME, CAMEL_RELATIVE_PATH) in name_location_pkg_map
-    return f"file://{REPODIR.absolute()}"
-
-
-def test_repo_4073(repo_4073_url):
-    assert repo_4073_url
-
-
 def test_repo_with_different_nevra_same_location_href(
-    repo_4073_url,
-    rpm_repository_factory,
-    rpm_rpmremote_factory,
+    repository_builder: RepositoryBuilder,
+    package_listing: PackageListFetcher,
     init_and_sync,
-    rpm_publication_factory,
     rpm_distribution_factory,
-    rpm_package_api,
-    distribution_base_url,
-    delete_orphans_pre,
+    rpm_publication_factory,
 ):
-    """Test syncing repository with packages having different NEVRA and same relative_path."""
+    """Test that Pulp normalizes location_href to match the package's NVRA.
 
-    # utils
-    def get_packages_in(repository) -> list[str]:
-        packages = rpm_package_api.list(repository_version=repository.latest_version_href)
-        package_name_location_href = [(pkg.name, pkg.location_href) for pkg in packages.results]
-        return package_name_location_href
+    The remote repo stores packages with mismatched filenames in location_href.
+    """
+    # given an upstream repository with bad metadata
+    nevra_1 = MetaPackage.generate_nevra(1)
+    nevra_2 = MetaPackage.generate_nevra(2)
+    common_filename = f"{nevra_1.to_nvra()}.rpm"
+    common_build_time = 1
+    pkg_1 = MetaPackage(
+        nevra=nevra_1,
+        digest=MetaPackage.generate_digest(1),
+        time_build=common_build_time,
+        location="aaa/{filename}".format(filename=common_filename),
+    )
+    pkg_2 = MetaPackage(
+        nevra=nevra_2,
+        digest=MetaPackage.generate_digest(2),
+        time_build=common_build_time,
+        location="bbb/{filename}".format(filename=common_filename),
+    )
 
-    def is_pkg_in_(distribution, pkg_relative_path) -> bool:
-        base_url = distribution_base_url(distribution.base_url)
-        pkg_url = urljoin(base_url, pkg_relative_path)
-        response = requests.get(pkg_url)
-        return response.status_code == 200
+    # when we do a sync, distribute and publish
+    remote_repo = repository_builder.build(packages=[pkg_1, pkg_2])
+    repository, _ = init_and_sync(
+        url=remote_repo.url, policy="on_demand", sync_policy="mirror_content_only"
+    )
+    publication = rpm_publication_factory(repository=repository.pulp_href)
+    distribution = rpm_distribution_factory(publication=publication.pulp_href)
 
-    # when
-    REMOTE_URL = repo_4073_url
-    SYNC_POLICY = "mirror_content_only"
-    repository, _ = init_and_sync(url=REMOTE_URL, sync_policy=SYNC_POLICY)
-    rpm_publication_factory(repository=repository.pulp_href)
-    distribution = rpm_distribution_factory(repository=repository.pulp_href)
+    # then both pacakges should be present on repoversion
+    repover_packages = package_listing.from_pulp_repoversion(repository.latest_version_href)
+    assert normalized_location(pkg_1, prefix=False) in repover_packages
+    assert normalized_location(pkg_2, prefix=False) in repover_packages
 
-    # then
-    package_name_location_href = get_packages_in(repository)
-    assert ("bear", "bear-4.1-1.noarch.rpm") in package_name_location_href
-    assert ("camel", "camel-0.1-1.noarch.rpm") in package_name_location_href
-
-    assert is_pkg_in_(distribution, "Packages/b/bear-4.1-1.noarch.rpm") is True
-    assert is_pkg_in_(distribution, "Packages/c/camel-0.1-1.noarch.rpm") is True
+    # and on published metadata
+    metadata_packages = package_listing.from_repository_metadata(url=distribution.base_url)
+    assert normalized_location(pkg_1) in metadata_packages
+    assert normalized_location(pkg_2) in metadata_packages

--- a/pulp_rpm/tests/functional/api/test_utils.py
+++ b/pulp_rpm/tests/functional/api/test_utils.py
@@ -1,0 +1,85 @@
+"""Tests for test utility classes (RepositoryBuilder, PackageListFetcher, etc.)."""
+
+from pulp_rpm.tests.functional.utils import (
+    MetaPackage,
+    PackageListFetcher,
+    RepositoryBuilder,
+    normalized_location,
+)
+
+
+def test_repository_builder(
+    repository_builder: RepositoryBuilder, package_listing: PackageListFetcher
+):
+    """RepositoryBuilder produces a valid local repo that PackageListFetcher can parse."""
+    pkg = MetaPackage(
+        nevra=MetaPackage.generate_nevra(1),
+        digest=MetaPackage.generate_digest(1),
+        time_build=1,
+        location="pkg1-1.0-1.noarch.rpm",
+    )
+    remote_repo = repository_builder.build(packages=[pkg])
+    entries = package_listing.from_repository_metadata(url=remote_repo.url).filter(
+        name=pkg.nevra.name
+    )
+    assert len(entries) == 1
+    assert entries[0].digest == pkg.digest
+
+
+def test_repository_builder_multiple_packages(
+    repository_builder: RepositoryBuilder, package_listing: PackageListFetcher
+):
+    """All packages added to RepositoryBuilder are discoverable in the resulting repo."""
+    pkgs = [
+        MetaPackage(
+            nevra=MetaPackage.generate_nevra(i),
+            digest=MetaPackage.generate_digest(i),
+            time_build=i,
+            location=f"pkg{i}-{i}.0-{i}.noarch.rpm",
+        )
+        for i in range(1, 4)
+    ]
+    remote_repo = repository_builder.build(packages=pkgs)
+    all_entries = package_listing.from_repository_metadata(url=remote_repo.url)
+    found_digests = {e.digest for e in all_entries}
+    assert {p.digest for p in pkgs} == found_digests
+
+
+def test_package_list_filter_is_exclusive(
+    repository_builder: RepositoryBuilder, package_listing: PackageListFetcher
+):
+    """PackageList.filter returns only packages with the requested name."""
+    pkg_a = MetaPackage(
+        nevra=MetaPackage.generate_nevra(1),
+        digest=MetaPackage.generate_digest(1),
+        time_build=1,
+        location="a-1.0-1.noarch.rpm",
+    )
+    pkg_b = MetaPackage(
+        nevra=MetaPackage.generate_nevra(2),
+        digest=MetaPackage.generate_digest(2),
+        time_build=2,
+        location="b-2.0-2.noarch.rpm",
+    )
+    remote_repo = repository_builder.build(packages=[pkg_a, pkg_b])
+    entries = package_listing.from_repository_metadata(url=remote_repo.url)
+
+    assert len(entries.filter(name=pkg_a.nevra.name)) == 1
+    assert len(entries.filter(name="nonexistent")) == 0
+
+
+def test_normalized_location():
+    """normalized_location produces the canonical Packages/<initial>/<nvra>.rpm path."""
+    pkg = MetaPackage(
+        nevra=MetaPackage.generate_nevra(1),
+        digest=MetaPackage.generate_digest(1),
+        time_build=1,
+        location="original-location.rpm",
+    )
+    nvra = pkg.nevra.to_nvra()
+
+    with_prefix = normalized_location(pkg, prefix=True)
+    assert with_prefix.location == f"Packages/{pkg.nevra.name[0]}/{nvra}.rpm"
+
+    without_prefix = normalized_location(pkg, prefix=False)
+    assert without_prefix.location == f"{nvra}.rpm"

--- a/pulp_rpm/tests/functional/conftest.py
+++ b/pulp_rpm/tests/functional/conftest.py
@@ -32,7 +32,11 @@ from pulp_rpm.tests.functional.constants import (
     RPM_SIGNED_FIXTURE_URL,
     RPM_SIGNED_URL,
 )
-from pulp_rpm.tests.functional.utils import init_signed_repo_configuration
+from pulp_rpm.tests.functional.utils import (
+    init_signed_repo_configuration,
+    PackageListFetcher,
+    RepositoryBuilder,
+)
 
 
 @pytest.fixture(scope="session")
@@ -51,6 +55,17 @@ def rpm_acs_api(rpm_client):
 def rpm_package_api(rpm_client):
     """Fixture for RPM distribution API."""
     return ContentPackagesApi(rpm_client)
+
+
+@pytest.fixture
+def package_listing(rpm_package_api):
+    """Fixture returning a PackageListFetcher with access to the packages API."""
+    return PackageListFetcher(rpm_package_api=rpm_package_api)
+
+
+@pytest.fixture
+def repository_builder(tmp_path):
+    return RepositoryBuilder(tmp_path=tmp_path)
 
 
 @pytest.fixture(scope="session")

--- a/pulp_rpm/tests/functional/utils.py
+++ b/pulp_rpm/tests/functional/utils.py
@@ -1,15 +1,26 @@
 """Utilities for tests for the rpm plugin."""
 
 import gzip
+import hashlib
 import os
 import subprocess
+import tempfile
+import xml.etree.ElementTree as ET
+import uuid
+import dataclasses
+from dataclasses import dataclass
+from pathlib import Path
+from typing import NamedTuple
+from typing import Optional
 
+import createrepo_c as cr
 import pyzstd
 import requests
 
 from pulp_rpm.tests.functional.constants import (
     PRIVATE_GPG_KEY_URL,
     PACKAGES_DIRECTORY,
+    RPM_NAMESPACES,
 )
 
 
@@ -83,3 +94,195 @@ def download_and_decompress_file(url):
     else:
         # FIXME: fix this as in CI primary/update_info.xml has '.gz' but it is not gzipped
         return resp.content
+
+
+def get_metadata_content_helper(base_url, repomd_elem, meta_type):
+    """Return the decompressed bytes of a named metadata file from a parsed repomd element.
+
+    Don't use this with large repos because it will blow up.
+    """
+    xpath_data = "{{{}}}data".format(RPM_NAMESPACES["metadata/repo"])
+    data_elems = [e for e in repomd_elem.findall(xpath_data) if e.get("type") == meta_type]
+    if not data_elems:
+        return None
+
+    xpath_location = "{{{}}}location".format(RPM_NAMESPACES["metadata/repo"])
+    location_href = data_elems[0].find(xpath_location).get("href")
+
+    return download_and_decompress_file(os.path.join(base_url, location_href))
+
+
+class Nevra(NamedTuple):
+    name: str
+    epoch: str
+    version: str
+    release: str
+    arch: str
+
+    def to_nvra(self) -> str:
+        return f"{self.name}-{self.version}-{self.release}.{self.arch}"
+
+
+SALT = uuid.uuid4().hex
+
+
+@dataclass
+class MetaPackage:
+    """Simplified package representation."""
+
+    nevra: Nevra
+    digest: str
+    time_build: int
+    location: str
+
+    @classmethod
+    def generate_nevra(cls, n: int) -> Nevra:
+        return Nevra(
+            name=f"pkg{n}-{SALT[:8]}",
+            epoch="0",
+            version=f"{n}.0",
+            release=f"{n}",
+            arch="noarch",
+        )
+
+    @classmethod
+    def generate_digest(cls, n: int) -> str:
+        return hashlib.sha256(f"digest-{SALT}-{n}".encode()).hexdigest()
+
+
+def normalized_location(pkg: MetaPackage, prefix: bool = True) -> MetaPackage:
+    """Return a copy of pkg with location set to the canonical NVRA filename."""
+    filename = f"{pkg.nevra.to_nvra()}.rpm"
+    if prefix:
+        filename = f"Packages/{pkg.nevra.name[0]}/{filename}"
+    return dataclasses.replace(pkg, location=filename)
+
+
+@dataclass
+class RemoteRepository:
+    url: str
+
+
+class PackageList(list[MetaPackage]):
+    """Parsed package list from an RPM repository. Behaves as a list of MetaPackage."""
+
+    def filter(self, name: str) -> "PackageList":
+        return PackageList(p for p in self if p.nevra.name == name)
+
+
+class PackageListFetcher:
+    """Builds PackageList instances; wires in the packages API for Pulp-side queries."""
+
+    def __init__(self, rpm_package_api):
+        self._rpm_package_api = rpm_package_api
+
+    def from_repository_metadata(self, url: str) -> PackageList:
+        """Build from a file:// or http(s):// URL pointing to an RPM repository."""
+        if url.startswith("file://"):
+            repodata = Path(url[len("file://") :]) / "repodata"
+            primary = next(repodata.glob("*primary.xml*"))
+            return self._from_path(str(primary))
+        return self._from_http_url(url)
+
+    def from_pulp_repoversion(self, repoversion_href: str) -> PackageList:
+        """Build from a Pulp repository version using the packages API."""
+        response = self._rpm_package_api.list(repository_version=repoversion_href, limit=1000)
+        packages = [
+            MetaPackage(
+                nevra=Nevra(
+                    name=pkg.name,
+                    epoch=pkg.epoch,
+                    version=pkg.version,
+                    release=pkg.release,
+                    arch=pkg.arch,
+                ),
+                digest=pkg.pkg_id,
+                time_build=pkg.time_build,
+                location=pkg.location_href,
+            )
+            for pkg in response.results
+        ]
+        return PackageList(packages)
+
+    @staticmethod
+    def _from_path(path: str) -> PackageList:
+        reader = cr.RepositoryReader.from_metadata_files(path, None, None)
+        packages_dict = reader.parse_packages(only_primary=True)[0]
+        entries = [
+            MetaPackage(
+                nevra=Nevra(
+                    name=p.name,
+                    epoch=p.epoch,
+                    version=p.version,
+                    release=p.release,
+                    arch=p.arch,
+                ),
+                digest=p.pkgId,
+                time_build=p.time_build,
+                location=p.location_href,
+            )
+            for p in packages_dict.values()
+        ]
+        return PackageList(entries)
+
+    @staticmethod
+    def _from_http_url(base_url: str) -> PackageList:
+        repomd_url = base_url.rstrip("/") + "/repodata/repomd.xml"
+        repomd = ET.fromstring(requests.get(repomd_url).content)
+        content = get_metadata_content_helper(base_url, repomd, "primary")
+        assert content is not None, "No primary metadata found in repomd.xml"
+        with tempfile.NamedTemporaryFile(suffix=".xml", delete=False) as f:
+            f.write(content)
+            tmp = f.name
+        try:
+            return PackageListFetcher._from_path(tmp)
+        finally:
+            os.unlink(tmp)
+
+
+class RepositoryBuilder:
+    """Builds local RPM repositories from MetaPackage entries using createrepo_c."""
+
+    def __init__(self, tmp_path: Path):
+        self._tmp_path = tmp_path
+
+    def build(
+        self, packages: list[MetaPackage], base_path: Optional[str] = None
+    ) -> RemoteRepository:
+        base_path = base_path or str(uuid.uuid4())
+        repo_dir = self._tmp_path / base_path
+        repo_dir.mkdir(parents=True, exist_ok=True)
+
+        cr_packages = []
+        for pkg in packages:
+            cr_pkg = cr.Package()
+            cr_pkg.name = pkg.nevra.name
+            cr_pkg.arch = pkg.nevra.arch
+            cr_pkg.epoch = pkg.nevra.epoch
+            cr_pkg.version = pkg.nevra.version
+            cr_pkg.release = pkg.nevra.release
+            cr_pkg.pkgId = pkg.digest
+            cr_pkg.checksum_type = "sha256"
+            cr_pkg.location_href = pkg.location
+            cr_pkg.summary = f"Headless package {pkg.nevra.name}"
+            cr_pkg.description = ""
+            cr_pkg.size_package = 0
+            cr_pkg.size_installed = 0
+            cr_pkg.size_archive = 0
+            cr_pkg.time_file = 0
+            cr_pkg.time_build = pkg.time_build
+            cr_pkg.rpm_header_start = 0
+            cr_pkg.rpm_header_end = 0
+            cr_pkg.rpm_license = ""
+            cr_pkg.rpm_vendor = ""
+            cr_pkg.rpm_group = ""
+            cr_pkg.rpm_buildhost = ""
+            cr_pkg.rpm_sourcerpm = ""
+            cr_packages.append(cr_pkg)
+
+        with cr.RepositoryWriter(str(repo_dir), compression=cr.NO_COMPRESSION) as writer:
+            writer.set_num_of_pkgs(len(cr_packages))
+            for cr_pkg in cr_packages:
+                writer.add_pkg(cr_pkg)
+
+        return RemoteRepository(url=f"file://{repo_dir.absolute()}")


### PR DESCRIPTION
When two packages shared the same NEVRA and identical build times but different checksums, both would pass the sync filter and be added to the repository version. Introduce a sentinel marker so the first-seen package wins deterministically, guaranteeing at most one package per NEVRA enters the pipeline.

Closes: #4341
Closes: #4240 

## Backports

#4426 (3.35)
#4427 (3.32)
#4428 (3.29)
#4430 (3.27)
#4431 (3.26)
