### PR TITLE
Remove the rest of the nested_by_both layout support

### DIFF
--- a/pulp_rpm/app/constants.py
+++ b/pulp_rpm/app/constants.py
@@ -19,7 +19,6 @@ LAYOUT_TYPES = SimpleNamespace(
     NESTED_ALPHABETICALLY="nested_alphabetically",
     FLAT="flat",
     NESTED_BY_DIGEST="nested_by_digest",
-    NESTED_BY_BOTH="nested_by_both",  # DEPRECATED
 )
 
 LAYOUT_CHOICES = (

--- a/pulp_rpm/app/tasks/publishing.py
+++ b/pulp_rpm/app/tasks/publishing.py
@@ -94,10 +94,8 @@ class _CollisionManager:
     """Helper to collect the "winning" packages when there are collisions on NEVRA or URL path."""
 
     def __init__(self) -> None:
-        self.cid_to_second_path: dict[UUID, str] = {}
         self._nevra_to_pkg: dict[str, PkgBuild] = {}
         self._path_to_pkg: dict[str, PkgBuild] = {}
-        self._second_path_to_pkg: dict[str, PkgBuild] = {}
         self._banned_cids: set[UUID] = set()
 
     def _pkg_to_ignore(
@@ -117,7 +115,7 @@ class _CollisionManager:
             return new
         return old
 
-    def add(self, pkg: PkgBuild, nevra: str, path: str, second_path: str | None) -> None:
+    def add(self, pkg: PkgBuild, nevra: str, path: str) -> None:
         """
         Add a package build to the collision manager. Ignore it if it is "worse" than an existing
         package that collides on nevra or path. If it's "better" and collides, mark the older one as
@@ -127,11 +125,6 @@ class _CollisionManager:
             pkg (PkgBuild): Information about the package build we're adding.
             nevra (str): NEVRA of the package. Checked for collisions in repo metadata.
             path (str): URL path of the package. Checked for collisions in published artifact URLs.
-            second_path (str | None):
-                An optional secondary URL path of the package. Only will exist in the nested_by_both
-                case. Checked for collisions like `path`, except collisions here only prevent the
-                "worse" package from being published at this secondary path, not from being
-                published at in general.
         """
         # If there is a collision on nevra or path, ignore the older package
         to_ignore_nevra = self._pkg_to_ignore(pkg, self._nevra_to_pkg, nevra)
@@ -147,22 +140,8 @@ class _CollisionManager:
         # We have record cids that were once added but later ignored; we don't know all its keys.
         if to_ignore_nevra:
             self._banned_cids.add(to_ignore_nevra.cid)
-            self.cid_to_second_path.pop(to_ignore_nevra.cid, None)
         if to_ignore_path:
             self._banned_cids.add(to_ignore_path.cid)
-            self.cid_to_second_path.pop(to_ignore_path.cid, None)
-
-        # In the nested_by_both case we may have a package that should be published in general, but
-        # collides on the alphabetical path and should be ignored for that path only.
-        if second_path:
-            to_ignore = self._pkg_to_ignore(pkg, self._second_path_to_pkg, second_path)
-            if to_ignore == pkg:
-                return
-            elif to_ignore:
-                self.cid_to_second_path.pop(to_ignore.cid, None)
-
-            self._second_path_to_pkg[second_path] = pkg
-            self.cid_to_second_path[pkg.cid] = second_path
 
     def retained_cids(self) -> list[UUID]:
         """
@@ -250,7 +229,6 @@ class PublicationData:
            1. "flat": "Packages/xxx.rpm"
            2. "nested_alphabetically": "Packages/f/filename.rpm"   - The "canonical" repo format.
            3. "nested_by_digest": "Packages/f/by-digest/xxxxxx-filename.rpm"
-           4. "nested_by_both": Both 2 and 3. Each rpm will result in 2 PublishedArtifacts.
 
         2. Handle "duplicate" packages.
 
@@ -396,23 +374,19 @@ class PublicationData:
 
             # Third, compute the path based on layout
             pkg_filename = os.path.basename(row["relative_path"])
-            second_path = None
             if layout == LAYOUT_TYPES.NESTED_ALPHABETICALLY:
                 path = nested_alphabetically_path(pkg_filename)
             elif layout == LAYOUT_TYPES.FLAT:
                 path = flat_path(pkg_filename)
             elif layout == LAYOUT_TYPES.NESTED_BY_DIGEST:
                 path = nested_by_digest_path(pkg_filename, checksum)
-            elif layout == LAYOUT_TYPES.NESTED_BY_BOTH:
-                path = nested_by_digest_path(pkg_filename, checksum)
-                second_path = nested_alphabetically_path(pkg_filename)
             else:
                 raise ValueError(f"Layout value {layout} is unsupported by this version")
 
             pkg_info = PackageInfo(
                 caid=caid, path=path, checksum_type=checksum_type, checksum=checksum
             )
-            collision_manager.add(pkg_build, nevra, path, second_path)
+            collision_manager.add(pkg_build, nevra, path)
             cid_to_pkginfo[cid] = pkg_info
 
         # Filter cid_to_pkginfo to only the retained packages
@@ -428,15 +402,6 @@ class PublicationData:
                     content_artifact_id=pkg_info.caid,
                 )
             )
-            if second_path := collision_manager.cid_to_second_path.get(cid, None):
-                # also add the nested_alphabetically path
-                published_artifacts.append(
-                    PublishedArtifact(
-                        relative_path=os.path.join(prefix, second_path),
-                        publication=self.publication,
-                        content_artifact_id=pkg_info.caid,
-                    )
-                )
 
         # Handle the non-packages
         is_treeinfo = Q(relative_path__in=["treeinfo", ".treeinfo"])

--- a/pulp_rpm/tests/unit/test_publishing.py
+++ b/pulp_rpm/tests/unit/test_publishing.py
@@ -17,33 +17,16 @@ class TestPublishing(TestCase):
 
         # Test that collisions on nevra or path are checking epoch correctly.
         cm = _CollisionManager()
-        cm.add(mid_epoch, "nevra", "path", None)
-        cm.add(low_epoch, "nevra", "path2", None)
+        cm.add(mid_epoch, "nevra", "path")
+        cm.add(low_epoch, "nevra", "path2")
         self.assertEqual([mid_epoch.cid], cm.retained_cids())
-        cm.add(high_epoch, "nevra2", "path", None)
+        cm.add(high_epoch, "nevra2", "path")
         self.assertEqual([high_epoch.cid], cm.retained_cids())
 
         # Test that collisions on nevra or path are checking build_time correctly.
         cm = _CollisionManager()
-        cm.add(mid_build_time, "nevra", "path", None)
-        cm.add(low_build_time, "nevra", "path2", None)
+        cm.add(mid_build_time, "nevra", "path")
+        cm.add(low_build_time, "nevra", "path2")
         self.assertEqual([mid_build_time.cid], cm.retained_cids())
-        cm.add(high_build_time, "nevra2", "path", None)
+        cm.add(high_build_time, "nevra2", "path")
         self.assertEqual([high_build_time.cid], cm.retained_cids())
-
-        # Test that collisions on 2nd_path are being handled correctly.
-        cm = _CollisionManager()
-        cm.add(mid_build_time, "nevra", "path", "second_path")
-        cm.add(low_build_time, "nevra2", "path2", "second_path")
-        self.assertEqual({mid_build_time.cid, low_build_time.cid}, set(cm.retained_cids()))
-        self.assertIn(mid_build_time.cid, cm.cid_to_second_path)
-        self.assertEqual(cm.cid_to_second_path[mid_build_time.cid], "second_path")
-        self.assertNotIn(low_build_time.cid, cm.cid_to_second_path)
-
-        cm.add(high_build_time, "nevra3", "path3", "second_path")
-        self.assertEqual(
-            {mid_build_time.cid, low_build_time.cid, high_build_time.cid}, set(cm.retained_cids())
-        )
-        self.assertIn(high_build_time.cid, cm.cid_to_second_path)
-        self.assertEqual(cm.cid_to_second_path[high_build_time.cid], "second_path")
-        self.assertNotIn(mid_build_time.cid, cm.cid_to_second_path)


### PR DESCRIPTION
Finish removing the leftovers kept for ZDU reasons

re #4358

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
