### PR TITLE
Fix signing key tracking on package upload

### DIFF
--- a/CHANGES/4487.bugfix
+++ b/CHANGES/4487.bugfix
@@ -1,0 +1,1 @@
+Fixed `signing_keys` not being populated for RPMs whose signatures contain only a key ID without a full fingerprint (common in packages signed by older GPG versions).

--- a/pulp_rpm/app/shared_utils.py
+++ b/pulp_rpm/app/shared_utils.py
@@ -64,16 +64,23 @@ _VERSION_PREFIX = {
 
 
 def format_signing_keys(signatures):
-    """Format rpm_rs signature objects into prefixed fingerprint strings.
+    """Format rpm_rs signature objects into prefixed identifier strings.
 
-    Returns prefixed, uppercased fingerprints (e.g. "v4:ABCD1234...") consistent
-    with PgpKeyFingerprintField normalization.
+    Uses "v4:"/"v6:" prefix with the full fingerprint when available, or
+    "keyid:" prefix with the short key ID for signatures that only carry a
+    key ID without the issuer fingerprint subpacket (common in RPMs signed
+    by older GPG versions).
+
+    Output is consistent with PgpKeyFingerprintField normalization, which
+    accepts "v4:<hex>", "v6:<hex>", and "keyid:<16-hex>" forms.
     """
-    return [
-        f"{_VERSION_PREFIX[sig.version]}:{sig.fingerprint.upper()}"
-        for sig in signatures
-        if sig.fingerprint is not None
-    ]
+    result = []
+    for sig in signatures:
+        if sig.fingerprint is not None:
+            result.append(f"{_VERSION_PREFIX[sig.version]}:{sig.fingerprint.upper()}")
+        elif sig.key_id is not None:
+            result.append(f"keyid:{sig.key_id.upper()}")
+    return result
 
 
 def extract_signing_keys(path):

--- a/pulp_rpm/tests/functional/api/test_package_signing.py
+++ b/pulp_rpm/tests/functional/api/test_package_signing.py
@@ -1,6 +1,4 @@
-import hashlib
 import shutil
-import uuid
 
 import pytest
 import requests
@@ -148,64 +146,6 @@ def test_sign_package_on_upload(
         )
 
 
-@pytest.fixture
-def pulpcore_chunked_file_factory(tmp_path):
-    """Returns a function to create chunks from file to be uploaded."""
-
-    def _create_chunks(upload_path, chunk_size=512):
-        """Chunks file to be uploaded."""
-        chunks = {"chunks": []}
-        hasher = hashlib.new("sha256")
-        start = 0
-        with open(upload_path, "rb") as f:
-            data = f.read()
-        chunks["size"] = len(data)
-
-        while start < len(data):
-            content = data[start : start + chunk_size]
-            chunk_file = tmp_path / str(uuid.uuid4())
-            hasher.update(content)
-            chunk_file.write_bytes(content)
-            content_sha = hashlib.sha256(content).hexdigest()
-            end = start + len(content) - 1
-            chunks["chunks"].append(
-                (str(chunk_file), f"bytes {start}-{end}/{chunks['size']}", content_sha)
-            )
-            start += len(content)
-        chunks["digest"] = hasher.hexdigest()
-        return chunks
-
-    return _create_chunks
-
-
-@pytest.fixture
-def pulpcore_upload_chunks(
-    pulpcore_bindings,
-    gen_object_with_cleanup,
-    monitor_task,
-):
-    """Upload file in chunks."""
-
-    def _upload_chunks(size, chunks, sha256, include_chunk_sha256=False):
-        """
-        Chunks is a list of tuples in the form of (chunk_filename, "bytes-ranges", optional_sha256).
-        """
-        upload = gen_object_with_cleanup(pulpcore_bindings.UploadsApi, {"size": size})
-
-        for data in chunks:
-            kwargs = {"file": data[0], "content_range": data[1], "upload_href": upload.pulp_href}
-            if include_chunk_sha256:
-                if len(data) != 3:
-                    raise Exception(f"Chunk didn't include its sha256: {data}")
-                kwargs["sha256"] = data[2]
-
-            pulpcore_bindings.UploadsApi.update(**kwargs)
-
-        return upload
-
-    yield _upload_chunks
-
-
 @pytest.mark.parallel
 def test_sign_chunked_package_on_upload(
     tmp_path,
@@ -251,7 +191,7 @@ def test_sign_chunked_package_on_upload(
         chunks = file_chunks_data["chunks"]
         sha256 = file_chunks_data["digest"]
 
-        upload = pulpcore_upload_chunks(size, chunks, sha256, include_chunk_sha256=True)
+        upload = pulpcore_upload_chunks(size, chunks, sha256)
         upload_response = rpm_package_api.create(
             upload=upload.pulp_href,
             repository=repository.pulp_href,

--- a/pulp_rpm/tests/functional/api/test_upload.py
+++ b/pulp_rpm/tests/functional/api/test_upload.py
@@ -5,6 +5,7 @@ from tempfile import NamedTemporaryFile
 
 import pytest
 import requests
+import rpm_rs
 
 from pulpcore.client.pulp_rpm import ApiException
 from pulpcore.client.pulpcore.exceptions import BadRequestException
@@ -16,7 +17,9 @@ from pulp_rpm.tests.functional.constants import (
     BIG_ENVIRONMENTS,
     BIG_GROUPS,
     BIG_LANGPACK,
+    KEY_V4_RSA4K,
     LEGACY_SIGNING_KEY,
+    RPM_FIXTURE_SIGNED,
     RPM_PACKAGE_FILENAME,
     RPM_PACKAGE_FILENAME2,
     RPM_PACKAGECATEGORY_CONTENT_NAME,
@@ -35,6 +38,28 @@ from pulp_rpm.tests.functional.constants import (
 
 SMALL_CONTENT = SMALL_GROUPS + SMALL_CATEGORY + SMALL_LANGPACK + SMALL_ENVIRONMENTS
 CENTOS8_CONTENT = BIG_GROUPS + BIG_CATEGORY + BIG_LANGPACK + BIG_ENVIRONMENTS
+
+MICROSOFT_PROD_RPM_URL = "https://packages.microsoft.com/config/rhel/10/packages-microsoft-prod.rpm"
+
+
+@pytest.fixture
+def key_id_only_signed_rpm(tmp_path):
+    """Download an RPM whose signatures carry only a key ID (no issuer fingerprint subpacket).
+
+    This is common for RPMs signed by older GPG versions. The Microsoft prod RPM
+    is a convenient, publicly available example.
+    """
+    path = tmp_path / "packages-microsoft-prod.rpm"
+    path.write_bytes(requests.get(MICROSOFT_PROD_RPM_URL).content)
+
+    pkg = rpm_rs.PackageMetadata.open(str(path))
+    sigs = list(pkg.signatures())
+    assert len(sigs) > 0, "Test RPM should be signed"
+    assert any(s.fingerprint is None and s.key_id is not None for s in sigs), (
+        "Test RPM should have key_id-only signatures (no fingerprint subpacket)"
+    )
+
+    return path
 
 
 def test_single_request_unit_and_duplicate_unit(
@@ -304,7 +329,12 @@ def test_synchronous_package_upload_from_artifact(
 
 
 def test_synchronous_package_upload_from_chunks(
-    delete_orphans_pre, rpm_package_api, gen_user, pulpcore_bindings, tmp_path
+    delete_orphans_pre,
+    rpm_package_api,
+    gen_user,
+    tmp_path,
+    pulpcore_chunked_file_factory,
+    pulpcore_upload_chunks,
 ):
     """Test synchronously uploading an RPM using chunked upload.
 
@@ -312,60 +342,158 @@ def test_synchronous_package_upload_from_chunks(
     2. Use synchronous RPM upload API with the upload object.
     3. Assert that the RPM package is created successfully.
     """
-    import hashlib
-    import uuid
-
     file_to_use = os.path.join(RPM_UNSIGNED_FIXTURE_URL, RPM_PACKAGE_FILENAME)
 
-    # Download the file and prepare chunks
-    with NamedTemporaryFile(delete=False) as file_to_upload:
-        file_to_upload.write(requests.get(file_to_use).content)
-        file_to_upload.flush()
-        file_path = file_to_upload.name
+    file_path = tmp_path / RPM_PACKAGE_FILENAME
+    file_path.write_bytes(requests.get(file_to_use).content)
 
-    # Create chunks (similar to pulpcore_chunked_file_factory)
-    chunk_size = 512
-    chunks = []
-    hasher = hashlib.new("sha256")
+    file_chunks_data = pulpcore_chunked_file_factory(file_path)
+    upload = pulpcore_upload_chunks(
+        file_chunks_data["size"], file_chunks_data["chunks"], file_chunks_data["digest"]
+    )
 
-    with open(file_path, "rb") as f:
-        data = f.read()
-
-    file_size = len(data)
-    start = 0
-
-    while start < len(data):
-        content = data[start : start + chunk_size]
-        chunk_file = tmp_path / str(uuid.uuid4())
-        hasher.update(content)
-        chunk_file.write_bytes(content)
-        content_sha = hashlib.sha256(content).hexdigest()
-        end = start + len(content) - 1
-        chunks.append((str(chunk_file), f"bytes {start}-{end}/{file_size}", content_sha))
-        start += len(content)
-
-    # Create an Upload object (requires core permissions, done outside gen_user)
-    upload = pulpcore_bindings.UploadsApi.create({"size": file_size})
-
-    # Upload all chunks
-    for chunk_file, content_range, chunk_sha in chunks:
-        pulpcore_bindings.UploadsApi.update(
-            upload_href=upload.pulp_href,
-            file=chunk_file,
-            content_range=content_range,
-            sha256=chunk_sha,
-        )
-
-    # Use synchronous upload API with the upload object (requires rpm uploader role)
     with gen_user(model_roles=["rpm.rpm_package_uploader"]):
-        upload_attrs = {"upload": upload.pulp_href}
-        package = rpm_package_api.upload(**upload_attrs)
-
-        # Verify package was created successfully
+        package = rpm_package_api.upload(upload=upload.pulp_href)
         assert package.location_href == RPM_PACKAGE_FILENAME
 
-    # Clean up
-    os.unlink(file_path)
+
+@pytest.mark.parametrize(
+    "fixture_url, expect_signed",
+    [
+        (RPM_UNSIGNED_FIXTURE_URL, False),
+        (RPM_SIGNED_FIXTURE_URL, True),
+    ],
+)
+def test_async_upload_signing_keys(
+    delete_orphans_pre, rpm_package_api, monitor_task, fixture_url, expect_signed
+):
+    """Test that signing_keys is populated correctly on async upload (rpm_package_api.create).
+
+    Upload both signed and unsigned packages via the async create endpoint and verify
+    that signing_keys reflects the actual signatures in the RPM.
+    """
+    file_to_use = os.path.join(fixture_url, RPM_PACKAGE_FILENAME)
+
+    with NamedTemporaryFile() as file_to_upload:
+        file_to_upload.write(requests.get(file_to_use).content)
+        upload = rpm_package_api.create(file=file_to_upload.name)
+
+    content = monitor_task(upload.task).created_resources[0]
+    package = rpm_package_api.read(content)
+
+    if expect_signed:
+        assert package.signing_keys == [f"v4:{LEGACY_SIGNING_KEY.signing_fingerprint}"]
+    else:
+        assert package.signing_keys == []
+
+
+def test_async_upload_signing_keys_from_artifact(
+    delete_orphans_pre, rpm_package_api, monitor_task, signed_artifact
+):
+    """Test that signing_keys is populated correctly on async upload from an artifact."""
+    upload = rpm_package_api.create(artifact=signed_artifact.pulp_href)
+    content = monitor_task(upload.task).created_resources[0]
+    package = rpm_package_api.read(content)
+
+    assert package.signing_keys == [f"v4:{LEGACY_SIGNING_KEY.signing_fingerprint}"]
+
+
+@pytest.mark.parametrize(
+    "fixture_url, expect_signed",
+    [
+        (RPM_UNSIGNED_FIXTURE_URL, False),
+        (RPM_SIGNED_FIXTURE_URL, True),
+    ],
+)
+def test_synchronous_upload_signing_keys_from_chunks(
+    delete_orphans_pre,
+    rpm_package_api,
+    gen_user,
+    tmp_path,
+    fixture_url,
+    expect_signed,
+    pulpcore_chunked_file_factory,
+    pulpcore_upload_chunks,
+):
+    """Test that signing_keys is populated correctly on synchronous chunked upload."""
+    file_to_use = os.path.join(fixture_url, RPM_PACKAGE_FILENAME)
+
+    file_path = tmp_path / RPM_PACKAGE_FILENAME
+    file_path.write_bytes(requests.get(file_to_use).content)
+
+    file_chunks_data = pulpcore_chunked_file_factory(file_path)
+    upload = pulpcore_upload_chunks(
+        file_chunks_data["size"], file_chunks_data["chunks"], file_chunks_data["digest"]
+    )
+
+    with gen_user(model_roles=["rpm.rpm_package_uploader"]):
+        package = rpm_package_api.upload(upload=upload.pulp_href)
+
+    if expect_signed:
+        assert package.signing_keys == [f"v4:{LEGACY_SIGNING_KEY.signing_fingerprint}"]
+    else:
+        assert package.signing_keys == []
+
+
+def test_async_upload_signing_keys_key_id_only(
+    delete_orphans_pre,
+    rpm_package_api,
+    monitor_task,
+    key_id_only_signed_rpm,
+):
+    """Test that signing_keys is populated for RPMs with key_id-only signatures.
+
+    Some RPMs (e.g. those signed by older GPG versions) have signatures that contain
+    only a key_id without a full fingerprint. These should still populate signing_keys.
+
+    Regression test for https://github.com/pulp/pulp_rpm/issues/4487
+    """
+    upload = rpm_package_api.create(file=str(key_id_only_signed_rpm))
+    content = monitor_task(upload.task).created_resources[0]
+    package = rpm_package_api.read(content)
+
+    assert package.signing_keys is not None
+    assert len(package.signing_keys) > 0, (
+        "signing_keys should be populated for RPMs with key_id-only signatures"
+    )
+    assert all(k.startswith("keyid:") for k in package.signing_keys)
+
+
+def test_sync_upload_signing_keys_key_id_only(
+    delete_orphans_pre,
+    rpm_package_api,
+    gen_user,
+    key_id_only_signed_rpm,
+):
+    """Test that signing_keys is populated on sync upload for RPMs with key_id-only signatures.
+
+    Regression test for https://github.com/pulp/pulp_rpm/issues/4487
+    """
+    with gen_user(model_roles=["rpm.rpm_package_uploader"]):
+        package = rpm_package_api.upload(file=str(key_id_only_signed_rpm))
+
+    assert package.signing_keys is not None
+    assert len(package.signing_keys) > 0, (
+        "signing_keys should be populated for RPMs with key_id-only signatures"
+    )
+    assert all(k.startswith("keyid:") for k in package.signing_keys)
+
+
+def test_async_upload_with_newer_fixture_rpm(
+    delete_orphans_pre,
+    rpm_package_api,
+    monitor_task,
+    tmp_path,
+):
+    """Test async upload with a newer fixture RPM (signed with KEY_V4_RSA4K)."""
+    file_to_upload = tmp_path / "test-package-signed.rpm"
+    file_to_upload.write_bytes(requests.get(RPM_FIXTURE_SIGNED).content)
+
+    upload = rpm_package_api.create(file=str(file_to_upload))
+    content = monitor_task(upload.task).created_resources[0]
+    package = rpm_package_api.read(content)
+
+    assert package.signing_keys == [f"v4:{KEY_V4_RSA4K.signing_fingerprint}"]
 
 
 def eval_resources(resources, is_small=True):

--- a/pulp_rpm/tests/functional/conftest.py
+++ b/pulp_rpm/tests/functional/conftest.py
@@ -186,6 +186,53 @@ def rpm_package_factory(
     return _rpm_package_factory
 
 
+@pytest.fixture
+def pulpcore_chunked_file_factory(tmp_path):
+    """Returns a function to create chunks from a file to be uploaded."""
+
+    def _create_chunks(upload_path, chunk_size=512):
+        chunks = {"chunks": []}
+        hasher = hashlib.new("sha256")
+        start = 0
+        with open(upload_path, "rb") as f:
+            data = f.read()
+        chunks["size"] = len(data)
+
+        while start < len(data):
+            content = data[start : start + chunk_size]
+            chunk_file = tmp_path / str(uuid.uuid4())
+            hasher.update(content)
+            chunk_file.write_bytes(content)
+            content_sha = hashlib.sha256(content).hexdigest()
+            end = start + len(content) - 1
+            chunks["chunks"].append(
+                (str(chunk_file), f"bytes {start}-{end}/{chunks['size']}", content_sha)
+            )
+            start += len(content)
+        chunks["digest"] = hasher.hexdigest()
+        return chunks
+
+    return _create_chunks
+
+
+@pytest.fixture
+def pulpcore_upload_chunks(pulpcore_bindings, gen_object_with_cleanup):
+    """Upload file in chunks and return the Upload object."""
+
+    def _upload_chunks(size, chunks, sha256):
+        upload = gen_object_with_cleanup(pulpcore_bindings.UploadsApi, {"size": size})
+        for chunk_file, content_range, chunk_sha in chunks:
+            pulpcore_bindings.UploadsApi.update(
+                upload_href=upload.pulp_href,
+                file=chunk_file,
+                content_range=content_range,
+                sha256=chunk_sha,
+            )
+        return upload
+
+    yield _upload_chunks
+
+
 @pytest.fixture(scope="class")
 def rpm_unsigned_repo_immediate(init_and_sync):
     repo, _ = init_and_sync()

--- a/pulp_rpm/tests/unit/test_signing.py
+++ b/pulp_rpm/tests/unit/test_signing.py
@@ -1,7 +1,10 @@
+from types import SimpleNamespace
+
 import pytest
 import requests
 import rpm_rs
 
+from pulp_rpm.app.shared_utils import extract_signing_keys, format_signing_keys
 from pulp_rpm.app.tasks.signing import _verify_package_fingerprint
 from pulp_rpm.tests.functional.constants import RPM_FIXTURE_SIGNED, RPM_FIXTURE_UNSIGNED
 
@@ -17,6 +20,10 @@ def _download_rpm(tmp_path, url, name="test.rpm"):
 def _get_fingerprint(path):
     pkg = rpm_rs.PackageMetadata.open(path)
     return next(s.fingerprint for s in pkg.signatures() if s.fingerprint)
+
+
+def _mock_sig(version=rpm_rs.SignatureVersion.V4, fingerprint=None, key_id=None):
+    return SimpleNamespace(version=version, fingerprint=fingerprint, key_id=key_id)
 
 
 @pytest.fixture
@@ -55,3 +62,68 @@ def test_verify_signed_package_wrong_fingerprint(signed_rpm):
 def test_verify_fingerprint_without_prefix(signed_rpm):
     fingerprint = _get_fingerprint(signed_rpm)
     assert _verify_package_fingerprint(signed_rpm, fingerprint.upper())
+
+
+# Tests for format_signing_keys
+
+
+def test_format_signing_keys_with_fingerprint():
+    sigs = [_mock_sig(fingerprint="abcd1234", key_id="1234")]
+    result = format_signing_keys(sigs)
+    assert result == ["v4:ABCD1234"]
+
+
+def test_format_signing_keys_with_key_id_only():
+    """Signatures with only key_id (no fingerprint) should use 'keyid:' prefix."""
+    sigs = [_mock_sig(fingerprint=None, key_id="ee4d7792f748182b")]
+    result = format_signing_keys(sigs)
+    assert result == ["keyid:EE4D7792F748182B"]
+
+
+def test_format_signing_keys_prefers_fingerprint_over_key_id():
+    sigs = [_mock_sig(fingerprint="abcd1234abcd1234", key_id="abcd1234")]
+    result = format_signing_keys(sigs)
+    assert result == ["v4:ABCD1234ABCD1234"]
+
+
+def test_format_signing_keys_mixed():
+    """Mix of signatures with fingerprint and key_id-only."""
+    sigs = [
+        _mock_sig(fingerprint="aaaa1111", key_id="1111"),
+        _mock_sig(fingerprint=None, key_id="bbbb2222"),
+    ]
+    result = format_signing_keys(sigs)
+    assert len(result) == 2
+    assert "v4:AAAA1111" in result
+    assert "keyid:BBBB2222" in result
+
+
+def test_format_signing_keys_no_fingerprint_no_key_id():
+    """Signatures with neither fingerprint nor key_id should be excluded."""
+    sigs = [_mock_sig(fingerprint=None, key_id=None)]
+    result = format_signing_keys(sigs)
+    assert result == []
+
+
+def test_format_signing_keys_empty():
+    assert format_signing_keys([]) == []
+
+
+def test_format_signing_keys_v6():
+    sigs = [_mock_sig(version=rpm_rs.SignatureVersion.V6, fingerprint="abcd1234")]
+    result = format_signing_keys(sigs)
+    assert result == ["v6:ABCD1234"]
+
+
+# Tests for extract_signing_keys
+
+
+def test_extract_signing_keys_signed_rpm(signed_rpm):
+    keys = extract_signing_keys(signed_rpm)
+    assert len(keys) > 0
+    assert all(k.startswith("v4:") or k.startswith("v6:") for k in keys)
+
+
+def test_extract_signing_keys_unsigned_rpm(unsigned_rpm):
+    keys = extract_signing_keys(unsigned_rpm)
+    assert keys == []


### PR DESCRIPTION
when the signature has only a key_id packet, not a fingerprint.

closes #4487

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [x] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [x] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [x] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
