### PR TITLE
Make concurrent package signing race-safe

### DIFF
--- a/CHANGES/4522.bugfix
+++ b/CHANGES/4522.bugfix
@@ -1,0 +1,1 @@
+Fixed an `IntegrityError` that could abort `signed_add_and_remove` when the same package was signed concurrently by making the `RpmPackageSigningResult` creation race-safe and reusing the existing result.

--- a/pulp_rpm/app/tasks/signing.py
+++ b/pulp_rpm/app/tasks/signing.py
@@ -144,11 +144,20 @@ def _sign_package(package, signing_service, signing_fingerprint):
             content=signed_package,
             relative_path=content_artifact.relative_path,
         )
-        RpmPackageSigningResult.objects.create(
+        # get_or_create guards against concurrent signing of the same package, which
+        # would otherwise violate the unique constraint and fail the task.
+        signing_result, created = RpmPackageSigningResult.objects.get_or_create(
             original_package_sha256=artifact_obj.sha256,
             package_signing_fingerprint=signing_fingerprint,
-            result_package=signed_package,
+            defaults={"result_package": signed_package},
         )
+        if not created:
+            # Another worker won the race; reuse its result and let orphan cleanup
+            # reap the redundant package we just created.
+            log.info(
+                f"Package {package.filename} was signed concurrently; reusing existing result."
+            )
+            return (package_id, str(signing_result.result_package.pk))
 
         resource = CreatedResource(content_object=signed_package)
         resource.save()


### PR DESCRIPTION
Use get_or_create for RpmPackageSigningResult so that concurrent signing of the same package reuses the existing result instead of failing the task with a unique-constraint IntegrityError.

fixes #4522 

Assisted-by: GitHub Copilot