### PR TITLE
[backport/3.27][#4070] Always use "{NVRA}.rpm" for location_href and publications

### DIFF
--- a/CHANGES/4073.bugfix
+++ b/CHANGES/4073.bugfix
@@ -1,0 +1,7 @@
+Fixed a bug where syncing from a remote repository with duplicate filenames and different paths
+would result in one of these packages being missing from a Pulp distribution.
+This is known to happen in some JFrog repositories.
+
+On systems that have synced from such repositories before, it is required to clean up the related
+packages with orphan cleanup or use the provided "pulpcore-manager rpm-datarepair 4073",
+which forces internal objects to use non-ambiguous filenames.

--- a/pulp_rpm/app/management/commands/rpm-datarepair.py
+++ b/pulp_rpm/app/management/commands/rpm-datarepair.py
@@ -3,9 +3,12 @@ from gettext import gettext as _
 
 from django.core.management import BaseCommand, CommandError
 
+from django.db.models import F, Value
+from django.db.models.functions import Concat
 from pulp_rpm.app.models import Package  # noqa
 from pulp_rpm.app.models.advisory import UpdateCollection, UpdateRecord  # noqa
 from pulp_rpm.app.models.repository import RpmRepository  # noqa
+from pulpcore.plugin.models import ContentArtifact
 
 
 def raise_if_dry_run(issue, dry_run):
@@ -40,6 +43,8 @@ class Command(BaseCommand):
             self.repair_3127(dry_run)
         elif issue == "4007":
             self.repair_4007(dry_run)
+        elif issue == "4073":
+            self.repair_4073(dry_run)
         else:
             raise CommandError(_("Unknown issue: '{}'").format(issue))
 
@@ -82,3 +87,60 @@ class Command(BaseCommand):
             self.stdout.write(f"Fixed {count} repositories with empty package_signing_fingerprint.")
         else:
             self.stdout.write(f"{count} repositories have an empty package_signing_fingerprint.")
+
+    def repair_4073(self, dry_run):
+        """Perform data repair for issue #4073.
+
+        For each updated ContentArtifact, print:
+            {ca.pkg_uuid} {ca_uuid} {old_relpath} {new_relpath}
+        """
+        raise_if_dry_run("4073", dry_run)
+        update_count = 0
+        batch = []
+        batch_msgs = []
+
+        def process_batch():
+            nonlocal update_count, batch, batch_msgs
+            ContentArtifact.objects.bulk_update(batch, fields=["relative_path"])
+            for msg in batch_msgs:
+                self.stdout.write(msg)
+            self.stdout.flush()
+            update_count += len(batch)
+            batch.clear()
+            batch_msgs.clear()
+
+        def add_to_batch(ca, pkg):
+            original_relpath = ca.relative_path
+            ca.relative_path = pkg.filename
+            batch.append(ca)
+            batch_msgs.append(
+                UPDATE_MSG.format(
+                    pkg_uuid=str(pkg.pk),
+                    ca_uuid=str(ca.pk),
+                    old_relpath=original_relpath,
+                    new_relpath=ca.relative_path,
+                )
+            )
+
+        bad_packages = Package.objects.annotate(
+            computed_filename=Concat(
+                F("name"),
+                Value("-"),
+                F("version"),
+                Value("-"),
+                F("release"),
+                Value("."),
+                F("arch"),
+                Value(".rpm"),
+            )
+        ).exclude(location_href__endswith=F("computed_filename"))
+
+        UPDATE_MSG = "{pkg_uuid!r} {ca_uuid!r} {old_relpath!r} {new_relpath!r}"
+        for pkg in bad_packages.iterator():
+            for ca in pkg.contentartifact_set.exclude(relative_path=pkg.filename):
+                add_to_batch(ca, pkg)
+                if len(batch) > 500:
+                    process_batch()
+        if batch:  # handle remaining
+            process_batch()
+        self.stdout.write(f"Updated {update_count} records")

--- a/pulp_rpm/app/tasks/publishing.py
+++ b/pulp_rpm/app/tasks/publishing.py
@@ -577,7 +577,7 @@ def generate_repo_metadata(
         pkg.checksum_type = checksum
         pkg.pkgId = pkgId
 
-        pkg_filename = os.path.basename(package.location_href)
+        pkg_filename = package.filename
         # this can cause an issue when two same RPM package names appears
         # a/name1.rpm b/name1.rpm
         pkg.location_href = os.path.join(PACKAGES_DIRECTORY, pkg_filename[0].lower(), pkg_filename)

--- a/pulp_rpm/app/tasks/synchronizing.py
+++ b/pulp_rpm/app/tasks/synchronizing.py
@@ -1402,15 +1402,21 @@ class RpmFirstStage(Stage):
                 last_seen_package_name = pkg.name
                 del pkg  # delete it as soon as we're done with it
 
-                store_package_for_mirroring(self.repository, package.pkgId, package.location_href)
+                # Location_href is not a property of the Package in isolation [0], and Pulp has
+                # a well defined way of generating the layout/locations on publication time.
+                # We only need to use the original location_href for metadata mirroring
+                # [0] https://github.com/pulp/pulp_rpm/issues/2580
+                original_location_href = package.location_href
+                package.location_href = package.filename
+                store_package_for_mirroring(self.repository, package.pkgId, original_location_href)
+
                 artifact = Artifact(size=package.size_package)
                 checksum_type = getattr(CHECKSUM_TYPES, package.checksum_type.upper())
                 setattr(artifact, checksum_type, package.pkgId)
-                filename = os.path.basename(package.location_href)
                 da = DeclarativeArtifact(
                     artifact=artifact,
                     url=url,
-                    relative_path=filename,
+                    relative_path=package.location_href,
                     remote=self.remote,
                     deferred_download=self.deferred_download,
                 )

--- a/pulp_rpm/tests/functional/api/test_sync.py
+++ b/pulp_rpm/tests/functional/api/test_sync.py
@@ -3,10 +3,13 @@
 import pytest
 from random import choice
 
+from urllib.parse import urljoin
 import dictdiffer
 import requests
+from pathlib import Path
 from django.conf import settings
 from django.utils.dateparse import parse_datetime
+import createrepo_c as cr
 
 from pulpcore.tests.functional.utils import PulpTaskError
 from pulp_smash.pulp3.utils import (
@@ -1150,3 +1153,102 @@ def test_config_repo_mirror_sync(
     assert bytes(f"baseurl={distribution.base_url}\n", "utf-8") in content
     assert bytes("gpgcheck=1\n", "utf-8") in content
     assert bytes("repo_gpgcheck=0", "utf-8") in content
+
+
+@pytest.fixture
+def repo_4073_url(
+    tmp_path,
+    rpm_repository_factory,
+    rpm_rpmremote_factory,
+    rpm_publication_factory,
+    rpm_distribution_factory,
+    init_and_sync,
+):
+    REPODIR = tmp_path / "repo_4073"
+
+    def download_fixture(fixture_name: str, to_relative_path: str) -> Path:
+        url = urljoin(RPM_UNSIGNED_FIXTURE_URL, fixture_name)
+        response = requests.get(url)
+        response.raise_for_status()
+        pkg = REPODIR / to_relative_path
+        pkg.parent.mkdir(parents=True, exist_ok=True)
+        pkg.write_bytes(response.content)
+        return pkg
+
+    def get_package_list_from_repodata(repodata_dir: Path):
+        assert repodata_dir.exists()
+        primary_xml_file = next(repodata_dir.glob("*primary.xml*"))
+        result_repo = cr.RepositoryReader.from_metadata_files(str(primary_xml_file), None, None)
+        parsed = result_repo.parse_packages(only_primary=True)[0]  # {<checksum>: <cr.Package>}
+        return list(parsed.values())
+
+    # Setup repository packages layout
+    BEAR_FILENAME = "bear-4.1-1.noarch.rpm"
+    BEAR_RELATIVE_PATH = f"bear/{BEAR_FILENAME}"
+    CAMEL_FILENAME = "camel-0.1-1.noarch.rpm"
+    CAMEL_RELATIVE_PATH = f"camel/{BEAR_FILENAME}"  # yes, we're faking the filename
+
+    bear_rpm = download_fixture(BEAR_FILENAME, to_relative_path=BEAR_RELATIVE_PATH)
+    camel_rpm = download_fixture(CAMEL_FILENAME, to_relative_path=CAMEL_RELATIVE_PATH)
+    bear_pkg = cr.package_from_rpm(str(bear_rpm), location_href=BEAR_RELATIVE_PATH)
+    camel_pkg = cr.package_from_rpm(str(camel_rpm), location_href=CAMEL_RELATIVE_PATH)
+    BEAR_NAME = bear_pkg.name
+    CAMEL_NAME = camel_pkg.name
+
+    # Create repository with messed location_hrefs
+    with cr.RepositoryWriter(str(REPODIR), compression=cr.NO_COMPRESSION) as writer:
+        writer.set_num_of_pkgs(2)
+        writer.add_pkg(bear_pkg)
+        writer.add_pkg(camel_pkg)
+
+    # Assert it's what we expect
+    repodata_dir = REPODIR / "repodata"
+    packages_from_repodata = get_package_list_from_repodata(repodata_dir)
+    name_location_pkg_map = [(p.name, p.location_href) for p in packages_from_repodata]
+
+    assert (BEAR_NAME, BEAR_RELATIVE_PATH) in name_location_pkg_map
+    assert (CAMEL_NAME, CAMEL_RELATIVE_PATH) in name_location_pkg_map
+    return f"file://{REPODIR.absolute()}"
+
+
+def test_repo_4073(repo_4073_url):
+    assert repo_4073_url
+
+
+def test_repo_with_different_nevra_same_location_href(
+    repo_4073_url,
+    rpm_repository_factory,
+    rpm_rpmremote_factory,
+    init_and_sync,
+    rpm_publication_factory,
+    rpm_distribution_factory,
+    rpm_package_api,
+    delete_orphans_pre,
+):
+    """Test syncing repository with packages having different NEVRA and same relative_path."""
+
+    # utils
+    def get_packages_in(repository) -> list[str]:
+        packages = rpm_package_api.list(repository_version=repository.latest_version_href)
+        package_name_location_href = [(pkg.name, pkg.location_href) for pkg in packages.results]
+        return package_name_location_href
+
+    def is_pkg_in_(distribution, pkg_relative_path) -> bool:
+        pkg_url = urljoin(distribution.base_url, pkg_relative_path)
+        response = requests.get(pkg_url)
+        return response.status_code == 200
+
+    # when
+    REMOTE_URL = repo_4073_url
+    SYNC_POLICY = "mirror_content_only"
+    repository, _ = init_and_sync(url=REMOTE_URL, sync_policy=SYNC_POLICY)
+    rpm_publication_factory(repository=repository.pulp_href)
+    distribution = rpm_distribution_factory(repository=repository.pulp_href)
+
+    # then
+    package_name_location_href = get_packages_in(repository)
+    assert ("bear", "bear-4.1-1.noarch.rpm") in package_name_location_href
+    assert ("camel", "camel-0.1-1.noarch.rpm") in package_name_location_href
+
+    assert is_pkg_in_(distribution, "Packages/b/bear-4.1-1.noarch.rpm") is True
+    assert is_pkg_in_(distribution, "Packages/c/camel-0.1-1.noarch.rpm") is True


### PR DESCRIPTION
Backported from PR: #4070

Some remote repositories use arbitrary path+filenames for their packages, which collides with how Pulp handles that. To avoid bugs caused by that, we force the filename to be dervied from NVRA, which makes the publication metadata and package listing unambigous.

On the sync task, Package now uses Package.filename as it's location_href. On publication task, the Package.filename is used to the loation href on the primary.xml metadata.

* Data Repair: On systems that had synced 'bad' repositories before (and maybe didn't realize it), the new changes will only fix the problem if this repository and its packages are cleaned up from Pulp.

This add an rpm-datarepair command that makes it possible to fix the sytem with a re-publish of the repository.

Closes: #4073
(cherry picked from commit 0067439a45b7ece39d658dea21c835aed2a69b46)

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
