### PR TITLE
Fix IntegrityError on multi-source copy with dependency solving

### DIFF
--- a/CHANGES/4286.bugfix
+++ b/CHANGES/4286.bugfix
@@ -1,0 +1,1 @@
+Fixed an `IntegrityError` raised when `copy_content` was invoked with `dependency_solving=True` and multiple source repository versions in the config mapped to the same destination repository. Units from all such config entries are now merged into a single new repository version on each shared destination, instead of attempting one new version per source entry.

--- a/pulp_rpm/app/tasks/copy.py
+++ b/pulp_rpm/app/tasks/copy.py
@@ -233,9 +233,25 @@ def copy_content(config, dependency_solving, dependency_upgrade=False):
             content_to_copy, focus_installed=not dependency_upgrade
         )
 
+        # Group units by destination repository before creating new versions.
+        # Multiple config entries may map to the same destination repository;
+        # calling new_version() more than once per destination would violate
+        # the unique (repository, number) constraint on RepositoryVersion.
+        dest_content = {}
         for from_repo, units in content_to_copy.items():
             src_repo_version = libsolv_repo_names[from_repo]
             dest_repo_version = repo_mapping[src_repo_version]
             base_version = dest_repo_version if base_versions[src_repo_version] else None
-            with dest_repo_version.repository.new_version(base_version=base_version) as new_version:
-                new_version.add_content(Content.objects.filter(pk__in=units))
+            dest_repo = dest_repo_version.repository
+            if dest_repo.pk not in dest_content:
+                dest_content[dest_repo.pk] = {
+                    "repo": dest_repo,
+                    "base_version": base_version,
+                    "units": set(),
+                }
+            dest_content[dest_repo.pk]["units"].update(units)
+        for d in dest_content.values():
+            if not d["units"]:
+                continue
+            with d["repo"].new_version(base_version=d["base_version"]) as new_version:
+                new_version.add_content(Content.objects.filter(pk__in=d["units"]))

--- a/pulp_rpm/tests/functional/api/test_copy.py
+++ b/pulp_rpm/tests/functional/api/test_copy.py
@@ -531,6 +531,162 @@ class TestCopyWithUnsignedRepoSyncedImmediate:
         assert "0.3" in kangaroo_versions
 
 
+def _repo_version_number(version_href):
+    """Parse the integer version number out of a RepositoryVersion href.
+
+    Expected shape: ``.../versions/<N>/``. Raises ``ValueError`` if the
+    trailing segment is not a non-negative integer, so test assertion
+    failures point at the parsing site rather than at downstream comparisons.
+    """
+    if not version_href:
+        raise ValueError(f"empty version_href: {version_href!r}")
+    last = version_href.rstrip("/").rsplit("/", 1)[-1]
+    return int(last)
+
+
+@pytest.mark.parallel
+def test_copy_multiple_sources_to_same_destination_with_depsolving(
+    init_and_sync,
+    monitor_task,
+    rpm_copy_api,
+    rpm_package_api,
+    rpm_repository_api,
+    rpm_repository_factory,
+):
+    """Regression test for #4286.
+
+    When ``copy_content`` is invoked with ``dependency_solving=True`` and
+    multiple source repository versions in the config map to the same
+    destination repository, the task must succeed and produce exactly one new
+    repository version on the destination. Previously, the task failed with an
+    ``IntegrityError`` because ``new_version()`` was called once per source
+    entry on the same destination inside one ``@transaction.atomic`` block,
+    violating the unique ``(repository, number)`` constraint.
+    """
+    src_a, _ = init_and_sync()
+    src_b, _ = init_and_sync(url=RPM_MODULAR_FIXTURE_URL)
+    dest = rpm_repository_factory()
+    initial_version = _repo_version_number(dest.latest_version_href)
+
+    # Specific seed by name in src_a; specific identity matters for the
+    # landing assertion below.
+    src_a_seed = rpm_package_api.list(
+        repository_version=src_a.latest_version_href, name="whale"
+    ).results[0]
+    # Any package from src_b — the bug is structural and triggers regardless
+    # of which packages are involved; we only need a non-empty content list
+    # so the depsolver loads this source. We pick the first result here
+    # deliberately (not by name) to keep the test independent of any
+    # specific modular-fixture package name.
+    src_b_packages = rpm_package_api.list(repository_version=src_b.latest_version_href).results
+    assert src_b_packages, "modular fixture must contain at least one package"
+    src_b_any = src_b_packages[0]
+
+    data = Copy(
+        config=[
+            {
+                "source_repo_version": src_a.latest_version_href,
+                "dest_repo": dest.pulp_href,
+                "content": [src_a_seed.pulp_href],
+            },
+            {
+                "source_repo_version": src_b.latest_version_href,
+                "dest_repo": dest.pulp_href,
+                "content": [src_b_any.pulp_href],
+            },
+        ],
+        dependency_solving=True,
+    )
+    monitor_task(rpm_copy_api.copy_content(data).task)
+
+    dest = rpm_repository_api.read(dest.pulp_href)
+    # Exactly one new repository version was created on the shared destination.
+    assert _repo_version_number(dest.latest_version_href) == initial_version + 1
+
+    dest_pkg_hrefs = {
+        p.pulp_href
+        for p in rpm_package_api.list(repository_version=dest.latest_version_href).results
+    }
+    # Both sources' requested packages must have landed in the merged version.
+    assert src_a_seed.pulp_href in dest_pkg_hrefs
+    assert src_b_any.pulp_href in dest_pkg_hrefs
+
+
+@pytest.mark.parallel
+def test_copy_multiple_sources_to_distinct_destinations_with_depsolving(
+    init_and_sync,
+    monitor_task,
+    rpm_copy_api,
+    rpm_package_api,
+    rpm_repository_api,
+    rpm_repository_factory,
+):
+    """Companion to the #4286 regression test.
+
+    When sources in a single ``copy_content`` call map to DIFFERENT
+    destinations, the batching fix must produce exactly one new repository
+    version per distinct destination, and content from one source must not
+    leak into the other source's destination. This guards against a
+    regression that would accidentally collapse distinct destinations.
+    """
+    src_a, _ = init_and_sync()
+    src_b, _ = init_and_sync(url=RPM_MODULAR_FIXTURE_URL)
+    dest_a = rpm_repository_factory()
+    dest_b = rpm_repository_factory()
+    initial_a = _repo_version_number(dest_a.latest_version_href)
+    initial_b = _repo_version_number(dest_b.latest_version_href)
+
+    src_a_seed = rpm_package_api.list(
+        repository_version=src_a.latest_version_href, name="whale"
+    ).results[0]
+    src_b_packages = rpm_package_api.list(repository_version=src_b.latest_version_href).results
+    assert src_b_packages, "modular fixture must contain at least one package"
+    src_b_any = src_b_packages[0]
+
+    data = Copy(
+        config=[
+            {
+                "source_repo_version": src_a.latest_version_href,
+                "dest_repo": dest_a.pulp_href,
+                "content": [src_a_seed.pulp_href],
+            },
+            {
+                "source_repo_version": src_b.latest_version_href,
+                "dest_repo": dest_b.pulp_href,
+                "content": [src_b_any.pulp_href],
+            },
+        ],
+        dependency_solving=True,
+    )
+    monitor_task(rpm_copy_api.copy_content(data).task)
+
+    dest_a = rpm_repository_api.read(dest_a.pulp_href)
+    dest_b = rpm_repository_api.read(dest_b.pulp_href)
+
+    # Each distinct destination got exactly one new repository version.
+    assert _repo_version_number(dest_a.latest_version_href) == initial_a + 1
+    assert _repo_version_number(dest_b.latest_version_href) == initial_b + 1
+
+    # Compare by pulp_href, not name: the unsigned and modular fixtures share
+    # several package names, so a name-based check could match a same-named but
+    # distinct package the depsolver legitimately pulled in.
+    dest_a_pkg_hrefs = {
+        p.pulp_href
+        for p in rpm_package_api.list(repository_version=dest_a.latest_version_href).results
+    }
+    dest_b_pkg_hrefs = {
+        p.pulp_href
+        for p in rpm_package_api.list(repository_version=dest_b.latest_version_href).results
+    }
+    # Each destination received its own source's requested package ...
+    assert src_a_seed.pulp_href in dest_a_pkg_hrefs
+    assert src_b_any.pulp_href in dest_b_pkg_hrefs
+    # ... and did NOT receive the other source's requested package. This is
+    # the actual "distinct destinations" invariant the test name promises.
+    assert src_b_any.pulp_href not in dest_a_pkg_hrefs
+    assert src_a_seed.pulp_href not in dest_b_pkg_hrefs
+
+
 class TestCopyWithKickstartRepoSyncedImmediate:
     def test_kickstart_content(
         self,


### PR DESCRIPTION
When copy_content ran with dependency_solving=True and multiple source repository versions in the config mapped to the same destination repository, the task failed with an IntegrityError on the unique (repository, number) constraint, because new_version() was called once per source entry on the same destination inside a single @transaction.atomic block.

Group units by destination repository before creating new versions, so that each destination receives exactly one new version regardless of how many source entries target it.

closes #4286

Assisted By: Claude (Anthropic)

### 📜 Checklist

- [X] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [X] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [X] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [X] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
