### PR TITLE
[PULP-1787][backport/3.35] Fix postgres 65k param limit on the Copy API

### DIFF
--- a/CHANGES/+fix-copy-api-postgres-param-limit.bugfix
+++ b/CHANGES/+fix-copy-api-postgres-param-limit.bugfix
@@ -1,0 +1,1 @@
+Fixed queries in the content copy API that could exceed PostgreSQL's 65535 bound-parameter limit.

--- a/pulp_rpm/app/advisory.py
+++ b/pulp_rpm/app/advisory.py
@@ -20,6 +20,7 @@ from pulp_rpm.app.models import (
     UpdateRecord,
 )
 from pulp_rpm.app.shared_utils import is_previous_version
+from pulp_rpm.app.sql_utils import get_content_in_repoversion
 
 
 def resolve_advisories(version, previous_version):
@@ -47,8 +48,8 @@ def resolve_advisories(version, previous_version):
     """
     # identify conflicting advisories
     advisory_pulp_type = UpdateRecord.get_pulp_type()
-    current_advisories = UpdateRecord.objects.filter(
-        pk__in=version.content.filter(pulp_type=advisory_pulp_type)
+    current_advisories = get_content_in_repoversion(
+        version, pulp_type=advisory_pulp_type, cast=True
     )
 
     # check for any conflict
@@ -62,8 +63,8 @@ def resolve_advisories(version, previous_version):
         current_advisories_by_id[advisory.id].append(advisory)
 
     if previous_version:
-        previous_advisories = UpdateRecord.objects.filter(
-            pk__in=previous_version.content.filter(pulp_type=advisory_pulp_type)
+        previous_advisories = get_content_in_repoversion(
+            previous_version, pulp_type=advisory_pulp_type, cast=True
         )
         previous_advisory_ids = set(previous_advisories.values_list("id", flat=True))
 

--- a/pulp_rpm/app/models/advisory.py
+++ b/pulp_rpm/app/models/advisory.py
@@ -197,12 +197,13 @@ class UpdateRecord(Content):
             pkglist(list): list of tuples with NEVRA info
 
         """
-        pkglist = []
-        for collection in self.collections.all():
-            for pkg in collection.packages.all().order_by("sum"):
-                nevra = (pkg.name, pkg.epoch, pkg.version, pkg.release, pkg.arch)
-                pkglist.append(nevra)
-        return pkglist
+        collection_pks = self.collections.values_list("pk", flat=True)  # lazy
+        packages = (
+            UpdateCollectionPackage.objects.filter(update_collection__in=collection_pks)
+            .order_by("sum")
+            .values_list("name", "epoch", "version", "release", "arch")
+        )
+        return list(packages.iterator())
 
     def get_module_list(self):
         """

--- a/pulp_rpm/app/models/repository.py
+++ b/pulp_rpm/app/models/repository.py
@@ -52,7 +52,8 @@ from pulp_rpm.app.models import (
     RpmPackageSigningService,
     UpdateRecord,
 )
-from pulp_rpm.app.shared_utils import annotate_with_age, urlpath_sanitize
+from pulp_rpm.app.shared_utils import urlpath_sanitize
+from pulp_rpm.app.sql_utils import annotate_with_age, get_content_in_repoversion
 
 log = getLogger(__name__)
 
@@ -482,7 +483,7 @@ class RpmRepository(Repository, AutoAddObjPermsMixin):
                                                                        the current incomplete one
         """
         disttree_pulp_type = DistributionTree.get_pulp_type()
-        current_disttrees = new_version.content.filter(pulp_type=disttree_pulp_type)
+        current_disttrees = get_content_in_repoversion(new_version, pulp_type=disttree_pulp_type)
 
         if len(current_disttrees) < 2:
             return

--- a/pulp_rpm/app/modulemd.py
+++ b/pulp_rpm/app/modulemd.py
@@ -7,7 +7,10 @@ from gettext import gettext as _  # noqa:F401
 
 import createrepo_c as cr
 import yaml
+from django.db.models import Prefetch
 from jsonschema import Draft7Validator
+
+from pulpcore.plugin.models import Content
 
 from pulp_rpm.app.constants import (
     PULP_MODULE_ATTR,
@@ -18,6 +21,7 @@ from pulp_rpm.app.constants import (
 )
 from pulp_rpm.app.models import Modulemd, Package
 from pulp_rpm.app.schema import MODULEMD_SCHEMA
+from pulp_rpm.app.sql_utils import get_content_in_repoversion, safe_in
 
 log = logging.getLogger(__name__)
 
@@ -32,22 +36,28 @@ def resolve_module_packages(version, previous_version):
                                                                     repository to compare to
 
     """
+    modulemd_pulp_type = Modulemd.get_pulp_type()
 
     def modules_packages(modules):
         packages = set()
-        for module in modules:
-            packages.update(module.packages.all().only("pk"))
+        # Materialize pks because Django dont allow prefetching on a difference's result
+        module_pks = [module.pk for module in modules]
+        modules_in_content = Content.objects.filter(
+            safe_in("pk", module_pks), pulp_type=modulemd_pulp_type
+        )
+        prefetched_modules = Modulemd.objects.filter(pk__in=modules_in_content).prefetch_related(
+            Prefetch("packages", queryset=Package.objects.only("pk"))
+        )
+        for module in prefetched_modules.only("pk", "pulp_type").iterator(chunk_size=2000):
+            packages.update(module.packages.all())
         return packages
 
-    modulemd_pulp_type = Modulemd.get_pulp_type()
-    current_modules = Modulemd.objects.filter(
-        pk__in=version.content.filter(pulp_type=modulemd_pulp_type)
-    )
+    current_modules = get_content_in_repoversion(version, pulp_type=modulemd_pulp_type, cast=True)
     current_module_packages = modules_packages(current_modules)
 
     if previous_version:
-        previous_modules = Modulemd.objects.filter(
-            pk__in=previous_version.content.filter(pulp_type=modulemd_pulp_type)
+        previous_modules = get_content_in_repoversion(
+            previous_version, pulp_type=modulemd_pulp_type, cast=True
         )
         added_modules = current_modules.difference(previous_modules)
         removed_modules = previous_modules.difference(current_modules)

--- a/pulp_rpm/app/shared_utils.py
+++ b/pulp_rpm/app/shared_utils.py
@@ -2,7 +2,6 @@ import shutil
 import subprocess
 import tempfile
 import typing as t
-from collections import defaultdict
 from hashlib import sha256
 from pathlib import Path
 
@@ -12,50 +11,6 @@ from django.utils.dateparse import parse_datetime
 from importlib_resources import files
 
 from pulpcore.plugin.exceptions import InvalidSignatureError
-
-from pulp_rpm.app.rpm_version import RpmVersion
-
-
-def annotate_with_age(qs):
-    """Provide an "age" score for each Package object in the queryset.
-
-    Annotate the Package objects with an "age". Age is calculated by partitioning the
-    Packages by name and architecture and ordering the packages in each group by 'evr',
-    which is the relative "age" within the group. The newest package gets age=1, second
-    newest age=2, and so on.
-
-    A second partition by architecture is important because there can be packages with
-    the same name and version numbers but they are not interchangeable because they have
-    differing arch, such as 'x86_64' and 'i686', or 'src' (SRPM) and any other arch.
-    """
-    # Get packages in current queryset with their basic info
-    packages = list(qs.values("pk", "name", "arch", "epoch", "version", "release"))
-
-    # Group packages by name and arch
-    groups = defaultdict(list)
-    for pkg in packages:
-        key = (pkg["name"], pkg["arch"])
-        groups[key].append(pkg)
-
-    # Calculate age for each group
-    age_mapping = {}
-    for group_packages in groups.values():
-        # Sort by EVR (newest first)
-        group_packages.sort(
-            key=lambda p: RpmVersion(p["epoch"], p["version"], p["release"]), reverse=True
-        )
-
-        # Assign ages (1 = newest, 2 = second newest, etc.)
-        for age, pkg in enumerate(group_packages, 1):
-            age_mapping[pkg["pk"]] = age
-
-    # Create a queryset with age annotation
-    # We'll use a CASE statement to map PKs to ages
-    from django.db.models import Case, IntegerField, When
-
-    when_clauses = [When(pk=pk, then=age) for pk, age in age_mapping.items()]
-
-    return qs.annotate(age=Case(*when_clauses, output_field=IntegerField()))
 
 
 def format_nevra(name=None, epoch=0, version=None, release=None, arch=None):

--- a/pulp_rpm/app/sql_utils.py
+++ b/pulp_rpm/app/sql_utils.py
@@ -1,0 +1,162 @@
+from collections import defaultdict
+from collections.abc import Iterable
+
+from django.db.models import Expression, F, Field, Func, IntegerField, Q
+from django.db.models.lookups import Lookup
+
+from pulpcore.plugin.models import Content, RepositoryVersion
+from pulpcore.plugin.util import get_domain_pk
+
+from pulp_rpm.app.rpm_version import RpmVersion
+
+
+class _AnyArray(Lookup):
+    """PostgreSQL ``= ANY(%s)`` lookup. Passes the list as one array parameter."""
+
+    lookup_name = "any_array"
+
+    def get_prep_lookup(self):
+        return [self.lhs.output_field.get_prep_value(v) for v in self.rhs]
+
+    def as_sql(self, compiler, connection):
+        lhs, lhs_params = self.process_lhs(compiler, connection)
+        return f"{lhs} = ANY(%s)", lhs_params + [list(self.rhs)]
+
+
+Field.register_lookup(_AnyArray)
+
+
+def safe_in(field_name: str, values: Iterable) -> Q:
+    """Passes a non-query-set iterable of values a single array parameter.
+
+    This ensures selections such as `pk__in=(1,2, ..., n)` doesn't generate a SQL with
+    n query params (e.g, `WHERE pk in (%s, %s, ..., %s)`), but a single %s which is a
+    postgres array of values. This prevent hitting the 65535 query param limit on the
+    extended query protocol:
+
+    <https://www.postgresql.org/docs/current/protocol-flow.html#PROTOCOL-FLOW-EXT-QUERY>
+
+    Use this if you need to pass a potentially large list of materialized values into
+    a `{field}__in` filter. If the values are purely from queryset, this is not required.
+
+    Notes:
+        * Doesn't work on "pk" for casted Content subclasses (e.g. PackageGroup, Package): there,
+          pk is a foreign key (content_ptr), not a plain UUID field, and any_array isn't supported.
+    """
+    if not isinstance(values, (list, set, tuple, frozenset)):
+        values_type = type(values)
+        raise TypeError(
+            f"This is designed to be used with in-memory iterable of values. Got: {values_type}"
+        )
+    return Q(**{f"{field_name}__any_array": list(values)})
+
+
+class UnnestMapping(Expression):
+    """Maps a model field to values using PostgreSQL unnest() with parallel arrays.
+
+    Resolves `field_name` through Django's own compiler (rather than a hardcoded table
+    name), so it works correctly regardless of the alias Django assigns the field's table -
+    including when the annotated queryset is embedded in a Subquery().
+    """
+
+    def __init__(
+        self, field_name, keys, values, key_type="uuid", value_type="int", output_field=None
+    ):
+        super().__init__(output_field=output_field or IntegerField())
+        self.field_expr = F(field_name) if isinstance(field_name, str) else field_name
+        self.keys = list(keys)
+        self.values = list(values)
+        self.key_type = key_type
+        self.value_type = value_type
+
+    def get_source_expressions(self):
+        return [self.field_expr]
+
+    def set_source_expressions(self, exprs):
+        (self.field_expr,) = exprs
+
+    def as_sql(self, compiler, connection):
+        field_sql, field_params = compiler.compile(self.field_expr)
+        sql = (
+            f"(SELECT map.val FROM unnest(%s::{self.key_type}[], %s::{self.value_type}[]) "
+            f"AS map(key, val) WHERE map.key = {field_sql})"
+        )
+        params = [self.keys, self.values] + list(field_params)
+        return sql, params
+
+
+def get_content_in_repoversion(repo_version, content_qs=None, pulp_type=None, cast=False):
+    """Get content present in repo_version.
+
+    Args:
+        repo_version: RepositoryVersion to restrict to.
+        content_qs: Base queryset to restrict, defaults to Content.objects.
+        pulp_type: Restrict to this pulp_type.
+        cast: If True, query the specific Content subclass for pulp_type instead of base
+            Content rows, so its own fields (not just pk) are accessible on the results.
+            Requires pulp_type.
+    """
+    # TODO: remove once RepositoryVersion.get_content() applies its own unnest() workaround
+    # unconditionally instead of only when content_ids has >= 65535 items.
+    #
+    # The reason behind this to enable testing membership against a large set (repo content)
+    # with few query params, which the use of the pg array solves. Besides that, the query
+    # leverages the fact that the table already contains the content_ids field, so it can
+    # select the content in the repository version directly on the db side (without requiring
+    # the app to ever re-send the whole set).
+    repo_content_ids = (
+        RepositoryVersion.objects.filter(pk=repo_version.pk)
+        .annotate(cids=Func(F("content_ids"), function="unnest"))
+        .values_list("cids", flat=True)
+    )
+
+    if cast:
+        if pulp_type is None:
+            raise ValueError("cast=True requires pulp_type")
+        content_qs = Content.get_model_for_pulp_type(pulp_type).objects
+        return content_qs.filter(pk__in=repo_content_ids, pulp_domain=get_domain_pk())
+
+    content_qs = content_qs if content_qs is not None else Content.objects
+    content_qs = content_qs.filter(pk__in=repo_content_ids, pulp_domain=get_domain_pk())
+    if pulp_type is not None:
+        content_qs = content_qs.filter(pulp_type=pulp_type)
+    return content_qs
+
+
+def annotate_with_age(qs):
+    """Provide an "age" score for each Package object in the queryset.
+
+    Annotate the Package objects with an "age". Age is calculated by partitioning the
+    Packages by name and architecture and ordering the packages in each group by 'evr',
+    which is the relative "age" within the group. The newest package gets age=1, second
+    newest age=2, and so on.
+
+    A second partition by architecture is important because there can be packages with
+    the same name and version numbers but they are not interchangeable because they have
+    differing arch, such as 'x86_64' and 'i686', or 'src' (SRPM) and any other arch.
+    """
+    # Get packages in current queryset with their basic info
+    packages = list(qs.values("pk", "name", "arch", "epoch", "version", "release"))
+
+    # Group packages by name and arch
+    groups = defaultdict(list)
+    for pkg in packages:
+        key = (pkg["name"], pkg["arch"])
+        groups[key].append(pkg)
+
+    # Calculate age for each group
+    age_mapping = {}
+    for group_packages in groups.values():
+        # Sort by EVR (newest first)
+        group_packages.sort(
+            key=lambda p: RpmVersion(p["epoch"], p["version"], p["release"]), reverse=True
+        )
+
+        # Assign ages (1 = newest, 2 = second newest, etc.)
+        for age, pkg in enumerate(group_packages, 1):
+            age_mapping[pkg["pk"]] = age
+
+    # Map pk -> age via a single unnest()-zipped array (2 params total, regardless of
+    # how many packages are involved).
+    pks, ages = zip(*age_mapping.items()) if age_mapping else ((), ())
+    return qs.annotate(age=UnnestMapping("pk", pks, ages))

--- a/pulp_rpm/app/tasks/copy.py
+++ b/pulp_rpm/app/tasks/copy.py
@@ -1,5 +1,6 @@
 from django.db import transaction
-from django.db.models import Q
+from django.db.models import BooleanField
+from django.db.models.expressions import RawSQL
 
 from pulpcore.plugin.models import Content, RepositoryVersion
 from pulpcore.plugin.util import get_domain_pk
@@ -14,7 +15,7 @@ from pulp_rpm.app.models import (
     RpmRepository,
     UpdateRecord,
 )
-from pulp_rpm.app.shared_utils import annotate_with_age
+from pulp_rpm.app.sql_utils import annotate_with_age, get_content_in_repoversion, safe_in
 
 
 def find_children_of_content(content, src_repo_version):
@@ -35,49 +36,72 @@ def find_children_of_content(content, src_repo_version):
     packagegroup_ids = content.filter(pulp_type=PackageGroup.get_pulp_type()).only("pk")
 
     # Content in the source repository version
-    package_ids = src_repo_version.content.filter(pulp_type=Package.get_pulp_type()).only("pk")
-    module_ids = src_repo_version.content.filter(pulp_type=Modulemd.get_pulp_type()).only("pk")
+    package_ids = get_content_in_repoversion(
+        src_repo_version, pulp_type=Package.get_pulp_type()
+    ).only("pk")
+    module_ids = get_content_in_repoversion(
+        src_repo_version, pulp_type=Modulemd.get_pulp_type()
+    ).only("pk")
 
-    advisories = UpdateRecord.objects.filter(pk__in=advisory_ids)
+    # pulp_type is required alongside pk: django-lifecycle (BaseModel) needs it per instance to
+    # evaluate its hooks, and omitting it here would trigger a refresh_from_db() per row instead.
+    advisories = UpdateRecord.objects.filter(pk__in=advisory_ids).only("pk", "pulp_type")
     packages = Package.objects.filter(pk__in=package_ids)
     packagecategories = PackageCategory.objects.filter(pk__in=packagecategory_ids)
     packageenvironments = PackageEnvironment.objects.filter(pk__in=packageenvironment_ids)
-    packagegroups = PackageGroup.objects.filter(pk__in=packagegroup_ids)
+    packagegroups = PackageGroup.objects.filter(pk__in=packagegroup_ids).only(
+        "pk", "packages", "pulp_type"
+    )
     modules = Modulemd.objects.filter(pk__in=module_ids)
 
     children = set()
 
+    # --- Advisories: resolve the packages and modules they reference ---
+    domain_pk = get_domain_pk()
     for advisory in advisories.iterator():
-        # Find rpms referenced by Advisories/Errata
         package_nevras = advisory.get_pkglist()
-        advisory_package_q = Q(pk__in=[])
-        for nevra in package_nevras:
-            name, epoch, version, release, arch = nevra
-            advisory_package_q |= Q(
-                name=name,
-                epoch=epoch,
-                version=version,
-                release=release,
-                arch=arch,
-                pulp_domain=get_domain_pk(),
+        if package_nevras:
+            # Uses a single unnest()-zipped array comparison (avoid param blow)
+            names, epochs, versions, releases, arches = zip(*package_nevras)
+            matching_packages = (
+                packages.filter(pulp_domain=domain_pk)
+                .annotate(
+                    _nevra_match=RawSQL(
+                        '("rpm_package"."name", "rpm_package"."epoch", "rpm_package"."version", '
+                        '"rpm_package"."release", "rpm_package"."arch") IN '
+                        "(SELECT * FROM unnest(%s::text[], %s::text[], %s::text[], "
+                        "%s::text[], %s::text[]))",
+                        (list(names), list(epochs), list(versions), list(releases), list(arches)),
+                        output_field=BooleanField(),
+                    )
+                )
+                .filter(_nevra_match=True)
             )
-        children.update(packages.filter(advisory_package_q).values_list("pk", flat=True))
+            children.update(matching_packages.values_list("pk", flat=True))
 
         module_nsvcas = advisory.get_module_list()
-        advisory_module_q = Q(pk__in=[])
-        for nsvca in module_nsvcas:
-            name, stream, version, context, arch = nsvca
-            advisory_module_q |= Q(
-                name=name,
-                stream=stream,
-                version=version,
-                context=context,
-                arch=arch,
-                pulp_domain=get_domain_pk(),
+        if module_nsvcas:
+            # Uses a single unnest()-zipped array comparison (avoid param blow)
+            names, streams, versions, contexts, arches = zip(*module_nsvcas)
+            matching_modules = (
+                modules.filter(pulp_domain=domain_pk)
+                .annotate(
+                    _nsvca_match=RawSQL(
+                        '("rpm_modulemd"."name", "rpm_modulemd"."stream", '
+                        '"rpm_modulemd"."version", "rpm_modulemd"."context", '
+                        '"rpm_modulemd"."arch") IN '
+                        "(SELECT * FROM unnest(%s::text[], %s::text[], %s::text[], "
+                        "%s::text[], %s::text[]))",
+                        (list(names), list(streams), list(versions), list(contexts), list(arches)),
+                        output_field=BooleanField(),
+                    )
+                )
+                .filter(_nsvca_match=True)
             )
-        children.update(modules.filter(advisory_module_q).values_list("pk", flat=True))
+            children.update(matching_modules.values_list("pk", flat=True))
 
-    # PackageCategories & PackageEnvironments resolution must go before PackageGroups
+    # --- PackageCategories & PackageEnvironments: resolve the PackageGroups they reference ---
+    # (must go before the PackageGroups section below, which needs the full group set)
     packagegroup_names = set()
     for packagecategory in packagecategories.iterator():
         for group_id in packagecategory.group_ids:
@@ -90,12 +114,12 @@ def find_children_of_content(content, src_repo_version):
             packagegroup_names.add(group_id["name"])
 
     child_package_groups = PackageGroup.objects.filter(
-        name__in=packagegroup_names, pk__in=src_repo_version.content
-    )
-    children.update([pkggroup.pk for pkggroup in child_package_groups])
+        safe_in("name", packagegroup_names), pk__in=get_content_in_repoversion(src_repo_version)
+    ).only("pk", "packages", "pulp_type")
+    children.update(child_package_groups.values_list("pk", flat=True))
     packagegroups = packagegroups.union(child_package_groups)
 
-    # Find rpms referenced by PackageGroups
+    # --- PackageGroups: resolve the packages they reference ---
     packagegroup_package_names = set()
     for packagegroup in packagegroups.iterator():
         packagegroup_package_names |= set(pkg["name"] for pkg in packagegroup.packages)
@@ -103,7 +127,7 @@ def find_children_of_content(content, src_repo_version):
     # TODO: do modular/nonmodular need to be taken into account?
     existing_package_names = (
         Package.objects.filter(
-            name__in=packagegroup_package_names,
+            safe_in("name", packagegroup_package_names),
             pk__in=content,
         )
         .values_list("name", flat=True)
@@ -113,16 +137,19 @@ def find_children_of_content(content, src_repo_version):
     missing_package_names = packagegroup_package_names - set(existing_package_names)
 
     needed_packages = annotate_with_age(
-        Package.objects.filter(name__in=missing_package_names, pk__in=src_repo_version.content)
+        Package.objects.filter(
+            safe_in("name", missing_package_names),
+            pk__in=get_content_in_repoversion(src_repo_version),
+        )
     )
 
     # Pick the latest version of each package available which isn't already present
     # in the content set.
-    for pkg in needed_packages.iterator():
-        if pkg.age == 1:
-            children.add(pkg.pk)
+    for pk, age in needed_packages.values_list("pk", "age").iterator():
+        if age == 1:
+            children.add(pk)
 
-    return Content.objects.filter(pk__in=children)
+    return Content.objects.filter(safe_in("pk", children))
 
 
 @transaction.atomic
@@ -151,19 +178,12 @@ def copy_content(config, dependency_solving):
             dest_repo_version = RepositoryVersion.objects.get(pk=entry["dest_base_version"])
         else:
             dest_repo_version = dest_repo.latest_version()
-
-        if entry.get("content") is not None:
-            content_filter = Q(pk__in=entry.get("content"))
-        else:
-            content_filter = Q()
-
-        content_filter &= Q(pulp_domain=get_domain_pk())
-
+        content_pks = entry.get("content")
         return (
             source_repo_version,
             dest_repo_version,
             dest_repo,
-            content_filter,
+            content_pks,
             dest_version_provided,
         )
 
@@ -175,12 +195,17 @@ def copy_content(config, dependency_solving):
                 source_repo_version,
                 dest_repo_version,
                 dest_repo,
-                content_filter,
+                content_pks,
                 dest_version_provided,
             ) = process_entry(entry)
 
-            content_to_copy = source_repo_version.content.filter(content_filter)
-            content_to_copy |= find_children_of_content(content_to_copy, source_repo_version)
+            content_in_repo = get_content_in_repoversion(source_repo_version)
+            if content_pks is None:
+                content_to_copy = content_in_repo
+            else:
+                user_selected = content_in_repo.filter(safe_in("pk", content_pks))
+                content_children = find_children_of_content(user_selected, source_repo_version)
+                content_to_copy = user_selected | content_children
 
             base_version = dest_repo_version if dest_version_provided else None
             with dest_repo.new_version(base_version=base_version) as new_version:
@@ -202,7 +227,7 @@ def copy_content(config, dependency_solving):
                 source_repo_version,
                 dest_repo_version,
                 dest_repo,
-                content_filter,
+                content_pks,
                 dest_version_provided,
             ) = process_entry(entry)
 
@@ -221,7 +246,11 @@ def copy_content(config, dependency_solving):
             # Find all of the matching content in the repository version, then determine
             # child relationships (e.g. RPM children of Errata/Advisories), then combine
             # those two sets to copy the specified content + children.
-            content = source_repo_version.content.filter(content_filter)
+            content_in_repo = get_content_in_repoversion(source_repo_version)
+            if content_pks is None:
+                content = content_in_repo
+            else:
+                content = content_in_repo.filter(safe_in("pk", content_pks))
             children = find_children_of_content(content, source_repo_version)
             content_to_copy[source_repo_name] = content | children
 

--- a/pulp_rpm/app/tasks/prune.py
+++ b/pulp_rpm/app/tasks/prune.py
@@ -16,7 +16,7 @@ from pulpcore.plugin.tasking import dispatch
 
 from pulp_rpm.app.models.package import Package
 from pulp_rpm.app.models.repository import RpmRepository
-from pulp_rpm.app.shared_utils import annotate_with_age
+from pulp_rpm.app.sql_utils import annotate_with_age
 
 log = getLogger(__name__)
 

--- a/pulp_rpm/tests/unit/conftest.py
+++ b/pulp_rpm/tests/unit/conftest.py
@@ -1,0 +1,36 @@
+import re
+from pathlib import Path
+
+import pytest
+
+_SAVED_ARTIFACTS = []
+
+
+@pytest.fixture
+def save_artifact(request):
+    """Returns a function that saves `content` to
+    /tmp/pytest-artifacts/{test_name}.{param_case}[.{suffix}].{extension}, for inspecting
+    test-generated artifacts (query dumps, etc.) after a run. Every saved path is printed in a
+    summary at the end of the pytest session.
+    """
+
+    def _save(content: str, suffix: str | None = None, extension: str = "sql") -> Path:
+        artifacts_dir = Path("/tmp/pytest-artifacts")
+        artifacts_dir.mkdir(exist_ok=True)
+        test_id = re.sub(r"\[(.+)\]$", r".\1", request.node.name)
+        test_id = re.sub(r"[^\w.-]", "_", test_id)
+        parts = [test_id, *([suffix] if suffix else []), extension]
+        path = artifacts_dir / ".".join(parts)
+        path.write_text(content)
+        _SAVED_ARTIFACTS.append(path)
+        return path
+
+    return _save
+
+
+def pytest_terminal_summary(terminalreporter, exitstatus, config):
+    if not _SAVED_ARTIFACTS:
+        return
+    terminalreporter.write_sep("-", "saved artifacts")
+    for path in _SAVED_ARTIFACTS:
+        terminalreporter.write_line(str(path))

--- a/pulp_rpm/tests/unit/test_copy.py
+++ b/pulp_rpm/tests/unit/test_copy.py
@@ -1,0 +1,286 @@
+"""Unit tests for copy_content in the copy task."""
+
+import json
+import re
+import uuid
+from dataclasses import dataclass
+
+import pytest
+
+from pulp_rpm.app.models import RpmRepository
+from pulp_rpm.app.tasks.copy import copy_content
+from pulp_rpm.tests.unit.utils.content_factory import RepoContentFactory
+from pulp_rpm.tests.unit.utils.query_recorder import QueryRecorder, detect_n1
+
+
+class GrowthProfiles:
+    """Builders for parent/child content relationships, one repo version each.
+
+    Each builder takes (count, repo_name) and returns (repo_version, only_content_ids selecting
+    just the parent, expected child pks).
+    """
+
+    @staticmethod
+    def packages_within_advisories(count, repo_name):
+        """Grow the packages one advisory references via an UpdateCollection."""
+        with RepoContentFactory(repo_name=repo_name) as repo:
+            package_names = [f"{repo_name}-pkg-{i}" for i in range(count)]
+            package_pks = repo.add_packages(package_names)
+            advisory_pk = repo.add_advisory(f"{repo_name}-advisory", package_names=package_names)
+        return repo.version, [advisory_pk], set(package_pks)
+
+    @staticmethod
+    def modules_within_advisories(count, repo_name):
+        """Grow the modules one advisory references, one UpdateCollection each."""
+        with RepoContentFactory(repo_name=repo_name) as repo:
+            module_names = [f"{repo_name}-mod-{i}" for i in range(count)]
+            module_nsvcas, module_pks = repo.add_modulemds(module_names)
+            advisory_pk = repo.add_advisory(f"{repo_name}-advisory", module_nsvcas=module_nsvcas)
+        return repo.version, [advisory_pk], set(module_pks)
+
+    @staticmethod
+    def packages_within_packagegroups(count, repo_name):
+        """Grow the packages one package group references."""
+        with RepoContentFactory(repo_name=repo_name) as repo:
+            package_names = [f"{repo_name}-pkg-{i}" for i in range(count)]
+            package_pks = repo.add_packages(package_names)
+            group_pk = repo.add_package_group(f"{repo_name}-group", packages=package_names)
+        return repo.version, [group_pk], set(package_pks)
+
+    @staticmethod
+    def packagegroups_within_packageenv(count, repo_name):
+        """Grow the package groups one environment references via group_ids (mandatory groups)."""
+        with RepoContentFactory(repo_name=repo_name) as repo:
+            group_names = [f"{repo_name}-grp-{i}" for i in range(count)]
+            group_pks = [repo.add_package_group(name) for name in group_names]
+            env_pk = repo.add_package_environment(f"{repo_name}-env", group_names=group_names)
+        return repo.version, [env_pk], set(group_pks)
+
+    @staticmethod
+    def packagegroups_within_packagecategory(count, repo_name):
+        """Grow the package groups one category references."""
+        with RepoContentFactory(repo_name=repo_name) as repo:
+            group_names = [f"{repo_name}-grp-{i}" for i in range(count)]
+            group_pks = [repo.add_package_group(name) for name in group_names]
+            category_pk = repo.add_package_category(f"{repo_name}-cat", group_names=group_names)
+        return repo.version, [category_pk], set(group_pks)
+
+    @staticmethod
+    def advisories(count, repo_name):
+        """Grow the number of empty advisories explicitly selected for copy.
+
+        Unlike the other profiles, what grows here is the *selection* itself
+        (content_pks/only_ids), not the children of a single fixed parent.
+        """
+        with RepoContentFactory(repo_name=repo_name) as repo:
+            advisory_pks = [repo.add_advisory(f"{repo_name}-advisory-{i}") for i in range(count)]
+        return repo.version, advisory_pks, set()
+
+    @staticmethod
+    def packagecategories(count, repo_name):
+        """Grow the number of empty package categories explicitly selected for copy."""
+        with RepoContentFactory(repo_name=repo_name) as repo:
+            category_pks = [
+                repo.add_package_category(f"{repo_name}-cat-{i}", group_names=[])
+                for i in range(count)
+            ]
+        return repo.version, category_pks, set()
+
+    @staticmethod
+    def packageenvironments(count, repo_name):
+        """Grow the number of empty package environments explicitly selected for copy."""
+        with RepoContentFactory(repo_name=repo_name) as repo:
+            env_pks = [
+                repo.add_package_environment(f"{repo_name}-env-{i}", group_names=[])
+                for i in range(count)
+            ]
+        return repo.version, env_pks, set()
+
+    @staticmethod
+    def packagegroups_within_packageenv_options(count, repo_name):
+        """Grow the package groups one environment references via option_ids (optional groups),
+        instead of group_ids (mandatory groups) - that loop is never exercised otherwise.
+        """
+        with RepoContentFactory(repo_name=repo_name) as repo:
+            group_names = [f"{repo_name}-grp-{i}" for i in range(count)]
+            group_pks = [repo.add_package_group(name) for name in group_names]
+            env_pk = repo.add_package_environment(
+                f"{repo_name}-env", group_names=[], option_names=group_names
+            )
+        return repo.version, [env_pk], set(group_pks)
+
+    @staticmethod
+    def packages_already_selected_within_packagegroup(count, repo_name):
+        """Grow the packages a group references that are ALSO part of the explicit selection.
+
+        Exercises the existing_package_names/missing_package_names dedup branch: since the
+        packages are already selected, none of them should be looked up via annotate_with_age.
+        """
+        with RepoContentFactory(repo_name=repo_name) as repo:
+            package_names = [f"{repo_name}-pkg-{i}" for i in range(count)]
+            package_pks = repo.add_packages(package_names)
+            group_pk = repo.add_package_group(f"{repo_name}-group", packages=package_names)
+        return repo.version, [group_pk, *package_pks], set()
+
+    @staticmethod
+    def packagegroups(count, repo_name):
+        """Grow the number of empty package groups explicitly selected for copy."""
+        with RepoContentFactory(repo_name=repo_name) as repo:
+            group_pks = [repo.add_package_group(f"{repo_name}-grp-{i}") for i in range(count)]
+        return repo.version, group_pks, set()
+
+    PROFILES = {
+        "grow_packages_within_advisories": packages_within_advisories,
+        "grow_modules_within_advisories": modules_within_advisories,
+        "grow_packages_within_packagegroups": packages_within_packagegroups,
+        "grow_packagegroups_within_packageenv": packagegroups_within_packageenv,
+        "grow_packagegroups_within_packagecategory": packagegroups_within_packagecategory,
+        "grow_advisories": advisories,
+        "grow_packagecategories": packagecategories,
+        "grow_packagegroups_within_packageenv_options": packagegroups_within_packageenv_options,
+        "grow_packages_already_selected_within_packagegroup": (
+            packages_already_selected_within_packagegroup
+        ),
+        "grow_packagegroups": packagegroups,
+        "grow_packageenvironments": packageenvironments,
+    }
+
+
+@dataclass
+class CopyWorkflowResult:
+    children: set
+    resolved: set
+    recorder: QueryRecorder
+
+
+@dataclass
+class IgnoreFromPath:
+    pattern: str
+    reason: str
+
+
+def make_growth_candidate_filter(ignore_paths=None):
+    """Build a get_queries() filter_fn matching non-ignored SELECTs with bound params."""
+    ignore_paths = ignore_paths or []
+
+    def is_growth_candidate(query) -> bool:
+        if query.statement_type != "SELECT" or query.num_params == 0:
+            return False
+        if any(
+            re.search(ignore.pattern, site) for ignore in ignore_paths for site in query.call_site
+        ):
+            return False
+        return True
+
+    return is_growth_candidate
+
+
+def make_not_ignored_filter(ignore_paths=None):
+    """Build a get_queries() filter_fn excluding queries matching one of `ignore_paths`."""
+    ignore_paths = ignore_paths or []
+
+    def not_ignored(query) -> bool:
+        return not any(
+            re.search(ignore.pattern, site) for ignore in ignore_paths for site in query.call_site
+        )
+
+    return not_ignored
+
+
+class TestCopyContentBase:
+    def call_copy_workflow(self, content_count: int, profile_name: str) -> CopyWorkflowResult:
+        build = GrowthProfiles.PROFILES[profile_name]
+        repo_name = f"{profile_name}-{content_count}"
+        version, ids, children = build(content_count, repo_name)
+        dest_repo = RpmRepository.objects.create(name=str(uuid.uuid4()))
+        config = [
+            {
+                "source_repo_version": version.pk,
+                "dest_repo": dest_repo.pk,
+                "content": list(ids),
+            }
+        ]
+        recorder = QueryRecorder()
+        with recorder:
+            copy_content(config, dependency_solving=False)
+        dest_content = dest_repo.latest_version().content
+        resolved = set(dest_content.values_list("pk", flat=True))
+        return CopyWorkflowResult(children=children, resolved=resolved, recorder=recorder)
+
+    @pytest.mark.parametrize("profile_name", GrowthProfiles.PROFILES.keys())
+    @pytest.mark.django_db
+    def test_query_count_is_size_invariant(self, profile_name, save_artifact):
+        """copy_content() must issue the same NUMBER of queries regardless of how much content
+        is being copied. A differing count for the same profile means an N+1 query bug (e.g. one
+        query per referenced item in a Python loop), as opposed to a query whose own bound-param
+        count merely grows - that's covered separately.
+        """
+        SMALL_COUNT = 20
+        SCALE_FACTOR = 10
+        LARGE_COUNT = SMALL_COUNT * SCALE_FACTOR
+        IGNORE_PATHS = [
+            IgnoreFromPath(
+                pattern=r"advisory\.py:\d+ in (get_pkglist|get_module_list)",
+                reason="needs further investigation",
+            ),
+        ]
+
+        small = self.call_copy_workflow(SMALL_COUNT, profile_name)
+        large = self.call_copy_workflow(LARGE_COUNT, profile_name)
+        save_artifact(small.recorder.summary_text(include_sql=True), suffix="small")
+
+        not_ignored = make_not_ignored_filter(IGNORE_PATHS)
+        small_queries = small.recorder.get_queries(not_ignored)
+        large_queries = large.recorder.get_queries(not_ignored)
+        offenders = detect_n1(small_queries, large_queries)
+
+        passed = not offenders  # keeps error msg clean
+        assert passed, (
+            json.dumps(offenders, indent=4)
+            + f"\n\n[{profile_name}] {len(offenders)} quer(ies) fired a different number of "
+            f"times between runs:\n"
+        )
+
+    @pytest.mark.parametrize("profile_name", GrowthProfiles.PROFILES.keys())
+    @pytest.mark.django_db
+    def test_scales_sublinearly_across_content_relationships(self, profile_name, save_artifact):
+        """The SQL param count from the COPY API should remain stable with input grow.
+
+        A query with growing param count rate means it could reach postgres's limit of 65532
+        for big enough input.
+        """
+        IGNORE_PATHS = [
+            IgnoreFromPath(
+                pattern=r"pulpcore/app/models/repository\.py:\d+ in __exit__",
+                reason="should be fixed in pulpcore",
+            ),
+        ]
+
+        SMALL_COUNT = 20
+        SCALE_FACTOR = 10
+        LARGE_COUNT = SMALL_COUNT * SCALE_FACTOR
+        THRESHOLD_FACTOR = 1.1  # only tolerate small growth rates
+        small = self.call_copy_workflow(SMALL_COUNT, profile_name)
+        large = self.call_copy_workflow(LARGE_COUNT, profile_name)
+
+        small_summary = small.recorder.summary_text(include_sql=True)
+        save_artifact(small_summary, suffix="small")
+
+        assert small.children < small.resolved
+        assert large.children < large.resolved
+
+        is_growth_candidate = make_growth_candidate_filter(IGNORE_PATHS)
+        small_queries = small.recorder.get_queries(is_growth_candidate)
+        large_queries = large.recorder.get_queries(is_growth_candidate)
+
+        failures = []
+        for small_query, large_query in zip(small_queries, large_queries):
+            growth_rate = large_query.num_params / small_query.num_params
+            if growth_rate >= THRESHOLD_FACTOR:
+                failures.append({**large_query.summary, "growth_rate": round(growth_rate, 2)})
+
+        passed = not failures  # keeps error msg clean
+        assert passed, (
+            json.dumps(failures, indent=4)
+            + f"\n\n[{profile_name}] {len(failures)} quer(ies) grew params count too fast:\n"
+        )

--- a/pulp_rpm/tests/unit/test_package_age.py
+++ b/pulp_rpm/tests/unit/test_package_age.py
@@ -5,7 +5,7 @@ Unit tests for Package age calculation functionality.
 from django.test import TestCase
 
 from pulp_rpm.app.models import Package
-from pulp_rpm.app.shared_utils import annotate_with_age
+from pulp_rpm.app.sql_utils import annotate_with_age
 
 
 class TestPackageAge(TestCase):

--- a/pulp_rpm/tests/unit/test_utils.py
+++ b/pulp_rpm/tests/unit/test_utils.py
@@ -1,0 +1,104 @@
+"""Unit tests for test-support utilities under tests/unit/utils/."""
+
+import uuid
+
+import pytest
+from django.db import connection
+
+from pulp_rpm.app.models import Package
+from pulp_rpm.tests.unit.utils.query_recorder import QueryRecorder
+
+
+class TestQueryRecorder:
+    """Sanity checks for QueryRecorder itself, using the cursor directly."""
+
+    @pytest.mark.django_db
+    def test_records_a_single_execute(self):
+        with QueryRecorder() as recorder:
+            with connection.cursor() as cursor:
+                cursor.execute("SELECT %s, %s, %s", [1, 2, 3])
+
+        assert len(recorder.queries) == 1
+        query = recorder.queries[0]
+        assert query.num_params == 3
+        assert query.many is False
+        assert query.statement_type == "SELECT"
+        assert "SELECT" in query.sql
+
+    @pytest.mark.django_db
+    def test_records_zero_params(self):
+        with QueryRecorder() as recorder:
+            with connection.cursor() as cursor:
+                cursor.execute("SELECT 1")
+
+        assert recorder.queries[0].num_params == 0
+
+    @pytest.mark.django_db
+    def test_records_multiple_queries_in_order(self):
+        with QueryRecorder() as recorder:
+            with connection.cursor() as cursor:
+                cursor.execute("SELECT %s", [1])
+                cursor.execute("SELECT %s, %s", [1, 2])
+
+        assert [q.num_params for q in recorder.queries] == [1, 2]
+
+    @pytest.mark.django_db
+    def test_records_executemany_by_summing_every_row(self):
+        with QueryRecorder() as recorder:
+            with connection.cursor() as cursor:
+                cursor.execute("CREATE TEMPORARY TABLE query_recorder_test (a int, b int)")
+                cursor.executemany(
+                    "INSERT INTO query_recorder_test (a, b) VALUES (%s, %s)",
+                    [(1, 2), (3, 4), (5, 6)],
+                )
+
+        insert_query = next(q for q in recorder.queries if q.many)
+        # 3 rows * 2 params each - not len(params) == 3, which would just be the row count.
+        assert insert_query.num_params == 6
+        assert insert_query.many is True
+        assert insert_query.statement_type == "INSERT"
+
+        create_query = next(q for q in recorder.queries if q.statement_type == "CREATE")
+        assert create_query.many is False
+
+    @pytest.mark.parametrize(
+        "sql,expected",
+        [
+            ("SELECT 1", "SELECT"),
+            ("  \n  UPDATE t SET a = 1", "UPDATE"),
+            ("delete from t where a = 1", "DELETE"),
+            ("", ""),
+            ("   ", ""),
+        ],
+    )
+    def test_sql_statement_type_heuristic(self, sql, expected):
+        assert QueryRecorder._sql_statement_type(sql) == expected
+
+    @pytest.mark.django_db
+    def test_max_params_returns_the_largest_single_query(self):
+        with QueryRecorder() as recorder:
+            with connection.cursor() as cursor:
+                cursor.execute("SELECT %s", [1])
+                cursor.execute("SELECT %s, %s, %s", [1, 2, 3])
+
+        assert recorder.max_params() == 3
+
+    def test_max_params_defaults_to_zero_when_empty(self):
+        assert QueryRecorder().max_params() == 0
+
+    @pytest.mark.django_db
+    def test_iterator_calls(self):
+        with QueryRecorder() as recorder:
+            list(Package.objects.all().only("pk"))
+            list(Package.objects.all().only("pk").iterator())
+            list(Package.objects.all().only("pk").iterator(chunk_size=100))
+        recorder.print_summary(include_sql=True)
+
+    @pytest.mark.django_db
+    def test_iterator_calls_with_pk__in(self):
+        ids = [uuid.uuid4() for _ in range(3)]
+        with QueryRecorder() as recorder:
+            list(Package.objects.filter(pk__in=ids).only("pk"))
+            list(Package.objects.filter(pk__in=ids).only("pk").iterator())
+            list(Package.objects.filter(pk__in=ids).only("pk").iterator(chunk_size=100))
+        recorder.print_summary(include_sql=True)

--- a/pulp_rpm/tests/unit/utils/content_factory.py
+++ b/pulp_rpm/tests/unit/utils/content_factory.py
@@ -1,0 +1,182 @@
+import uuid
+
+from pulpcore.plugin.models import Content
+
+from pulp_rpm.app.models import (
+    Modulemd,
+    Package,
+    PackageCategory,
+    PackageEnvironment,
+    PackageGroup,
+    RpmRepository,
+    UpdateCollection,
+    UpdateCollectionPackage,
+    UpdateRecord,
+)
+
+
+class RepoContentFactory:
+    """Accumulates content added inside a `with` block into one RepositoryVersion on exit.
+
+    Each `add_*` method creates a single content unit, adds it to this factory's pending set,
+    and returns whatever identifies it (pk, or (nsvca, pk) for modules). Callers loop over
+    `add_*` themselves for "many" - this class only tracks what to put in the repo version.
+    """
+
+    def __init__(self, repo_name=None):
+        self._repo_name = repo_name or str(uuid.uuid4())
+        self._content_pks = []
+        self._repo = None
+        self.version = None
+
+    def __enter__(self):
+        self._repo, _ = RpmRepository.objects.get_or_create(name=self._repo_name)
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        if exc_type is None:
+            with self._repo.new_version() as version:
+                version.add_content(Content.objects.filter(pk__in=self._content_pks))
+            self.version = self._repo.latest_version()
+
+    def get_repository(self):
+        return self._repo
+
+    def add_packages(self, names: list[str]) -> list:
+        """Create one Package per name. Returns their pks, in the same order as `names`."""
+        pks = []
+        for name in names:
+            pk = Package.objects.create(
+                name=name,
+                epoch="0",
+                version="1.0",
+                release="1",
+                arch="noarch",
+                pkgId=f"fakedigest-{name}",
+                checksum_type="sha256",
+            ).pk
+            pks.append(pk)
+        self._content_pks.extend(pks)
+        return pks
+
+    def add_package_group(self, name, *, packages=()):
+        group, _ = PackageGroup.objects.get_or_create(
+            id=name,
+            defaults={
+                "name": name,
+                "digest": uuid.uuid4().hex,
+                "packages": [{"name": n} for n in packages],
+            },
+        )
+        self._content_pks.append(group.pk)
+        return group.pk
+
+    def add_package_category(self, name, *, group_names):
+        category, _ = PackageCategory.objects.get_or_create(
+            id=name,
+            defaults={
+                "name": name,
+                "digest": uuid.uuid4().hex,
+                "group_ids": [{"name": group_name, "default": True} for group_name in group_names],
+            },
+        )
+        self._content_pks.append(category.pk)
+        return category.pk
+
+    def add_package_environment(self, name, *, group_names, option_names=()):
+        environment, _ = PackageEnvironment.objects.get_or_create(
+            id=name,
+            defaults={
+                "name": name,
+                "digest": uuid.uuid4().hex,
+                "group_ids": [{"name": group_name, "default": True} for group_name in group_names],
+                "option_ids": [{"name": g, "default": True} for g in option_names],
+            },
+        )
+        self._content_pks.append(environment.pk)
+        return environment.pk
+
+    def add_modulemds(self, names: list[str]) -> tuple[list, list]:
+        """Create one Modulemd per name. Returns (nsvcas, pks), both in `names` order."""
+        nsvcas = []
+        pks = []
+        for name in names:
+            nsvca = (name, "stream0", "1", uuid.uuid4().hex[:8], "noarch")
+            pk = Modulemd.objects.create(
+                name=nsvca[0],
+                stream=nsvca[1],
+                version=nsvca[2],
+                context=nsvca[3],
+                arch=nsvca[4],
+                description="",
+                digest=uuid.uuid4().hex,
+                snippet="",
+            ).pk
+            nsvcas.append(nsvca)
+            pks.append(pk)
+        self._content_pks.extend(pks)
+        return nsvcas, pks
+
+    def add_advisory(self, advisory_id, *, package_names=None, module_nsvcas=None):
+        """UpdateRecord referencing the given package names and/or module NSVCAs.
+
+        Packages all go in one UpdateCollection. Modules each need their own UpdateCollection,
+        since a collection carries at most one module NSVCA (UpdateCollection.module).
+        """
+        advisory, _ = UpdateRecord.objects.get_or_create(
+            id=advisory_id,
+            defaults={
+                "updated_date": "",
+                "description": "",
+                "issued_date": "",
+                "fromstr": "",
+                "status": "",
+                "title": "",
+                "summary": "",
+                "version": "",
+                "type": "",
+                "severity": "",
+                "solution": "",
+                "release": "",
+                "rights": "",
+                "pushcount": "",
+                "digest": uuid.uuid4().hex,
+            },
+        )
+        if package_names:
+            collection, _ = UpdateCollection.objects.get_or_create(
+                update_record=advisory, name="collection"
+            )
+            UpdateCollectionPackage.objects.bulk_create(
+                [
+                    UpdateCollectionPackage(
+                        update_collection=collection,
+                        name=name,
+                        epoch="0",
+                        version="1.0",
+                        release="1",
+                        arch="noarch",
+                        filename=f"{name}.rpm",
+                        src="",
+                        sum="",
+                    )
+                    for name in package_names
+                ]
+            )
+        if module_nsvcas:
+            for i, (name, stream, version, context, arch) in enumerate(module_nsvcas):
+                UpdateCollection.objects.get_or_create(
+                    update_record=advisory,
+                    name=f"collection-{i}",
+                    defaults={
+                        "module": {
+                            "name": name,
+                            "stream": stream,
+                            "version": version,
+                            "context": context,
+                            "arch": arch,
+                        },
+                    },
+                )
+        self._content_pks.append(advisory.pk)
+        return advisory.pk

--- a/pulp_rpm/tests/unit/utils/query_recorder.py
+++ b/pulp_rpm/tests/unit/utils/query_recorder.py
@@ -1,0 +1,217 @@
+import inspect
+import json
+from collections import Counter
+from dataclasses import dataclass
+
+import sqlparse
+import sqlparse.exceptions
+from django.db import connection
+
+
+def _pretty_sql(sql: str) -> str:
+    """Reformat SQL via sqlparse, falling back to the raw string if it's too large to parse.
+
+    sqlparse caps parsing at 10000 tokens (a DoS guard) and raises SQLParseError past that -
+    queries with a huge literal IN (...) list can easily exceed it.
+    """
+    try:
+        return sqlparse.format(sql, reindent=True, keyword_case="upper")
+    except sqlparse.exceptions.SQLParseError:
+        return sql
+
+
+@dataclass
+class RecordedQuery:
+    """A single query as actually sent to the database, with its raw bound params."""
+
+    sql: str
+    num_params: int
+    many: bool
+    django_cursor_t: str
+    psycopg_cursor_t: str | None
+    statement_type: str
+    call_site: list[str]
+    call_line: str
+
+    @property
+    def summary(self) -> dict:
+        """A short representation of this query, omitting the (often long) raw SQL text."""
+        return {
+            "statement_type": self.statement_type,
+            "num_params": self.num_params,
+            "many": self.many,
+            "django_cursor_t": self.django_cursor_t,
+            "psycopg_cursor_t": self.psycopg_cursor_t,
+            "call_site": self.call_site,
+            "call_line": self.call_line,
+        }
+
+
+class QueryRecorder:
+    """Captures every query's raw bound-parameter count as it's actually executed.
+
+    Usable as a context manager: `with QueryRecorder() as recorder: ...` wraps the block in
+    `connection.execute_wrapper(self)`.
+    """
+
+    def __init__(self):
+        self.queries: list[RecordedQuery] = []
+        self._wrapper = None
+
+    def get_queries(self, filter_fn=None) -> list[RecordedQuery]:
+        """Recorded queries, optionally narrowed by filter_fn(query) -> bool."""
+        return [q for q in self.queries if filter_fn is None or filter_fn(q)]
+
+    @staticmethod
+    def _sql_statement_type(sql: str) -> str:
+        """Best-effort statement keyword (SELECT/INSERT/UPDATE/CREATE/...).
+
+        Not a real SQL parser - just the leading token, uppercased. Good enough to classify SQL
+        our own code generates; doesn't handle leading comments or distinguish e.g. CREATE TABLE
+        from CREATE INDEX.
+        """
+        sql = sql.strip()
+        return sql.split(None, 1)[0].upper() if sql else ""
+
+    @staticmethod
+    def _qualname(a_class: type) -> str:
+        return f"{a_class.__module__}.{a_class.__qualname__}"
+
+    @staticmethod
+    def _psycopg_base(raw_cursor_class: type) -> type | None:
+        """The psycopg-defined base in the MRO, e.g. django's ServerBindingCursor -> psycopg.Cursor.
+
+        Django's own cursor classes (django.db.backends.postgresql.base.Cursor,
+        ServerBindingCursor, ...) subclass psycopg's cursor directly rather than wrapping it, so
+        the actual psycopg class only shows up in the MRO, not as a separate `.cursor` attribute.
+        """
+        return next(
+            (c for c in raw_cursor_class.__mro__ if c.__module__.split(".")[0] == "psycopg"),
+            None,
+        )
+
+    @staticmethod
+    def _call_site() -> tuple[list[str], str]:
+        """Collect every stack frame whose file path contains "pulp", innermost first.
+
+        A single frame often isn't enough context (e.g. a generic helper shared by many call
+        sites), so this walks the whole call chain through pulp code instead of stopping at the
+        first match. Excludes this file itself.
+        Returns (sites, line): sites is a list of "file:lineno in function" strings; line is the
+        innermost matching frame's source text.
+        """
+        sites = []
+        line = ""
+        for frame_info in inspect.stack(context=1):
+            if frame_info.filename == __file__:
+                continue
+            if "pulp" not in frame_info.filename:
+                continue
+            sites.append(f"{frame_info.filename}:{frame_info.lineno} in {frame_info.function}")
+            if not line:
+                line = frame_info.code_context[0].strip() if frame_info.code_context else ""
+        sites.reverse()
+        return sites, line
+
+    def __call__(self, execute, sql, params, many, context):
+        result = execute(sql, params, many, context)
+        if many:
+            # executemany(): params is a list of per-row parameter sequences, not one flat
+            # sequence - count every row's params, not just the number of rows.
+            num_params = sum(len(row) for row in params or ())
+        else:
+            num_params = len(params or ())
+
+        # context["cursor"] is Django's CursorWrapper; .cursor is Django's own cursor class
+        # (e.g. django.db.backends.postgresql.base.ServerBindingCursor), which is what actually
+        # enforces the limit - and which itself subclasses the underlying psycopg cursor class.
+        raw_cursor = getattr(context["cursor"], "cursor", context["cursor"])
+        raw_cursor_class = type(raw_cursor)
+        psycopg_base = self._psycopg_base(raw_cursor_class)
+        call_site, call_line = self._call_site()
+
+        self.queries.append(
+            RecordedQuery(
+                sql=sql,
+                num_params=num_params,
+                many=many,
+                django_cursor_t=self._qualname(raw_cursor_class),
+                psycopg_cursor_t=self._qualname(psycopg_base) if psycopg_base else None,
+                statement_type=self._sql_statement_type(sql),
+                call_site=call_site,
+                call_line=call_line,
+            )
+        )
+        return result
+
+    def __enter__(self):
+        self._wrapper = connection.execute_wrapper(self)
+        self._wrapper.__enter__()
+        return self
+
+    def __exit__(self, *exc_info):
+        return self._wrapper.__exit__(*exc_info)
+
+    def max_params(self):
+        return max((q.num_params for q in self.queries), default=0)
+
+    def summary_text(self, include_sql=False) -> str:
+        """Build every recorded query's summary as indented JSON, as a single string.
+
+        Each entry carries a query_id matching the "--- query N ---" labels below it, so the two
+        can be correlated. By default omits the (often long) raw SQL text. With include_sql=True,
+        each query's SQL is also included - reformatted with sqlparse, as its own readable block
+        after the JSON summary, since JSON strings can't hold the real newlines a pretty-printed
+        query needs.
+        """
+        summaries = [{"query_id": i, **q.summary} for i, q in enumerate(self.queries)]
+        lines = [json.dumps(summaries, indent=4)]
+        if include_sql:
+            for i, query in enumerate(self.queries):
+                lines.append(f"\n--- query {i} ---")
+                for site in query.call_site:
+                    lines.append(f"--- {site}")
+                lines.append(f"--- {query.call_line}")
+                lines.append(_pretty_sql(query.sql))
+        return "\n".join(lines)
+
+    def print_summary(self, include_sql=False):
+        """Print summary_text() to stdout."""
+        print(self.summary_text(include_sql=include_sql))
+
+
+def detect_n1(small_queries, large_queries) -> list[dict]:
+    """Find call sites whose query count differs between a small and a large run.
+
+    Groups by (call_site[-1], call_line) - the innermost call_site entry (the frame that
+    actually produced call_line) paired with the source text itself - not call_line alone,
+    which can collide across unrelated call sites and merge distinct query origins together.
+    A per-item N+1 loop shows up here as a call site firing small_count times in the small run
+    and large_count times in the large run.
+
+    Returns one {**query.summary, "small_count", "large_count", "growth_rate"} dict (using one
+    representative large-run query) per call site whose counts differ.
+    """
+
+    def key_of(query):
+        return (query.call_site[-1], query.call_line)
+
+    small_counts = Counter(key_of(q) for q in small_queries)
+    large_counts = Counter(key_of(q) for q in large_queries)
+    representative = {key_of(q): q for q in large_queries}
+
+    offenders = []
+    for key, large_count in large_counts.items():
+        small_count = small_counts.get(key, 0)
+        if large_count == small_count:
+            continue
+        growth_rate = round(large_count / small_count, 2) if small_count else None
+        offenders.append(
+            {
+                **representative[key].summary,
+                "small_count": small_count,
+                "large_count": large_count,
+                "growth_rate": growth_rate,
+            }
+        )
+    return offenders


### PR DESCRIPTION
* Add growth rate based tests
* Fix linear SQL params count growth rate in copy API
* Add n+1 detector test for copy API and fixes for some of them

Assisted-By: Claude Sonnet 5
(cherry picked from commit ccd0f5954371eea3dc3c8ba882166af2ce5a4f98)

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
