### PR TITLE
Fix vulnerability report endpoint name

### DIFF
--- a/CHANGES/+vuln-report.feature
+++ b/CHANGES/+vuln-report.feature
@@ -1,1 +1,2 @@
-Added a `vulnerability_report` action to `RpmRepositoryVersionViewSet` that scans all RPM packages in a repository version for known CVEs via osv.dev. Repositories are opted in by setting the `osv.rpm.config` label to a JSON list of ecosystem entries with required `releases` (e.g., `[{"name": "Red Hat", "releases": ["cpe:/o:redhat:enterprise_linux:9::baseos"]}]`).
+Added a `scan` action to `RepositoryVersion` endpoint that scans all RPM packages in a repository version via <https://osv.dev/>.
+Repositories must be configured via the `osv_config` field, which specifies the ecosystems and releases to query.

--- a/docs/user/guides/vulnerability-report.md
+++ b/docs/user/guides/vulnerability-report.md
@@ -60,7 +60,7 @@ http PATCH $BASE_URL$REPO_HREF \
 Scan a `RepositoryVersion` by passing the repository version href:
 
 ```bash
-http POST $BASE_URL$VERSION_HREF/vulnerability_report/
+http POST $BASE_URL$VERSION_HREF/scan/
 ```
 
 ## Understanding Scan Results
@@ -104,7 +104,7 @@ http PATCH $BASE_URL$REPO_HREF \
   osv_config:='[{"name": "AlmaLinux", "releases": ["9"]}]'
 
 # Trigger the scan
-http POST $BASE_URL$VERSION_HREF/vulnerability_report/
+http POST $BASE_URL$VERSION_HREF/scan/
 
 # Retrieve and inspect the report
 VULN_REPORT=$(pulp rpm repository version show --repository myrepo | jq -r '.vuln_report')

--- a/pulp_rpm/app/viewsets/repository.py
+++ b/pulp_rpm/app/viewsets/repository.py
@@ -321,7 +321,7 @@ class RpmRepositoryVersionViewSet(RepositoryVersionViewSet):
                 ],
             },
             {
-                "action": ["vulnerability_report"],
+                "action": ["scan"],
                 "principal": "authenticated",
                 "effect": "allow",
                 "condition": "has_repository_model_or_domain_or_obj_perms:rpm.view_rpmrepository",
@@ -341,7 +341,7 @@ class RpmRepositoryVersionViewSet(RepositoryVersionViewSet):
         responses={202: AsyncOperationResponseSerializer},
     )
     @action(detail=True, methods=["post"], serializer_class=None)
-    def vulnerability_report(self, request, repository_pk, **kwargs):
+    def scan(self, request, repository_pk, **kwargs):
         repository_version = self.get_object()
         repo = repository_version.repository
 

--- a/pulp_rpm/tests/functional/api/test_vuln_report.py
+++ b/pulp_rpm/tests/functional/api/test_vuln_report.py
@@ -1,4 +1,4 @@
-"""Functional tests for the vulnerability_report action on RpmRepositoryVersionViewSet."""
+"""Functional tests for the scan action on RpmRepositoryVersionViewSet."""
 
 import uuid
 
@@ -94,10 +94,10 @@ class TestOsvConfig:
 
     @pytest.mark.parallel
     def test_missing_config(self, rpm_repository_factory, rpm_repository_versions_api):
-        """Repository without osv_config returns 400 when vulnerability_report is called."""
+        """Repository without osv_config returns 400 when scan is called."""
         repo = rpm_repository_factory()
         with pytest.raises(ApiException) as exc:
-            rpm_repository_versions_api.vulnerability_report(repo.latest_version_href)
+            rpm_repository_versions_api.scan(repo.latest_version_href)
         assert exc.value.status == 400
         assert "Required label" in exc.value.body
 
@@ -167,7 +167,7 @@ class TestVulnReportIntegration:
             monitor_task=monitor_task,
         )
 
-        resp = rpm_repository_versions_api.vulnerability_report(repo.latest_version_href)
+        resp = rpm_repository_versions_api.scan(repo.latest_version_href)
         monitor_task(resp.task)
 
         vulns_list = pulpcore_bindings.VulnReportApi.list()


### PR DESCRIPTION
The method must be named `scan` to conform to the standard, which facilitates `pulp-glue`/`pulp-cli` to handle the endpoint smoothly.

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
