### PR TITLE
Fix flaky time_file assertion in test_signed_repo_modify

### DIFF
--- a/pulp_rpm/tests/functional/api/test_package_signing.py
+++ b/pulp_rpm/tests/functional/api/test_package_signing.py
@@ -306,7 +306,7 @@ def test_signed_repo_modify(
     ).results[0]
     assert signed_package.pulp_href != created_package.pulp_href
     assert signed_package.signing_keys == [prefixed_fingerprint]
-    assert signed_package.time_file != created_package.time_file
+    assert signed_package.pkg_id != created_package.pkg_id
     assert sorted(task_result.created_resources) == sorted(
         [repository.latest_version_href, signed_package.pulp_href, signed_package.artifact]
     )


### PR DESCRIPTION
The test asserted that the signed package's `time_file` differed from the original unsigned package's. `time_file` has 1-second resolution (it's the RPM file mtime), and signing happens in the same task as the upload, so the values can collide within a single second and cause the test to fail (as seen in [run 26162463277](https://github.com/pulp/pulp_rpm/actions/runs/26162463277/job/76957845386), where both ended up at `1779281135`).

Compare `pkg_id` (the RPM checksum) instead, which is guaranteed to differ whenever the file content changes.