### PR TITLE
Match signing fingerprints against issuer key IDs

### DIFF
--- a/CHANGES/4545.bugfix
+++ b/CHANGES/4545.bugfix
@@ -1,0 +1,1 @@
+Fixed packages being re-signed on every add when their signature carries only an issuer key ID and no issuer fingerprint subpacket, by comparing the configured fingerprint against the package's signing keys on their key IDs whenever either side lacks a full fingerprint.

--- a/pulp_rpm/app/shared_utils.py
+++ b/pulp_rpm/app/shared_utils.py
@@ -62,6 +62,8 @@ _VERSION_PREFIX = {
     rpm_rs.SignatureVersion.V6: "v6",
 }
 
+_KEY_ID_LENGTH = 16
+
 
 def format_signing_keys(signatures):
     """Format rpm_rs signature objects into prefixed identifier strings.
@@ -87,6 +89,50 @@ def extract_signing_keys(path):
     """Extract signing key fingerprints from an RPM file using rpm_rs."""
     pkg = rpm_rs.PackageMetadata.open(path)
     return format_signing_keys(pkg.signatures())
+
+
+def _split_key_identifier(identifier):
+    """Split a key identifier into (prefix, uppercase hex); a bare hex is assumed to be v4."""
+    prefix, sep, hex_part = identifier.partition(":")
+    return (prefix.lower(), hex_part.upper()) if sep else ("v4", identifier.upper())
+
+
+def _key_id_of(prefix, hex_part):
+    """Derive the key ID of a key identifier, or None if no rule is known for it."""
+    if len(hex_part) < _KEY_ID_LENGTH:
+        return None
+    if prefix == "keyid":
+        return hex_part
+    if prefix == "v4":  # a v4 key ID is the low-order 64 bits of the fingerprint
+        return hex_part[-_KEY_ID_LENGTH:]
+    if prefix == "v6":  # a v6 key ID is the high-order 64 bits (RFC 9580)
+        return hex_part[:_KEY_ID_LENGTH]
+    return None
+
+
+def _same_key(identifier, other):
+    """Check whether two key identifiers refer to the same key."""
+    prefix, hex_part = _split_key_identifier(identifier)
+    other_prefix, other_hex = _split_key_identifier(other)
+    if (prefix, hex_part) == (other_prefix, other_hex):
+        return True
+    # Only fall back to comparing key IDs when one side lacks a full fingerprint.
+    if "keyid" not in (prefix, other_prefix):
+        return False
+    key_id = _key_id_of(prefix, hex_part)
+    return key_id is not None and key_id == _key_id_of(other_prefix, other_hex)
+
+
+def signing_key_matches(fingerprint, signing_keys):
+    """Check whether fingerprint refers to the same key as any of signing_keys.
+
+    All arguments are prefixed identifiers of the form produced by format_signing_keys,
+    i.e. "v4:<hex>", "v6:<hex>" or "keyid:<16-hex>". Two full fingerprints must be equal,
+    but when either side carries only a key ID the comparison falls back to key IDs, so a
+    configured fingerprint still matches a package whose signature has no issuer
+    fingerprint subpacket.
+    """
+    return any(_same_key(fingerprint, signing_key) for signing_key in signing_keys)
 
 
 def read_crpackage_from_artifact(artifact, working_dir="."):

--- a/pulp_rpm/app/tasks/signing.py
+++ b/pulp_rpm/app/tasks/signing.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from tempfile import NamedTemporaryFile
 
 import createrepo_c as cr
-import rpm_rs
 from django.conf import settings
 
 from pulpcore.plugin.models import (
@@ -22,7 +21,7 @@ from pulp_rpm.app.exceptions import PackageSigningError
 from pulp_rpm.app.models.content import RpmPackageSigningResult, RpmPackageSigningService
 from pulp_rpm.app.models.package import Package
 from pulp_rpm.app.models.repository import RpmRepository
-from pulp_rpm.app.shared_utils import extract_signing_keys
+from pulp_rpm.app.shared_utils import extract_signing_keys, signing_key_matches
 
 log = logging.getLogger(__name__)
 
@@ -43,25 +42,11 @@ def _save_upload(uploadobj, final_package):
 
 def _verify_package_fingerprint(path, fingerprint):
     """Verify if the package at path is signed with signing_fingerprint or not."""
-    _, _, raw_fingerprint = fingerprint.upper().partition(":")
-    if not raw_fingerprint:
-        raw_fingerprint = fingerprint.upper()
-    pkg = rpm_rs.PackageMetadata.open(path)
-    key_ids = []
-    fingerprints = []
-    for sig in pkg.signatures():
-        if sig.fingerprint:
-            fingerprints.append(sig.fingerprint.upper())
-        elif sig.key_id:
-            key_ids.append(sig.key_id.upper())
-
-    if raw_fingerprint in key_ids + fingerprints:
+    signing_keys = extract_signing_keys(path)
+    if signing_key_matches(fingerprint, signing_keys):
         return True
 
-    log.debug(
-        f"Fingerprint mismatch for {path}: expected {raw_fingerprint}, "
-        f"found key IDs {key_ids} and fingerprints {fingerprints}."
-    )
+    log.debug(f"Fingerprint mismatch for {path}: expected {fingerprint}, found {signing_keys}.")
     return False
 
 

--- a/pulp_rpm/tests/functional/constants.py
+++ b/pulp_rpm/tests/functional/constants.py
@@ -389,6 +389,11 @@ RPM_FIXTURE_MULTI_SIGNED = urljoin(
 RPM_FIXTURE_COMPLEX = urljoin(RPM_FIXTURES_PACKAGES_URL, "complex-package-2.3.4-5.el8.x86_64.rpm")
 """An RPM fixture package with complex metadata."""
 
+RPM_FIXTURE_KEYID_SIGNED = urljoin(
+    RPM_FIXTURES_PACKAGES_URL, "static/test-package-keyid-signed-1.0-1.fc41.noarch.rpm"
+)
+"""An RPM fixture package signed with KEY_V4_RSA4K, carrying only an issuer key ID."""
+
 RPM_UPDATED_UPDATEINFO_FIXTURE_URL = urljoin(PULP_FIXTURES_BASE_URL, "rpm-updated-updateinfo/")
 """The URL to a repository containing UpdateRecords (Advisory) with the same IDs
 as the ones in the standard repositories, but with different metadata.

--- a/pulp_rpm/tests/unit/test_signing.py
+++ b/pulp_rpm/tests/unit/test_signing.py
@@ -4,9 +4,18 @@ import pytest
 import requests
 import rpm_rs
 
-from pulp_rpm.app.shared_utils import extract_signing_keys, format_signing_keys
+from pulp_rpm.app.shared_utils import extract_signing_keys, format_signing_keys, signing_key_matches
 from pulp_rpm.app.tasks.signing import _verify_package_fingerprint
-from pulp_rpm.tests.functional.constants import RPM_FIXTURE_SIGNED, RPM_FIXTURE_UNSIGNED
+from pulp_rpm.tests.functional.constants import (
+    RPM_FIXTURE_KEYID_SIGNED,
+    RPM_FIXTURE_SIGNED,
+    RPM_FIXTURE_UNSIGNED,
+)
+
+V4_FINGERPRINT = "AA86F75E427A19DD33346403EE4D7792F748182B"
+V4_KEY_ID = "EE4D7792F748182B"  # low-order 64 bits of V4_FINGERPRINT
+V6_FINGERPRINT = "CB186C4F0609A697D5A3BCE4DB0E5CD9E4B3394501AB1650B7FE1AAD1C1AFB4C"
+V6_KEY_ID = "CB186C4F0609A697"  # high-order 64 bits of V6_FINGERPRINT
 
 
 def _download_rpm(tmp_path, url, name="test.rpm"):
@@ -36,6 +45,16 @@ def signed_rpm(tmp_path):
     return _download_rpm(tmp_path, RPM_FIXTURE_SIGNED)
 
 
+@pytest.fixture
+def key_id_only_rpm(tmp_path):
+    """An RPM signed by the same key as signed_rpm, but with no issuer fingerprint.
+
+    Signed by a GnuPG predating the issuer fingerprint subpacket, as packages in
+    the wild often are.
+    """
+    return _download_rpm(tmp_path, RPM_FIXTURE_KEYID_SIGNED, name="key-id-only.rpm")
+
+
 def test_verify_unsigned_package(unsigned_rpm):
     assert not _verify_package_fingerprint(
         unsigned_rpm, "v4:0000000000000000000000000000000000000000"
@@ -62,6 +81,96 @@ def test_verify_signed_package_wrong_fingerprint(signed_rpm):
 def test_verify_fingerprint_without_prefix(signed_rpm):
     fingerprint = _get_fingerprint(signed_rpm)
     assert _verify_package_fingerprint(signed_rpm, fingerprint.upper())
+
+
+def test_verify_key_id_against_signed_package(signed_rpm):
+    """A repo configured with a 'keyid:' fingerprint matches a full package signature."""
+    # signed_rpm has a v4 signature, whose key ID is the low-order 64 bits of the fingerprint.
+    fingerprint = _get_fingerprint(signed_rpm).upper()
+    assert _verify_package_fingerprint(signed_rpm, f"keyid:{fingerprint[-16:]}")
+    assert not _verify_package_fingerprint(signed_rpm, f"keyid:{fingerprint[:16]}")
+
+
+def test_verify_key_id_only_signature_matches_full_fingerprint(signed_rpm, key_id_only_rpm):
+    """A package signature carrying only an issuer key ID matches a configured fingerprint."""
+    fingerprint = _get_fingerprint(signed_rpm).upper()
+
+    assert extract_signing_keys(key_id_only_rpm) == [f"keyid:{fingerprint[-16:]}"]
+    assert _verify_package_fingerprint(key_id_only_rpm, f"v4:{fingerprint}")
+
+
+# Tests for signing_key_matches
+
+
+def test_signing_key_matches_no_signing_keys():
+    assert not signing_key_matches(f"v4:{V4_FINGERPRINT}", [])
+
+
+def test_signing_key_matches_identical_fingerprint():
+    assert signing_key_matches(f"v4:{V4_FINGERPRINT}", [f"v4:{V4_FINGERPRINT}"])
+
+
+def test_signing_key_matches_is_case_insensitive():
+    assert signing_key_matches(f"v4:{V4_FINGERPRINT.lower()}", [f"v4:{V4_FINGERPRINT.upper()}"])
+
+
+def test_signing_key_matches_bare_fingerprint_assumed_v4():
+    assert signing_key_matches(V4_FINGERPRINT, [f"v4:{V4_FINGERPRINT}"])
+    assert signing_key_matches(V4_FINGERPRINT, [f"keyid:{V4_KEY_ID}"])
+
+
+def test_signing_key_matches_different_fingerprint():
+    assert not signing_key_matches(f"v4:{V4_FINGERPRINT}", ["v4:" + "0" * 40])
+
+
+def test_signing_key_matches_v4_fingerprint_against_key_id():
+    """A v4 key ID is the low-order 64 bits of its fingerprint."""
+    assert signing_key_matches(f"v4:{V4_FINGERPRINT}", [f"keyid:{V4_KEY_ID}"])
+    assert not signing_key_matches(f"v4:{V4_FINGERPRINT}", [f"keyid:{V4_FINGERPRINT[:16]}"])
+
+
+def test_signing_key_matches_key_id_against_v4_fingerprint():
+    """The comparison is symmetric: a configured key ID matches a full fingerprint."""
+    assert signing_key_matches(f"keyid:{V4_KEY_ID}", [f"v4:{V4_FINGERPRINT}"])
+    assert not signing_key_matches(f"keyid:{V4_FINGERPRINT[:16]}", [f"v4:{V4_FINGERPRINT}"])
+
+
+def test_signing_key_matches_v6_fingerprint_against_key_id():
+    """A v6 key ID is the high-order 64 bits of its fingerprint, not the low-order ones."""
+    assert signing_key_matches(f"v6:{V6_FINGERPRINT}", [f"keyid:{V6_KEY_ID}"])
+    assert not signing_key_matches(f"v6:{V6_FINGERPRINT}", [f"keyid:{V6_FINGERPRINT[-16:]}"])
+
+
+def test_signing_key_matches_key_id_against_v6_fingerprint():
+    assert signing_key_matches(f"keyid:{V6_KEY_ID}", [f"v6:{V6_FINGERPRINT}"])
+    assert not signing_key_matches(f"keyid:{V6_FINGERPRINT[-16:]}", [f"v6:{V6_FINGERPRINT}"])
+
+
+def test_signing_key_matches_identical_key_ids():
+    assert signing_key_matches(f"keyid:{V4_KEY_ID}", [f"keyid:{V4_KEY_ID}"])
+    assert not signing_key_matches(f"keyid:{V4_KEY_ID}", [f"keyid:{V6_KEY_ID}"])
+
+
+def test_signing_key_matches_requires_same_version():
+    """Fingerprints of different versions are different keys even if the hex matches."""
+    assert not signing_key_matches(f"v4:{V4_FINGERPRINT}", [f"v6:{V4_FINGERPRINT}"])
+
+
+def test_signing_key_matches_ignores_truncated_key_ids():
+    """Short key IDs are too collision-prone to match on, unlike a full 16-hex key ID."""
+    assert not signing_key_matches(f"v4:{V4_FINGERPRINT}", [f"keyid:{V4_KEY_ID[-8:]}"])
+    assert not signing_key_matches(f"keyid:{V4_KEY_ID[-8:]}", [f"v4:{V4_FINGERPRINT}"])
+
+
+def test_signing_key_matches_any_of_multiple_signing_keys():
+    signing_keys = ["v4:" + "0" * 40, f"keyid:{V4_KEY_ID}"]
+    assert signing_key_matches(f"v4:{V4_FINGERPRINT}", signing_keys)
+
+
+def test_signing_key_matches_unknown_version_prefix():
+    """An unknown version has no known key ID rule, so only exact equality can match."""
+    assert signing_key_matches(f"v5:{V4_FINGERPRINT}", [f"v5:{V4_FINGERPRINT}"])
+    assert not signing_key_matches(f"v5:{V4_FINGERPRINT}", [f"keyid:{V4_KEY_ID}"])
 
 
 # Tests for format_signing_keys


### PR DESCRIPTION
Many RPM signatures carry only an issuer key ID and no issuer fingerprint subpacket, so a repo configured with a full fingerprint never matched them and re-signed those packages with the same key on every add.

Compare the configured identifier and the package's signing keys on their key IDs whenever either side lacks a full fingerprint, deriving the key ID per signature version: a v4 key ID is the low-order 64 bits of the fingerprint, a v6 key ID the high-order ones (RFC 9580). Truncated key IDs never match, since 32 bits is too collision prone for a check that skips signing.

fixes #4545

Assisted-by: Claude Opus 5