### PR TITLE
[PULP-1828] Update vulnerability report docs to use pulp-cli

### DIFF
--- a/CHANGES/+vuln-report-cli-docs.misc
+++ b/CHANGES/+vuln-report-cli-docs.misc
@@ -1,0 +1,1 @@
+Updated vulnerability report guide to use `pulp-cli` commands instead of raw HTTP calls.

--- a/docs/user/guides/vulnerability-report.md
+++ b/docs/user/guides/vulnerability-report.md
@@ -4,6 +4,9 @@ Scan RPM packages in a repository version for known CVEs by querying the [OSV da
 
 Results are linked to the repository version and individual packages.
 
+!!! info "New in `pulp_rpm>=3.38.0`"
+!!! info "New in `pulp-cli>=0.41.0` (optional)"
+
 ## Prerequisites
 
 Before scanning, ensure you have:
@@ -12,7 +15,7 @@ Before scanning, ensure you have:
 2. Connectivity to the OSV API (`https://api.osv.dev/v1/query`).
 3. The repository configured with an `osv_config` specifying which ecosystem(s) to query.
 
-### Supported ecosystems
+## Supported ecosystems
 
 The following ecosystems from the [OSV ecosystem list](https://github.com/ossf/osv-schema/blob/main/ecosystems.json) are supported:
 
@@ -28,96 +31,139 @@ The following ecosystems from the [OSV ecosystem list](https://github.com/ossf/o
 | Rocky Linux | Release number (e.g. `9`) |
 | SUSE | `PRETTY_NAME` from `/etc/os-release` (e.g. `SUSE Linux Enterprise Server 15 SP5`) |
 
-The `releases` list is required for all ecosystems and scopes the OSV query to specific product releases.
-Each release triggers a separate query to OSV, so a package with two releases will be scanned twice - once per release.
+## Usage
 
-### Configure osv_config
+### Configure the repository
+
+The repository needs to be configured so the vulnerability scan knows what RPM ecosystem it will use.
+
+The configuration is a list of `{name, releases}` entries, where `name` is the name of the ecosystem
+and `releases` is a list of release identifiers.
+These identifiers scope the OSV query to specific product/ecosystem releases, as shown in [Supported ecosystems](#supported-ecosystems).
+
+Each release entry triggers a separate query to OSV.
+This means configuring two releases (for the same ecosystem or not) will generate one report per release for each package.
 
 Set `osv_config` on the repository before triggering a scan:
 
 ```bash
-# AlmaLinux
-http PATCH $BASE_URL$REPO_HREF \
-  osv_config:='[{"name": "AlmaLinux", "releases": ["9"]}]'
-
-# Red Hat (releases must be CPEs)
-http PATCH $BASE_URL$REPO_HREF \
-  osv_config:='[{"name": "Red Hat", "releases": ["cpe:/o:redhat:enterprise_linux:9::baseos"]}]'
+pulp rpm repository update \
+  --name "$REPOSITORY" \
+  --osv-config '[{"name": "AlmaLinux", "releases": ["9"]}]'
 ```
-
-Multiple ecosystems can be combined:
+  
+Multiple ecosystems can be combined for multiple scans:
 
 ```bash
-http PATCH $BASE_URL$REPO_HREF \
-  osv_config:='[
+pulp rpm repository update \
+  --name "$REPOSITORY" \
+  --osv-config='[
     {"name": "Red Hat", "releases": ["cpe:/o:redhat:enterprise_linux:9::baseos"]},
     {"name": "AlmaLinux", "releases": ["9"]}
   ]'
 ```
 
-## Generating a Vulnerability Report
-
-Scan a `RepositoryVersion` by passing the repository version href:
-
-```bash
-http POST $BASE_URL$VERSION_HREF/scan/
-```
-
-## Understanding Scan Results
-
-Results appear at two levels:
-
-### 1. Repository Version Level
+Set `osv_config` to `null` to opt the repository back out.
+Note that removing the config does not delete existing scan results already stored for prior versions.
 
 ```bash
-pulp rpm repository version show --repository my-repo --version 1
+pulp rpm repository update \
+  --name "$REPOSITORY" \
+  --osv-config=""
 ```
 
-The response includes a `vuln_report` field:
+### Generate a Vulnerability Report
 
-```json
+Scan a `RepositoryVersion` by passing the repository or repository version:
+
+```bash
+# Use the latest version
+pulp rpm repository version scan --repository "$REPOSITORY"
+
+# Or a specify a version
+pulp rpm repository version scan --repository "$REPOSITORY" --version 2
+```
+
+### Viewing Scan Results
+
+After a scan completes, vulnerability information is available in two places:
+
+1. The `RepositoryVersion` includes a `vuln_report` field. It contains an href that shows all vulnerabilities found in that version
+1. Individual packages includes a `vuln_report` field. It contains an href that shows all vulnerabilities associated with that package
+
+=== "Get by Repository Version"
+
+    ```bash
+    pulp rpm repository version show --repository "$REPOSITORY" --version 1
+    ```
+
+    The response includes a `vuln_report` field:
+
+    ```json
+    {
+      "pulp_href": "/pulp/api/v3/repositories/rpm/rpm/.../versions/1/",
+      "number": 1,
+      ...
+      "vuln_report": "/pulp/api/v3/vuln-reports/..."
+    }
+    ```
+
+=== "Get by Package"
+
+    ```bash
+    pulp rpm content -t package list
+    ```
+
+    Each package in the response includes:
+
+    ```json
+    {
+        "pulp_href": "/pulp/api/v3/content/rpm/packages/.../",
+        ...
+        "vuln_report": "/pulp/api/v3/vuln-reports/...",
+    }
+    ```
+
+To view the actual vulnerability data, retrieve the vulnerability report href from an `RepositoryVersion` or a `Package`.
+This will return a list of vulnerability report resources:
+
+```bash
+pulp show --href $VULN_REPORT_HREF
+```
+
+Each individual report include:
+
+- Data provided by the [OSV format](https://ossf.github.io/osv-schema/) (e.g, CVE identifiers, fixed versions, ...)
+- Pulp `RepositoryVersion` and `Content` impacted
+
+```python
 {
-  "pulp_href": "/pulp/api/v3/repositories/rpm/rpm/.../versions/1/",
-  "number": 1,
-  "vuln_report": "/pulp/api/v3/vuln-reports/..."
+  "prn": "prn:core.vulnerabilityreport:...",
+  "content": "/pulp/api/v3/content/rpm/packages/.../",  # associated Package
+  "repo_versions": [...]  # Impacted repository versions
+  "vulns": [...]  # osv data
 }
 ```
 
-### 2. Viewing Vulnerability Details
-
-```bash
-pulp vulnerability-report show --href $VULN_REPORT_HREF
-```
-
-Reports include CVE identifiers, affected versions, references, and impacted repository content.
-
 ## Example Workflow
 
-```bash
-# Create a repository and sync content
-pulp rpm remote create --name myremote --url https://fixtures.pulpproject.org/rpm-signed/
-pulp rpm repository create --name myrepo --remote myremote
-pulp rpm repository sync --name myrepo
+Here's a complete example of scanning a repository for vulnerabilities:
 
-# Configure the OSV ecosystem
-http PATCH $BASE_URL$REPO_HREF \
-  osv_config:='[{"name": "AlmaLinux", "releases": ["9"]}]'
+```bash
+REPOSITORY=myrepo
+KERNEL_URL="https://vault.centos.org/7.0.1406/os/x86_64/Packages/kernel-3.10.0-123.el7.x86_64.rpm"
+OSV_CONFIG='[{"name": "Red Hat", "releases": ["cpe:/o:redhat:enterprise_linux:7::workstation"]}]'
+
+# Create a repository and put a package in
+pulp rpm repository create \
+  --name "$REPOSITORY" --osv-config="$OSV_CONFIG"
+pulp rpm content -t package create \
+  --repository "$REPOSITORY" --file-url "$KERNEL_URL"
 
 # Trigger the scan
-http POST $BASE_URL$VERSION_HREF/scan/
+pulp rpm repository version scan --repository "$REPOSITORY"
 
-# Retrieve and inspect the report
-VULN_REPORT=$(pulp rpm repository version show --repository myrepo | jq -r '.vuln_report')
-pulp vulnerability-report show --href $VULN_REPORT
+# Show reports for the latest repository version
+VULN_REPORT=$(pulp rpm repository version show --repository "$REPOSITORY" | jq -r '.vuln_report')
+pulp show --href "$VULN_REPORT"
 ```
-
-## Remove the config
-
-Set `osv_config` to `null` to opt the repository back out:
-
-```bash
-http PATCH $BASE_URL$REPO_HREF \
-  osv_config:=null
-```
-
-Removing the config does not delete existing scan results already stored for prior versions.


### PR DESCRIPTION
**Requires: https://github.com/pulp/pulp-cli/pull/1431**

Replaces raw HTTP examples with pulp-cli commands throughout the
vulnerability report guide. Also renames the viewset action from
`vulnerability_report` to `scan` for a cleaner API endpoint name.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
