### PR TITLE
Another attempt at fixing the evr_t extension

### DIFF
--- a/CHANGES/+new-evr-t-v2.misc
+++ b/CHANGES/+new-evr-t-v2.misc
@@ -1,0 +1,1 @@
+Package EVR sorting is now once again based on a special database type / field / function. evr_t_v2 correctly handles tilde and caret operator sorting and is faster than the original.

--- a/pulp_rpm/app/migrations/0001_squashed_0062_rpmpackagesigningservice_and_more.py
+++ b/pulp_rpm/app/migrations/0001_squashed_0062_rpmpackagesigningservice_and_more.py
@@ -510,10 +510,19 @@ class Migration(migrations.Migration):
         migrations.RunSQL(
             sql='\n-- create pulp_evr_t on insert, so it matches the provided E/V/R cols\nCREATE TRIGGER pulp_evr_insert_trigger\n  BEFORE INSERT\n  ON rpm_package\n  FOR EACH ROW\n  EXECUTE PROCEDURE pulp_evr_trigger();\n\n-- create pulp_evr_t on update, so it continues to match the provided E/V/R cols, but only if Something Changed\nCREATE TRIGGER pulp_evr_update_trigger\n  BEFORE UPDATE OF epoch, version, release\n  ON rpm_package\n  FOR EACH ROW\n  WHEN (\n    OLD.epoch IS DISTINCT FROM NEW.epoch OR\n    OLD.version IS DISTINCT FROM NEW.version OR\n    OLD.release IS DISTINCT FROM NEW.release\n  )\n  EXECUTE PROCEDURE pulp_evr_trigger();\n',
         ),
-        migrations.AddField(
-            model_name='package',
-            name='evr',
-            field=pulp_rpm.app.models.package.RpmVersionField(),
+        migrations.SeparateDatabaseAndState(
+            database_operations=[
+                migrations.RunSQL(
+                    sql="ALTER TABLE rpm_package ADD COLUMN evr pulp_evr_t;",
+                ),
+            ],
+            state_operations=[
+                migrations.AddField(
+                    model_name='package',
+                    name='evr',
+                    field=pulp_rpm.app.models.package.RpmVersionField(),
+                ),
+            ],
         ),
         migrations.RunSQL(
             sql='\nupdate rpm_package set evr = (\n  select ROW(coalesce(epoch::numeric,0),\n             pulp_rpmver_array(version)::pulp_evr_array_item[],\n             pulp_rpmver_array(release)::pulp_evr_array_item[])::pulp_evr_t\n  );\n',

--- a/pulp_rpm/app/migrations/0072_fix_evr_version_sorting.py
+++ b/pulp_rpm/app/migrations/0072_fix_evr_version_sorting.py
@@ -92,6 +92,7 @@ DECLARE
     pos INTEGER := 1;
     len INTEGER;
     ch TEXT;
+    cc INTEGER;
     result BYTEA := ''::bytea;
     segment TEXT;
     seg_len INTEGER;
@@ -105,12 +106,14 @@ BEGIN
 
     WHILE pos <= len LOOP
         -- Skip non-alphanumeric, non-tilde, non-caret characters
+        -- Uses ascii() for collation-independent ASCII range checks (matches C isalpha/isdigit)
         LOOP
             IF pos > len THEN EXIT; END IF;
             ch := substr(ver, pos, 1);
-            EXIT WHEN ch BETWEEN 'a' AND 'z'
-                     OR ch BETWEEN 'A' AND 'Z'
-                     OR ch BETWEEN '0' AND '9'
+            cc := ascii(ch);
+            EXIT WHEN (cc BETWEEN 97 AND 122)   -- a-z
+                     OR (cc BETWEEN 65 AND 90)   -- A-Z
+                     OR (cc BETWEEN 48 AND 57)   -- 0-9
                      OR ch = '~'
                      OR ch = '^';
             pos := pos + 1;
@@ -119,6 +122,7 @@ BEGIN
         IF pos > len THEN EXIT; END IF;
 
         ch := substr(ver, pos, 1);
+        cc := ascii(ch);
 
         -- Tilde sorts before everything, including end-of-version
         IF ch = '~' THEN
@@ -134,10 +138,10 @@ BEGIN
             CONTINUE;
         END IF;
 
-        IF ch BETWEEN '0' AND '9' THEN
+        IF cc BETWEEN 48 AND 57 THEN  -- 0-9
             -- Numeric segment
             segment := '';
-            WHILE pos <= len AND substr(ver, pos, 1) BETWEEN '0' AND '9' LOOP
+            WHILE pos <= len AND ascii(substr(ver, pos, 1)) BETWEEN 48 AND 57 LOOP  -- 0-9
                 segment := segment || substr(ver, pos, 1);
                 pos := pos + 1;
             END LOOP;
@@ -153,8 +157,8 @@ BEGIN
             -- Alpha segment
             segment := '';
             WHILE pos <= len AND (
-                substr(ver, pos, 1) BETWEEN 'a' AND 'z' OR
-                substr(ver, pos, 1) BETWEEN 'A' AND 'Z'
+                ascii(substr(ver, pos, 1)) BETWEEN 97 AND 122 OR   -- a-z
+                ascii(substr(ver, pos, 1)) BETWEEN 65 AND 90      -- A-Z
             ) LOOP
                 segment := segment || substr(ver, pos, 1);
                 pos := pos + 1;

--- a/pulp_rpm/app/migrations/0072_fix_evr_version_sorting.py
+++ b/pulp_rpm/app/migrations/0072_fix_evr_version_sorting.py
@@ -1,0 +1,236 @@
+# Adds a new 'evr_v2' column alongside the old 'evr' column.
+# Dropping the old column to remain zero-downtime safe.
+#
+# The trigger is updated to maintain both columns simultaneously.
+#
+# == Why replace evr? ==
+#
+# The old evr column (pulp_evr_t) decomposed version strings into arrays of
+# (numeric, text) tuples and relied on PostgreSQL's native array comparison.
+# This cannot correctly handle tilde (~) or caret (^):
+#
+#   - Tilde must sort BEFORE end-of-string: 1.0~rc1 < 1.0
+#     But PostgreSQL always sorts a shorter prefix-matching array as less-than
+#     a longer one, so no element value can invert this.
+#
+#   - Caret must sort AFTER end-of-string but BEFORE any continuation segment:
+#     1.0 < 1.0^git1 < 1.0.1
+#     Same fundamental problem with array length comparison.
+#
+# == How evr_v2 works ==
+#
+# The evr_v2 column is a single BYTEA value encoding the entire EVR
+# (epoch, version, release) as a sortable binary key. Native bytea comparison
+# (memcmp-style, byte by byte) produces correct RPM version ordering per
+# rpmvercmp(). The parsing logic mirrors RPM's rpmvercmp.cc.
+#
+# The key is structured as: [4-byte epoch] [version sortkey] [release sortkey]
+#
+# Epoch is encoded as a 4-byte big-endian unsigned integer. Because memcmp
+# compares left-to-right, the epoch bytes are always compared first, and a
+# higher epoch always dominates regardless of version/release — matching RPM
+# semantics. NULL epochs are coalesced to 0.
+#
+# Each version/release sortkey uses five byte markers, chosen so their numeric
+# order matches the required RPM sort order:
+#
+#   \x01  — tilde (~), sorts lowest, before end-of-version
+#   \x02  — end-of-version (appended once at the end of the key)
+#   \x03  — caret (^), sorts after end but before real segments
+#   \x04  — alpha segment prefix (followed by the segment text + \x00 delimiter)
+#   \x05  — numeric segment prefix (followed by length byte + digits + \x00)
+#
+# This order directly encodes the RPM rule: ~ < end < ^ < alpha < numeric.
+#
+# Segment encoding details:
+#
+#   Alpha segments: \x04 + raw ASCII text + \x00
+#     Lexicographic byte comparison gives correct alphabetical ordering.
+#
+#   Numeric segments: \x05 + length_byte + stripped_digits + \x00
+#     Leading zeros are stripped. The length byte sorts first, so longer digit
+#     strings (= larger numbers) always sort after shorter ones. Within the
+#     same length, digit characters compare lexicographically, which is correct
+#     for same-length decimal integers.
+#
+# Each version/release component ends with \x02 (end-of-version). When two
+# versions are equal, the comparison naturally falls through the end marker
+# into the release bytes. This is why no separator is needed between the
+# version and release sortkeys — the \x02 end marker serves as a delimiter.
+#
+# Example: EVR "2:1.0~rc1-3.fc40" encodes as:
+#
+#   epoch (4-byte big-endian):
+#     \x00 \x00 \x00 \x02            — epoch 2
+#
+#   version sortkey ("1.0~rc1"):
+#     \x05 \x01 1 \x00               — numeric segment "1"
+#     \x05 \x01 0 \x00               — numeric segment "0"
+#     \x01                            — tilde
+#     \x04 rc \x00                    — alpha segment "rc"
+#     \x05 \x01 1 \x00               — numeric segment "1"
+#     \x02                            — end-of-version
+#
+#   release sortkey ("3.fc40"):
+#     \x05 \x01 3 \x00               — numeric segment "3"
+#     \x04 fc \x00                    — alpha segment "fc"
+#     \x05 \x02 40 \x00              — numeric segment "40"
+#     \x02                            — end-of-version
+#
+# Comparing "1.0~rc1" vs "1.0": after the shared prefix "1.0", the first key
+# has \x01 (tilde) while the second has \x02 (end). Since \x01 < \x02,
+# "1.0~rc1" correctly sorts before "1.0".
+
+from django.db import migrations, models
+from pulp_rpm.app.models.package import RpmVersionField
+
+# The sort key function (version/release component)
+extension_sql = """
+CREATE OR REPLACE FUNCTION pulp_rpm_version_sortkey(ver TEXT)
+RETURNS BYTEA AS $$
+DECLARE
+    pos INTEGER := 1;
+    len INTEGER;
+    ch TEXT;
+    result BYTEA := ''::bytea;
+    segment TEXT;
+    seg_len INTEGER;
+    stripped TEXT;
+BEGIN
+    IF ver IS NULL OR ver = '' THEN
+        RETURN '\\x02'::bytea;
+    END IF;
+
+    len := length(ver);
+
+    WHILE pos <= len LOOP
+        -- Skip non-alphanumeric, non-tilde, non-caret characters
+        LOOP
+            IF pos > len THEN EXIT; END IF;
+            ch := substr(ver, pos, 1);
+            EXIT WHEN ch BETWEEN 'a' AND 'z'
+                     OR ch BETWEEN 'A' AND 'Z'
+                     OR ch BETWEEN '0' AND '9'
+                     OR ch = '~'
+                     OR ch = '^';
+            pos := pos + 1;
+        END LOOP;
+
+        IF pos > len THEN EXIT; END IF;
+
+        ch := substr(ver, pos, 1);
+
+        -- Tilde sorts before everything, including end-of-version
+        IF ch = '~' THEN
+            result := result || '\\x01'::bytea;
+            pos := pos + 1;
+            CONTINUE;
+        END IF;
+
+        -- Caret sorts after end-of-version but before any real segment
+        IF ch = '^' THEN
+            result := result || '\\x03'::bytea;
+            pos := pos + 1;
+            CONTINUE;
+        END IF;
+
+        IF ch BETWEEN '0' AND '9' THEN
+            -- Numeric segment
+            segment := '';
+            WHILE pos <= len AND substr(ver, pos, 1) BETWEEN '0' AND '9' LOOP
+                segment := segment || substr(ver, pos, 1);
+                pos := pos + 1;
+            END LOOP;
+            -- Strip leading zeros for numeric comparison
+            stripped := ltrim(segment, '0');
+            seg_len := length(stripped);
+            -- Encode: type(\\x05) + length_byte + digits + delimiter(\\x00)
+            result := result || '\\x05'::bytea
+                             || set_byte('\\x00'::bytea, 0, seg_len)
+                             || stripped::bytea
+                             || '\\x00'::bytea;
+        ELSE
+            -- Alpha segment
+            segment := '';
+            WHILE pos <= len AND (
+                substr(ver, pos, 1) BETWEEN 'a' AND 'z' OR
+                substr(ver, pos, 1) BETWEEN 'A' AND 'Z'
+            ) LOOP
+                segment := segment || substr(ver, pos, 1);
+                pos := pos + 1;
+            END LOOP;
+            -- Encode: type(\\x04) + segment + delimiter(\\x00)
+            result := result || '\\x04'::bytea
+                             || segment::bytea
+                             || '\\x00'::bytea;
+        END IF;
+    END LOOP;
+
+    -- End-of-version marker: sorts between tilde (\\x01) and caret (\\x03)
+    result := result || '\\x02'::bytea;
+
+    RETURN result;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+CREATE OR REPLACE FUNCTION pulp_rpm_evr_sortkey(epoch_val TEXT, ver TEXT, rel TEXT)
+RETURNS BYTEA AS $$
+BEGIN
+    RETURN int4send(coalesce(epoch_val::int, 0))
+        || pulp_rpm_version_sortkey(coalesce(ver, ''))
+        || pulp_rpm_version_sortkey(coalesce(rel, ''));
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+"""
+
+# Add new column, populate it, make it NOT NULL
+add_column_sql = """
+ALTER TABLE rpm_package ADD COLUMN evr_v2 bytea;
+
+UPDATE rpm_package SET evr_v2 = pulp_rpm_evr_sortkey(epoch, version, release);
+
+ALTER TABLE rpm_package ALTER COLUMN evr_v2 SET NOT NULL;
+"""
+
+# Replace trigger to maintain BOTH old evr and new evr_v2
+dual_trigger_sql = """
+CREATE OR REPLACE FUNCTION pulp_evr_trigger() RETURNS trigger AS $$
+BEGIN
+    -- Maintain old evr column (for running services during deployment)
+    NEW.evr = (select ROW(coalesce(NEW.epoch::numeric,0),
+                          pulp_rpmver_array(coalesce(NEW.version,'pulp_isempty'))::pulp_evr_array_item[],
+                          pulp_rpmver_array(coalesce(NEW.release,'pulp_isempty'))::pulp_evr_array_item[])::pulp_evr_t);
+    -- Maintain new evr_v2 column
+    NEW.evr_v2 = pulp_rpm_evr_sortkey(NEW.epoch, NEW.version, NEW.release);
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+"""
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('rpm', '0071_alter_rpmpublication_layout_and_more'),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            database_operations=[
+                migrations.RunSQL(extension_sql),
+                migrations.RunSQL(add_column_sql),
+                migrations.RunSQL(dual_trigger_sql),
+            ],
+            state_operations=[
+                migrations.AlterField(
+                    model_name='package',
+                    name='evr',
+                    field=RpmVersionField(db_column='evr_v2'),
+                ),
+            ],
+        ),
+        migrations.AddIndex(
+            model_name='package',
+            index=models.Index(fields=['name', 'arch', 'evr'], name='rpm_package_name_5db9c5_idx'),
+        ),
+    ]

--- a/pulp_rpm/app/models/package.py
+++ b/pulp_rpm/app/models/package.py
@@ -25,11 +25,10 @@ log = getLogger(__name__)
 
 # Hard to move this due to circular import problems
 class RpmVersionField(models.Field):
-    """Model Field for pulp_evr_t, a custom type for representing RPM EVR."""
+    """Model Field for the EVR sort key (single BYTEA encoding epoch+version+release)."""
 
     def db_type(self, connection):
-        """Returns the database column type."""
-        return "pulp_evr_t"
+        return "bytea"
 
 
 class Package(Content):
@@ -143,7 +142,7 @@ class Package(Content):
     arch = models.CharField(max_length=20)
 
     # Currently filled by a database trigger - consider eventually switching to generated column
-    evr = RpmVersionField()
+    evr = RpmVersionField(db_column="evr_v2")
 
     pkgId = models.TextField(db_index=True)  # formerly "checksum" in Pulp 2
     checksum_type = models.TextField(choices=CHECKSUM_CHOICES)
@@ -274,6 +273,9 @@ class Package(Content):
             "checksum_type",
             "pkgId",
         )
+        indexes = [
+            models.Index(fields=["name", "arch", "evr"]),
+        ]
         permissions = [
             ("upload_rpm_packages", "Can upload RPM packages using synchronous API."),
         ]

--- a/pulp_rpm/app/shared_utils.py
+++ b/pulp_rpm/app/shared_utils.py
@@ -1,15 +1,15 @@
 import shutil
 import tempfile
-from collections import defaultdict
 from hashlib import sha256
 
 import createrepo_c as cr
 import rpm_rs
 from django.conf import settings
+from django.db.models import F, Window
+from django.db.models.functions import RowNumber
 from django.utils.dateparse import parse_datetime
 
 from pulp_rpm.app.constants import CR_HEADER_FLAGS
-from pulp_rpm.app.rpm_version import RpmVersion
 
 
 def annotate_with_age(qs):
@@ -24,34 +24,13 @@ def annotate_with_age(qs):
     the same name and version numbers but they are not interchangeable because they have
     differing arch, such as 'x86_64' and 'i686', or 'src' (SRPM) and any other arch.
     """
-    # Get packages in current queryset with their basic info
-    packages = list(qs.values("pk", "name", "arch", "epoch", "version", "release"))
-
-    # Group packages by name and arch
-    groups = defaultdict(list)
-    for pkg in packages:
-        key = (pkg["name"], pkg["arch"])
-        groups[key].append(pkg)
-
-    # Calculate age for each group
-    age_mapping = {}
-    for group_packages in groups.values():
-        # Sort by EVR (newest first)
-        group_packages.sort(
-            key=lambda p: RpmVersion(p["epoch"], p["version"], p["release"]), reverse=True
+    return qs.annotate(
+        age=Window(
+            expression=RowNumber(),
+            partition_by=[F("name"), F("arch")],
+            order_by=F("evr").desc(),
         )
-
-        # Assign ages (1 = newest, 2 = second newest, etc.)
-        for age, pkg in enumerate(group_packages, 1):
-            age_mapping[pkg["pk"]] = age
-
-    # Create a queryset with age annotation
-    # We'll use a CASE statement to map PKs to ages
-    from django.db.models import Case, IntegerField, When
-
-    when_clauses = [When(pk=pk, then=age) for pk, age in age_mapping.items()]
-
-    return qs.annotate(age=Case(*when_clauses, output_field=IntegerField()))
+    )
 
 
 def format_nevra(name=None, epoch=0, version=None, release=None, arch=None):

--- a/pulp_rpm/tests/unit/test_package_age.py
+++ b/pulp_rpm/tests/unit/test_package_age.py
@@ -240,62 +240,56 @@ class TestPackageAge(TestCase):
 
     def test_age_with_tilde_and_caret_versions(self):
         """Test age calculation with tilde and caret version characters."""
-        # Create packages with tilde and caret versions
-        Package.objects.create(
-            name="tildepkg",
-            epoch="0",
-            version="1.0~rc1",
-            release="1.el8",
-            arch="x86_64",
-            pkgId="tilde1",
-            checksum_type="sha256",
-        )
-
-        Package.objects.create(
-            name="tildepkg",
-            epoch="0",
-            version="1.0",
-            release="1.el8",
-            arch="x86_64",
-            pkgId="tilde2",
-            checksum_type="sha256",
-        )
-
-        Package.objects.create(
-            name="tildepkg",
-            epoch="0",
-            version="1.0~rc2",
-            release="1.el8",
-            arch="x86_64",
-            pkgId="tilde3",
-            checksum_type="sha256",
-        )
-
-        Package.objects.create(
-            name="tildepkg",
-            epoch="0",
-            version="1.0^git123",
-            release="1.el8",
-            arch="x86_64",
-            pkgId="tilde4",
-            checksum_type="sha256",
-        )
+        versions = [
+            ("1.0~rc1~git1", "tilde1"),
+            ("1.0~rc1", "tilde2"),
+            ("1.0~rc2", "tilde3"),
+            ("1.0", "tilde4"),
+            ("1.0^git123", "tilde5"),
+            ("1.0^git456", "tilde6"),
+            ("1.0.1", "tilde7"),
+            ("1.0~rc1^git1", "tilde8"),
+        ]
+        for version, pkgId in versions:
+            Package.objects.create(
+                name="tildepkg",
+                epoch="0",
+                version=version,
+                release="1.el8",
+                arch="x86_64",
+                pkgId=pkgId,
+                checksum_type="sha256",
+            )
 
         packages = annotate_with_age(Package.objects.filter(name="tildepkg")).order_by("age")
 
-        # Expected order: 1.0^git123 (age=1), 1.0 (age=2), 1.0~rc2 (age=3), 1.0~rc1 (age=4)
-        # Caret sorts higher than regular, regular sorts higher than tilde
-        self.assertEqual(packages[0].version, "1.0^git123")
-        self.assertEqual(packages[0].age, 1)
-
-        self.assertEqual(packages[1].version, "1.0")
-        self.assertEqual(packages[1].age, 2)
-
-        self.assertEqual(packages[2].version, "1.0~rc2")
-        self.assertEqual(packages[2].age, 3)
-
-        self.assertEqual(packages[3].version, "1.0~rc1")
-        self.assertEqual(packages[3].age, 4)
+        # Expected order (newest to oldest):
+        #   1.0.1         — regular continuation, sorts highest
+        #   1.0^git456    — caret sorts after base but before regular continuation
+        #   1.0^git123    — caret, alphabetically before git456
+        #   1.0           — base version
+        #   1.0~rc2       — tilde sorts before base
+        #   1.0~rc1^git1  — tilde rc1 with caret: still under ~rc1 umbrella, but above plain ~rc1
+        #   1.0~rc1       — tilde rc1
+        #   1.0~rc1~git1  — nested tilde sorts before ~rc1
+        expected_order = [
+            "1.0.1",
+            "1.0^git456",
+            "1.0^git123",
+            "1.0",
+            "1.0~rc2",
+            "1.0~rc1^git1",
+            "1.0~rc1",
+            "1.0~rc1~git1",
+        ]
+        self.assertEqual(len(packages), len(expected_order))
+        for i, expected_version in enumerate(expected_order):
+            self.assertEqual(
+                packages[i].version,
+                expected_version,
+                f"age={i + 1}: expected {expected_version}, got {packages[i].version}",
+            )
+            self.assertEqual(packages[i].age, i + 1)
 
     def test_age_with_numeric_handling_versions(self):
         """Test age calculation with numeric version handling edge cases."""


### PR DESCRIPTION
I saw Ian was still dealing with this in Katello-land, so I decided to give this another shot with a different approach.  It seems to work much better than the original attempts.

### 📜 Checklist

- [x] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [x] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [x] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
